### PR TITLE
Use MetalANGLE wrapper classes.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,3 +49,6 @@
 [submodule "maplibre-gl-js"]
 	path = maplibre-gl-js
 	url = https://github.com/maplibre/maplibre-gl-js.git
+[submodule "platform/ios/platform/ios/vendor/metalangle"]
+	path = platform/ios/platform/ios/vendor/metalangle
+	url = https://github.com/kakashidinho/metalangle.git

--- a/platform/ios/ios.cmake
+++ b/platform/ios/ios.cmake
@@ -22,7 +22,7 @@ set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC
 if(MBGL_WITH_OPENGL)
     target_compile_definitions(
         mbgl-core
-        PUBLIC MBGL_USE_GLES2 GLES_SILENCE_DEPRECATION
+        PUBLIC MBGL_USE_GLES2
     )
     target_sources(
         mbgl-core
@@ -32,7 +32,7 @@ if(MBGL_WITH_OPENGL)
     )
     target_link_libraries(
         mbgl-core
-        PRIVATE "-framework GLKit" "-framework OpenGLES"
+        PRIVATE "-framework MetalANGLE"
     )
 endif()
 

--- a/platform/ios/platform/darwin/src/MGLOpenGLStyleLayer.h
+++ b/platform/ios/platform/darwin/src/MGLOpenGLStyleLayer.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class MGLMapView;
 @class MGLStyle;
+@class MGLContext;
 
 typedef struct MGLStyleLayerDrawingContext {
     CGSize size;
@@ -30,7 +31,7 @@ MGL_EXPORT
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #if TARGET_OS_IPHONE
-@property (nonatomic, readonly) EAGLContext *context;
+@property (nonatomic, readonly) MGLContext *context;
 #else
 @property (nonatomic, readonly) CGLContextObj context;
 #endif

--- a/platform/ios/platform/darwin/src/MGLOpenGLStyleLayer.mm
+++ b/platform/ios/platform/darwin/src/MGLOpenGLStyleLayer.mm
@@ -76,7 +76,7 @@ class MGLOpenGLLayerHost;
 }
 
 #if TARGET_OS_IPHONE
-- (EAGLContext *)context {
+- (MGLContext *)context {
     return self.mapView.context;
 }
 #else

--- a/platform/ios/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/platform/ios/ios.xcodeproj/project.pbxproj
@@ -185,7 +185,6 @@
 		35E79F201D41266300957B9E /* MGLStyleLayer_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 35E79F1F1D41266300957B9E /* MGLStyleLayer_Private.h */; };
 		35E79F211D41266300957B9E /* MGLStyleLayer_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 35E79F1F1D41266300957B9E /* MGLStyleLayer_Private.h */; };
 		3E6465D62065767A00685536 /* LimeGreenStyleLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E6465D42065767A00685536 /* LimeGreenStyleLayer.m */; };
-		3E8770612074297100B7E842 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 554180411D2E97DE00012372 /* OpenGLES.framework */; };
 		3EA93369F61CF70AFA50465D /* MGLRendererConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EA931BC4F087E166D538F21 /* MGLRendererConfiguration.m */; };
 		3EA934623AD0000B7D99C3FB /* MGLRendererConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EA9337830C7738BF7F5493C /* MGLRendererConfiguration.h */; };
 		3EA9363147E77DD29FA06063 /* MGLRendererConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EA9337830C7738BF7F5493C /* MGLRendererConfiguration.h */; };
@@ -370,6 +369,8 @@
 		A4DE3DCB23038C98005B3473 /* MGLMockGestureRecognizers.h in Sources */ = {isa = PBXBuildFile; fileRef = A4DE3DCA23038A7F005B3473 /* MGLMockGestureRecognizers.h */; };
 		A4DE3DCC23038CCA005B3473 /* MGLMockGestureRecognizers.m in Sources */ = {isa = PBXBuildFile; fileRef = A4DE3DC823038A07005B3473 /* MGLMockGestureRecognizers.m */; };
 		A4F3FB1D2254865900A30170 /* missing_icon.json in Resources */ = {isa = PBXBuildFile; fileRef = A4F3FB1C2254865900A30170 /* missing_icon.json */; };
+		AC3302A425EEEDB0004890E9 /* MetalANGLE.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC3302A325EEEDB0004890E9 /* MetalANGLE.framework */; };
+		AC3302A525EEEDB0004890E9 /* MetalANGLE.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AC3302A325EEEDB0004890E9 /* MetalANGLE.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CA0B3C022329DE9A00E4B493 /* MGLTestAssertionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = CAAA65D82321BBA900F08A39 /* MGLTestAssertionHandler.m */; };
 		CA0C27922076C804001CE5B7 /* MGLShapeSourceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA0C27912076C804001CE5B7 /* MGLShapeSourceTests.m */; };
 		CA0C27942076CA19001CE5B7 /* MGLMapViewIntegrationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA0C27932076CA19001CE5B7 /* MGLMapViewIntegrationTest.m */; };
@@ -428,7 +429,6 @@
 		DA1DC99F1CB6E088006E619F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DA1DC99E1CB6E088006E619F /* Assets.xcassets */; };
 		DA1F8F3D1EBD287B00367E42 /* MGLDocumentationGuideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1F8F3C1EBD287B00367E42 /* MGLDocumentationGuideTests.swift */; };
 		DA2784FC1DF02FF4001D5B8D /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DA2784FB1DF02FF4001D5B8D /* Media.xcassets */; };
-		DA27C24E1CBB3811000B0ECD /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA27C24D1CBB3811000B0ECD /* GLKit.framework */; };
 		DA27C24F1CBB4C11000B0ECD /* MGLAccountManager_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8847FF1CBAFA6200AB86E3 /* MGLAccountManager_Private.h */; };
 		DA2DBBCE1D51E80400D38FF9 /* MGLStyleLayerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA2DBBCD1D51E80400D38FF9 /* MGLStyleLayerTests.m */; };
 		DA2E88611CC0382C00F24E7B /* MGLGeometryTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA2E885C1CC0382C00F24E7B /* MGLGeometryTests.mm */; };
@@ -706,6 +706,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		AC3302A625EEEDB0004890E9 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				AC3302A525EEEDB0004890E9 /* MetalANGLE.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA0FA9E62379C39C00C9F3C9 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1011,6 +1022,7 @@
 		A4DE3DC823038A07005B3473 /* MGLMockGestureRecognizers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLMockGestureRecognizers.m; sourceTree = "<group>"; };
 		A4DE3DCA23038A7F005B3473 /* MGLMockGestureRecognizers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLMockGestureRecognizers.h; sourceTree = "<group>"; };
 		A4F3FB1C2254865900A30170 /* missing_icon.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = missing_icon.json; sourceTree = "<group>"; };
+		AC3302A325EEEDB0004890E9 /* MetalANGLE.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MetalANGLE.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA0C27912076C804001CE5B7 /* MGLShapeSourceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLShapeSourceTests.m; sourceTree = "<group>"; };
 		CA0C27932076CA19001CE5B7 /* MGLMapViewIntegrationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLMapViewIntegrationTest.m; sourceTree = "<group>"; wrapsLines = 0; };
 		CA0C27952076CA50001CE5B7 /* MGLMapViewIntegrationTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLMapViewIntegrationTest.h; sourceTree = "<group>"; };
@@ -1343,12 +1355,12 @@
 			files = (
 				DA0BDD202407C12600DAA576 /* libmbgl-core.a in Frameworks */,
 				CAB369E5237471D600592F74 /* libz.tbd in Frameworks */,
+				AC3302A425EEEDB0004890E9 /* MetalANGLE.framework in Frameworks */,
 				DA35D9CE240920AB0013ECB0 /* libmbgl-vendor-csscolorparser.a in Frameworks */,
 				358B3DBB2359EA0F007BEB26 /* libmbgl-vendor-icu.a in Frameworks */,
 				DA35D9D1240920B60013ECB0 /* libmbgl-vendor-parsedate.a in Frameworks */,
 				358B3DB92359E4A0007BEB26 /* libsqlite3.tbd in Frameworks */,
 				96802766226556C5006BA4A1 /* libmbxaccounts.a in Frameworks */,
-				DA27C24E1CBB3811000B0ECD /* GLKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1370,7 +1382,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				DAA4E4081CBB6C9500178DFB /* Mapbox.framework in Frameworks */,
-				3E8770612074297100B7E842 /* OpenGLES.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1772,6 +1783,7 @@
 		DA1DC9921CB6DF24006E619F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				AC3302A325EEEDB0004890E9 /* MetalANGLE.framework */,
 				DA27C24D1CBB3811000B0ECD /* GLKit.framework */,
 				DA4A26961CB6E795000B7809 /* Mapbox.framework */,
 				554180411D2E97DE00012372 /* OpenGLES.framework */,
@@ -2568,6 +2580,7 @@
 				DA8847CE1CBAF91600AB86E3 /* Frameworks */,
 				DA8847CF1CBAF91600AB86E3 /* Headers */,
 				DA8847D01CBAF91600AB86E3 /* Resources */,
+				AC3302A625EEEDB0004890E9 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/platform/ios/platform/ios/ios.xcworkspace/contents.xcworkspacedata
+++ b/platform/ios/platform/ios/ios.xcworkspace/contents.xcworkspacedata
@@ -6,5 +6,8 @@
    </FileRef>
    <FileRef
       location = "group:../../build/ios/Mapbox GL Native.xcodeproj">
-   </FileRef>   
+   </FileRef>
+   <FileRef
+      location = "group:vendor/metalangle/ios/xcode/OpenGLES.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/platform/ios/platform/ios/src/MGLMapView+Impl.h
+++ b/platform/ios/platform/ios/src/MGLMapView+Impl.h
@@ -1,6 +1,7 @@
 #import <mbgl/gfx/renderer_backend.hpp>
 #import <mbgl/map/map_observer.hpp>
 #import <mbgl/util/image.hpp>
+#import <MetalANGLE/MGLContext.h>
 
 #import <UIKit/UIView.h>
 #import <UIKit/UIImage.h>
@@ -18,7 +19,7 @@ public:
     virtual mbgl::gfx::RendererBackend& getRendererBackend() = 0;
 
     // Returns a handle to the OpenGL context object if this view is rendered with OpenGL.
-    virtual EAGLContext* getEAGLContext() {
+    virtual MGLContext* getEAGLContext() {
         return nullptr;
     }
 

--- a/platform/ios/platform/ios/src/MGLMapView+OpenGL.h
+++ b/platform/ios/platform/ios/src/MGLMapView+OpenGL.h
@@ -47,7 +47,7 @@ public:
         return *this;
     }
 
-    EAGLContext* getEAGLContext() override;
+    MGLContext* getEAGLContext() override;
     void setOpaque(bool) override;
     void display() override;
     void setPresentsWithTransaction(bool) override;

--- a/platform/ios/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/platform/ios/src/MGLMapView.mm
@@ -1504,7 +1504,7 @@ public:
 
 #pragma mark - GL / display link wake/sleep
 
-- (EAGLContext *)context {
+- (MGLContext *)context {
     return _mbglView->getEAGLContext();
 }
 

--- a/platform/ios/platform/ios/src/MGLMapView_Private.h
+++ b/platform/ios/platform/ios/src/MGLMapView_Private.h
@@ -1,6 +1,8 @@
 #import "MGLMapView.h"
 #import "MGLUserLocationAnnotationView.h"
 #import "MGLAnnotationContainerView.h"
+#import <MetalANGLE/MGLContext.h>
+#import <MetalANGLE/MGLKView.h>
 
 #include <mbgl/util/size.hpp>
 
@@ -24,7 +26,7 @@ FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const _Nonnull MGLUnderlyingMapUna
 @interface MGLMapView (Private)
 
 /// The map view’s OpenGL rendering context.
-@property (nonatomic, readonly, nullable) EAGLContext *context;
+@property (nonatomic, readonly, nullable) MGLContext *context;
 
 /// Currently shown popover representing the selected annotation.
 @property (nonatomic, nonnull) UIView<MGLCalloutView> *calloutViewForSelectedAnnotation;

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -219,10 +219,8 @@ UniqueTexture Context::createUniqueTexture() {
 }
 
 bool Context::supportsVertexArrays() const {
-    return vertexArray &&
-           vertexArray->genVertexArrays &&
-           vertexArray->bindVertexArray &&
-           vertexArray->deleteVertexArrays;
+    // TODO: Metal: Metal does not work with vertex arrays.
+    return false;
 }
 
 VertexArray Context::createVertexArray() {

--- a/src/mbgl/gl/renderer_backend.cpp
+++ b/src/mbgl/gl/renderer_backend.cpp
@@ -33,6 +33,9 @@ void RendererBackend::assumeFramebufferBinding(const gl::FramebufferID fbo) {
 
 void RendererBackend::assumeViewport(int32_t x, int32_t y, const Size& size) {
     getContext<gl::Context>().viewport.setCurrentValue({ x, y, size });
+    if (gl::value::Viewport::Get() != getContext<gl::Context>().viewport.getCurrentValue()) {
+        gl::value::Viewport::Set(getContext<gl::Context>().viewport.getCurrentValue());
+    }
     assert(gl::value::Viewport::Get() == getContext<gl::Context>().viewport.getCurrentValue());
 }
 
@@ -54,6 +57,9 @@ void RendererBackend::setFramebufferBinding(const gl::FramebufferID fbo) {
 
 void RendererBackend::setViewport(int32_t x, int32_t y, const Size& size) {
     getContext<gl::Context>().viewport = { x, y, size };
+    if (gl::value::Viewport::Get() != getContext<gl::Context>().viewport.getCurrentValue()) {
+        gl::value::Viewport::Set(getContext<gl::Context>().viewport.getCurrentValue());
+    }
     assert(gl::value::Viewport::Get() == getContext<gl::Context>().viewport.getCurrentValue());
 }
 


### PR DESCRIPTION
Hello!

Here is the initial PR for a preview version of MapLibre with Metal support. Kudos to kakashidinho for his hard work on https://github.com/kakashidinho/metalangle!

Here are the instructions to build the test "iosapp" target:
1. `cd <MapLibre>/`
1. `git submodule update --init --recursive`
1. `cd <MapLibre>/platform/ios/platform/ios/vendor/metalangle/ios/xcode`
1. `./fetchDependencies.sh`
1. `cd <MapLibre>/platform/ios`
1. `make iproj`
1. In XCode build and run "iosapp" target.

Known problems:
1. I have tested the Metal version only in the Simulator so far.
1. I haven't tried the "static" build yet.
1. Building "bench" requires switching the "Run" schema to "Debug".
1. No proper CI integration yet.

Things to consider:
1. Should we move the MetalANGLE library to a different folder, e.g., if we want to support OSX?
1. Should we support two flavors (Metal and OpenGL), or should we migrate fully to Metal?

I hope we will address the known (and newly discovered) problems in the subsequent PRs.
