### PR TITLE
[ios] Disable map snapshots by default

### DIFF
--- a/platform/ios/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/platform/ios/src/MGLMapView.mm
@@ -6699,7 +6699,9 @@ static void *windowScreenContext = &windowScreenContext;
         return;
     }
 
+#ifdef MBGL_ENABLE_MAP_SNAPSHOTS
     [self queueBackgroundSnapshot];
+#endif
 
     if ([self.delegate respondsToSelector:@selector(mapViewDidBecomeIdle:)]) {
         [self.delegate mapViewDidBecomeIdle:self];


### PR DESCRIPTION
MapLibre currently periodically takes snapshots of the map view, and when brought from background to foreground, it will first display the latest snapshot and then change the display to rendered map.

With #68, to prevent iOS crashes, we limited map snapshotting to foreground. Snapshots are now taken every 60 seconds on iOS when map is idle in the foreground. Due to this, map snapshot is not necessarily very recent one. This causes following issues:

* If user has changed map style after last snapshot, wrong map style can flash when app is brought to foreground
* Map can jump quite much when brought to foreground
* Snapshotting also causes this "zoomed in" flash issue with with Metal branch: #76

I have been testing the iOS SDK and I have not noticed any drawbacks yet when disabling the map snapshotting completely. If we don't find any drawbacks, I suggest we first disable the snapshotting with a define (as done in this PR) and later we can remove the snapshotting logic completely if no issues arise.