### PR TITLE
Address crash when localFontFamilyName is nil

### DIFF
--- a/platform/ios/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/platform/ios/src/MGLMapView.mm
@@ -479,7 +479,7 @@ public:
     // setup mbgl map
     MGLRendererConfiguration *config = [MGLRendererConfiguration currentConfiguration];
 
-    auto localFontFamilyName = config.localFontFamilyName ? std::string(config.localFontFamilyName.UTF8String) : nullptr;
+    mbgl::optional<std::string> localFontFamilyName = config.localFontFamilyName ? mbgl::optional<std::string>(std::string(config.localFontFamilyName.UTF8String)) : mbgl::nullopt;
     auto renderer = std::make_unique<mbgl::Renderer>(_mbglView->getRendererBackend(), config.scaleFactor, localFontFamilyName);
     BOOL enableCrossSourceCollisions = !config.perSourceCollisions;
     _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, _mbglView->getRendererBackend());


### PR DESCRIPTION
Cherry-pick from https://github.com/mapbox/mapbox-gl-native-ios/pull/467 