### PR TITLE
[ios] Fixed test: testSetCenterCoordinatePauseRendering

### DIFF
--- a/platform/ios/platform/ios/Integration Tests/MGLMapViewPendingBlockTests.m
+++ b/platform/ios/platform/ios/Integration Tests/MGLMapViewPendingBlockTests.m
@@ -3,7 +3,7 @@
 
 @interface MGLMapView (MGLMapViewPendingBlockTests)
 @property (nonatomic) NSMutableArray *pendingCompletionBlocks;
-- (void)pauseRendering:(__unused NSNotification *)notification;
+- (void)stopDisplayLink;
 @end
 
 @interface MGLMapViewPendingBlockTests : MGLMapViewIntegrationTest
@@ -256,9 +256,9 @@
         
         MGLTestAssert(strongSelf, !strongSelf.completionHandlerCalled);
         
-        // Pause rendering, stopping display link
-        [strongSelf.mapView pauseRendering:nil];
-        
+        // Stopping display link, should trigger the pending blocks
+        [strongSelf.mapView stopDisplayLink];
+
         MGLTestAssert(strongSelf, strongSelf.completionHandlerCalled);
     };
     


### PR DESCRIPTION
Fixed testSetCenterCoordinatePauseRendering broken in PR #68