### PR TITLE
Displaying view annotations (#96).

### DIFF
--- a/platform/ios/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/platform/ios/src/MGLMapView.mm
@@ -4382,7 +4382,7 @@ public:
     newAnnotationContainerView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     newAnnotationContainerView.contentMode = UIViewContentModeCenter;
     [newAnnotationContainerView addSubviews:annotationViews];
-    [_mbglView->getView() insertSubview:newAnnotationContainerView atIndex:0];
+    [_mbglView->getView() insertSubview:newAnnotationContainerView atIndex:1];
     self.annotationContainerView = newAnnotationContainerView;
     
     [self updatePresentsWithTransaction];


### PR DESCRIPTION
The annotation view container is added below the map instead of on top. The change fixes that.