### PR TITLE
Copyright to MapLibre contributors

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,8 @@
-mapbox-gl-native Copyright (c) 2014-2020 Mapbox.
+BSD 2-Clause License
+
+Copyright (c) 2021 MapLibre
+Copyright (c) 2018-2021 MapTiler.com
+Copyright (c) 2014-2020 Mapbox
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,9 @@
 BSD 2-Clause License
 
-Copyright (c) 2021 MapLibre
+Copyright (c) 2021 MapLibre contributors
+
 Copyright (c) 2018-2021 MapTiler.com
+
 Copyright (c) 2014-2020 Mapbox
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The same BSD 2-Clause license. From now on copyright goes to MapLibre contributors. Closes #21 