### PR TITLE
Ignore sizing and positioning for hidden elements in assertions

### DIFF
--- a/platform/ios/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/platform/ios/src/MGLMapView.mm
@@ -1040,13 +1040,13 @@ public:
 
     [self updateAttributionAlertView];
 
-    MGLAssert(CGRectContainsRect(self.bounds, self.attributionButton.mgl_frameForIdentifyTransform),
+    MGLAssert(self.attributionButton.isHidden || CGRectContainsRect(self.bounds, self.attributionButton.mgl_frameForIdentifyTransform),
               @"The attribution is not in the visible area of the mapview. Please check your position and offset settings");
-    MGLAssert(CGRectContainsRect(self.bounds, self.scaleBar.mgl_frameForIdentifyTransform),
+    MGLAssert(self.scaleBar.isHidden || CGRectContainsRect(self.bounds, self.scaleBar.mgl_frameForIdentifyTransform),
               @"The scaleBar is not in the visible area of the mapview. Please check your position and offset settings");
-    MGLAssert(CGRectContainsRect(self.bounds, self.compassView.mgl_frameForIdentifyTransform),
+    MGLAssert(self.compassView.isHidden || CGRectContainsRect(self.bounds, self.compassView.mgl_frameForIdentifyTransform),
               @"The compassView is not in the visible area of the mapview. Please check your position and offset settings");
-    MGLAssert(CGRectContainsRect(self.bounds, self.logoView.mgl_frameForIdentifyTransform),
+    MGLAssert(self.logoView.isHidden || CGRectContainsRect(self.bounds, self.logoView.mgl_frameForIdentifyTransform),
               @"The logoView is not in the visible area of the mapview. Please check your position and offset settings");
 }
 


### PR DESCRIPTION
Currently assertions are triggered when for example the logo doesn't fit into a map, because it is too small. This shouldn't matter for hidden elements.