### PR TITLE
[qt] Update for tile server configuration changes

### DIFF
--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -61,7 +61,7 @@ void MapWindow::changeStyle()
 {
     static uint8_t currentStyleIndex;
 
-    auto& styles = QMapbox::defaultStyles();
+    auto& styles = m_map->defaultStyles();
 
     m_map->setStyleUrl(styles[currentStyleIndex].first);
     setWindowTitle(QString("Mapbox GL: ") + styles[currentStyleIndex].second);
@@ -467,14 +467,14 @@ void MapWindow::initializeGL()
     connect(m_map.data(), SIGNAL(needsRendering()), this, SLOT(update()));
 
     // Set default location to Helsinki.
-    m_map->setCoordinateZoom(QMapbox::Coordinate(60.170448, 24.942046), 14);
+    m_map->setCoordinateZoom(QMapbox::Coordinate(60.170448, 24.942046), 5);
 
-    QString styleUrl = qgetenv("MAPBOX_STYLE_URL");
+    QString styleUrl = qgetenv("MGL_STYLE_URL");
     if (styleUrl.isEmpty()) {
         changeStyle();
     } else {
         m_map->setStyleUrl(styleUrl);
-        setWindowTitle(QString("Mapbox GL: ") + styleUrl);
+        setWindowTitle(QString("MapLibre GL: ") + styleUrl);
     }
 
     m_bearingAnimation = new QPropertyAnimation(m_map.data(), "bearing");

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -102,8 +102,6 @@ enum NetworkMode {
     Offline,
 };
 
-Q_MAPBOXGL_EXPORT QVector<QPair<QString, QString> >& defaultStyles();
-
 Q_MAPBOXGL_EXPORT NetworkMode networkMode();
 Q_MAPBOXGL_EXPORT void setNetworkMode(NetworkMode);
 

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -16,6 +16,12 @@ class QMapboxGLPrivate;
 
 // This header follows the Qt coding style: https://wiki.qt.io/Qt_Coding_Style
 
+// TODO: this will be wrapped at some point
+namespace mbgl
+{
+    class TileServerOptions;
+}
+
 class Q_MAPBOXGL_EXPORT QMapboxGLSettings
 {
 public:
@@ -63,8 +69,8 @@ public:
     QString assetPath() const;
     void setAssetPath(const QString &);
 
-    QString accessToken() const;
-    void setAccessToken(const QString &);
+    QString apiKey() const;
+    void setApiKey(const QString &);
 
     QString apiBaseUrl() const;
     void setApiBaseUrl(const QString &);
@@ -75,6 +81,8 @@ public:
     std::function<std::string(const std::string &)> resourceTransform() const;
     void setResourceTransform(const std::function<std::string(const std::string &)> &);
 
+    mbgl::TileServerOptions *tileServerOptionsInternal() const;
+
 private:
     GLContextMode m_contextMode;
     MapMode m_mapMode;
@@ -84,10 +92,11 @@ private:
     unsigned m_cacheMaximumSize;
     QString m_cacheDatabasePath;
     QString m_assetPath;
-    QString m_accessToken;
-    QString m_apiBaseUrl;
+    QString m_apiKey;
     QString m_localFontFamily;
     std::function<std::string(const std::string &)> m_resourceTransform;
+
+    mbgl::TileServerOptions *m_tileServerOptionsInternal{};
 };
 
 struct Q_MAPBOXGL_EXPORT QMapboxGLCameraOptions {
@@ -251,6 +260,8 @@ public:
     void createRenderer();
     void destroyRenderer();
     void setFramebufferObject(quint32 fbo, const QSize &size);
+
+    const QVector<QPair<QString, QString>> &defaultStyles() const;
 
 public slots:
     void render();

--- a/platform/qt/src/http_file_source.cpp
+++ b/platform/qt/src/http_file_source.cpp
@@ -11,7 +11,9 @@
 
 namespace mbgl {
 
-HTTPFileSource::Impl::Impl() : m_manager(new QNetworkAccessManager(this))
+HTTPFileSource::Impl::Impl(const ResourceOptions& options)
+    : m_manager(new QNetworkAccessManager(this)),
+      m_resourceOptions(options.clone())
 {
     QNetworkProxyFactory::setUseSystemConfiguration(true);
 }
@@ -87,8 +89,18 @@ void HTTPFileSource::Impl::onReplyFinished()
     reply->deleteLater();
 }
 
-HTTPFileSource::HTTPFileSource()
-    : impl(std::make_unique<Impl>()) {
+void HTTPFileSource::Impl::setResourceOptions(ResourceOptions options)
+{
+    m_resourceOptions = options;
+}
+
+ResourceOptions HTTPFileSource::Impl::getResourceOptions()
+{
+    return m_resourceOptions.clone();
+}
+
+HTTPFileSource::HTTPFileSource(const ResourceOptions& options)
+    : impl(std::make_unique<Impl>(options)) {
 }
 
 HTTPFileSource::~HTTPFileSource() = default;
@@ -96,6 +108,14 @@ HTTPFileSource::~HTTPFileSource() = default;
 std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, Callback callback)
 {
     return std::make_unique<HTTPRequest>(impl.get(), resource, callback);
+}
+
+void HTTPFileSource::setResourceOptions(ResourceOptions options) {
+    impl->setResourceOptions(options.clone());
+}
+
+ResourceOptions HTTPFileSource::getResourceOptions() {
+    return impl->getResourceOptions();
 }
 
 } // namespace mbgl

--- a/platform/qt/src/http_file_source.hpp
+++ b/platform/qt/src/http_file_source.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/storage/http_file_source.hpp>
 #include <mbgl/storage/resource.hpp>
+#include <mbgl/storage/resource_options.hpp>
 
 #include <QMap>
 #include <QNetworkAccessManager>
@@ -21,11 +22,14 @@ class HTTPFileSource::Impl : public QObject
     Q_OBJECT
 
 public:
-    Impl();
+    Impl(const ResourceOptions& options);
     virtual ~Impl() = default;
 
     void request(HTTPRequest *);
     void cancel(HTTPRequest *);
+
+    void setResourceOptions(ResourceOptions options);
+    ResourceOptions getResourceOptions();
 
 public slots:
     void onReplyFinished();
@@ -33,6 +37,7 @@ public slots:
 private:
     QMap<QUrl, QPair<QPointer<QNetworkReply>, QVector<HTTPRequest *>>> m_pending;
     QNetworkAccessManager *m_manager;
+    ResourceOptions m_resourceOptions;
 };
 
 } // namespace mbgl

--- a/platform/qt/src/qmapbox.cpp
+++ b/platform/qt/src/qmapbox.cpp
@@ -1,7 +1,6 @@
 #include "qmapbox.hpp"
 
 #include <mbgl/storage/network_status.hpp>
-#include <mbgl/util/default_styles.hpp>
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/util/traits.hpp>
 #include <mbgl/util/projection.hpp>
@@ -201,26 +200,6 @@ NetworkMode networkMode()
 void setNetworkMode(NetworkMode mode)
 {
     mbgl::NetworkStatus::Set(static_cast<mbgl::NetworkStatus::Status>(mode));
-}
-
-/*!
-    \fn QVector<QPair<QString, QString> >& QMapbox::defaultStyles()
-
-    Returns a list containing a pair of string objects, representing the style
-    URL and name, respectively.
-*/
-QVector<QPair<QString, QString> >& defaultStyles()
-{
-    static QVector<QPair<QString, QString>> styles;
-
-    if (styles.isEmpty()) {
-        for (auto style : mbgl::util::default_styles::orderedStyles) {
-            styles.append(QPair<QString, QString>(
-                QString::fromStdString(style.url), QString::fromStdString(style.name)));
-        }
-    }
-
-    return styles;
 }
 
 /*!

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -40,6 +40,7 @@ public:
 
     mbgl::EdgeInsets margins;
     std::unique_ptr<mbgl::Map> mapObj;
+    QVector<QPair<QString, QString>> defaultStyles;
 
 public slots:
     void requestRendering();

--- a/src/mbgl/storage/http_file_source.hpp
+++ b/src/mbgl/storage/http_file_source.hpp
@@ -21,8 +21,9 @@ public:
     void setResourceOptions(ResourceOptions) override;
     ResourceOptions getResourceOptions() override;
 
-private:
     class Impl;
+
+private:
     const std::unique_ptr<Impl> impl;
 };
 


### PR DESCRIPTION
Update the Qt platform for tile server configuration changes.

This is the first in a set of MRs to add proper Qt support for `maplibre-gl-native`.

Note that the default demo MapLibre style still does not work. I only get blue background. Other styles seem to work fine. Any idea why?