### PR TITLE
[qt] Ignore status code with 'data' URLs

### DIFF
--- a/platform/qt/src/http_request.cpp
+++ b/platform/qt/src/http_request.cpp
@@ -94,6 +94,16 @@ void HTTPRequest::handleNetworkReply(QNetworkReply *reply, const QByteArray& dat
         }
     }
 
+    if (reply->url().scheme() == QStringLiteral("data")) {
+        if (data.isEmpty()) {
+            response.data = std::make_shared<std::string>();
+        } else {
+            response.data = std::make_shared<std::string>(data.constData(), data.size());
+        }
+        callback(response);
+        return;
+    }
+
     int responseCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 
     switch(responseCode) {


### PR DESCRIPTION
This is a cherry-pick from `qt-staging` branch of `mapbox-gl-native` of one of my improvements that was not present in master.