### PR TITLE
Not render MapView if frame is empty (#67)

### DIFF
--- a/platform/ios/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/platform/ios/src/MGLMapView.mm
@@ -989,7 +989,7 @@ public:
 
 - (void)renderSync
 {
-    if ( ! self.dormant && _rendererFrontend)
+    if (!self.dormant && _rendererFrontend && !CGRectIsEmpty(self.frame))
     {
         _rendererFrontend->render();
     }


### PR DESCRIPTION
To prevent https://github.com/maplibre/maplibre-gl-native/issues/67 we are simply skipping the rendering if the viewport is empty.