### PR TITLE
scaleBar enhancements

### DIFF
--- a/platform/ios/platform/ios/src/MGLMapView.h
+++ b/platform/ios/platform/ios/src/MGLMapView.h
@@ -327,6 +327,16 @@ MGL_EXPORT
 @property (nonatomic, readonly) UIView *scaleBar;
 
 /**
+ Sets whether the scale uses styles that make it easier to read on a dark styled map
+ */
+@property (nonatomic, assign) BOOL scaleBarShouldShowDarkStyles;
+
+/**
+ Sets whether the scale uses metric
+ */
+@property (nonatomic, assign) BOOL scaleBarUsesMetricSystem;
+
+/**
  The position of the scale bar. The default value is `MGLOrnamentPositionTopLeft`.
  */
 @property (nonatomic, assign) MGLOrnamentPosition scaleBarPosition;

--- a/platform/ios/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/platform/ios/src/MGLMapView.mm
@@ -2979,6 +2979,20 @@ static void *windowScreenContext = &windowScreenContext;
     }
 }
 
+- (void)setScaleBarShouldShowDarkStyles:(BOOL)scaleBarShouldShowDarkStyles {
+    
+    _scaleBarShouldShowDarkStyles = scaleBarShouldShowDarkStyles;
+    [(MGLScaleBar *)self.scaleBar setShouldShowDarkStyles:scaleBarShouldShowDarkStyles];
+    
+}
+
+- (void)setScaleBarUsesMetricSystem:(BOOL)scaleBarUsesMetricSystem {
+    
+    _scaleBarUsesMetricSystem = scaleBarUsesMetricSystem;
+    [(MGLScaleBar *)self.scaleBar setUsesMetricSystem:scaleBarUsesMetricSystem];
+    
+}
+
 - (void)setPrefetchesTiles:(BOOL)prefetchesTiles
 {
     self.mbglMap.setPrefetchZoomDelta(prefetchesTiles ? mbgl::util::DEFAULT_PREFETCH_ZOOM_DELTA : 0);

--- a/platform/ios/platform/ios/src/MGLScaleBar.h
+++ b/platform/ios/platform/ios/src/MGLScaleBar.h
@@ -6,4 +6,7 @@
 // Sets the scale and redraws the scale bar
 @property (nonatomic, assign) CLLocationDistance metersPerPoint;
 
+// Sets whether the scale uses styles that make it easier to read on a dark styled map
+@property (nonatomic, assign) BOOL shouldShowDarkStyles;
+
 @end

--- a/platform/ios/platform/ios/src/MGLScaleBar.h
+++ b/platform/ios/platform/ios/src/MGLScaleBar.h
@@ -9,4 +9,7 @@
 // Sets whether the scale uses styles that make it easier to read on a dark styled map
 @property (nonatomic, assign) BOOL shouldShowDarkStyles;
 
+// Sets whether the scale uses metric
+@property (nonatomic, assign) BOOL usesMetricSystem;
+
 @end

--- a/platform/ios/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/platform/ios/src/MGLScaleBar.mm
@@ -169,6 +169,10 @@ static const CGFloat MGLScaleBarMinimumBarWidth = 30.0; // Arbitrary
     self.clipsToBounds = NO;
     self.hidden = YES;
     
+    // Default to current local
+    NSLocale *locale = [NSLocale currentLocale];
+    _usesMetricSystem = [[locale objectForKey:NSLocaleUsesMetricSystem] boolValue];
+    
     _containerView                     = [[UIView alloc] init];
     _containerView.clipsToBounds       = YES;
     _containerView.backgroundColor     = _secondaryColor;
@@ -266,11 +270,6 @@ static const CGFloat MGLScaleBarMinimumBarWidth = 30.0; // Arbitrary
     return [UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.superview.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft;
 }
 
-- (BOOL)usesMetricSystem {
-    NSLocale *locale = [NSLocale currentLocale];
-    return [[locale objectForKey:NSLocaleUsesMetricSystem] boolValue];
-}
-
 - (MGLRow)preferredRow {
     CLLocationDistance maximumDistance = [self maximumWidth] * [self unitsPerPoint];
     
@@ -320,6 +319,25 @@ static const CGFloat MGLScaleBarMinimumBarWidth = 30.0; // Arbitrary
 
 
 #pragma mark - Setters
+
+- (void)setUsesMetricSystem:(BOOL)usesMetricSystem {
+    
+    if (_usesMetricSystem != usesMetricSystem) {
+        
+        _usesMetricSystem = usesMetricSystem;
+        
+        // Set the distance formatter locale using Germany for metric and United States for imperial.
+        self.formatter.numberFormatter.locale = usesMetricSystem ? [NSLocale localeWithLocaleIdentifier:@"de_DE"] : [NSLocale localeWithLocaleIdentifier:@"en_US"];
+       
+        [self resetLabelImageCache];
+        [self updateVisibility];
+        
+        self.recalculateSize = YES;
+        [self invalidateIntrinsicContentSize];
+        
+    }
+    
+}
 
 - (void)setMetersPerPoint:(CLLocationDistance)metersPerPoint {
     if (_metersPerPoint == metersPerPoint) {

--- a/platform/ios/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/platform/ios/src/MGLScaleBar.mm
@@ -98,10 +98,21 @@ static const CGFloat MGLScaleBarLabelWidthHint = 30.0;
 static const CGFloat MGLScaleBarMinimumBarWidth = 30.0; // Arbitrary
 
 @interface MGLScaleBarLabel : UILabel
-
+@property (nonatomic) BOOL shouldShowDarkStyles;
 @end
 
 @implementation MGLScaleBarLabel
+
+- (void)setShouldShowDarkStyles:(BOOL)shouldShowDarkStyles {
+    
+    if (_shouldShowDarkStyles != shouldShowDarkStyles) {
+        _shouldShowDarkStyles = shouldShowDarkStyles;
+        
+        // Redraw labels
+        [self setNeedsDisplay];
+        
+    }
+}
 
 - (void)drawTextInRect:(CGRect)rect {
     CGSize shadowOffset = self.shadowOffset;
@@ -111,11 +122,19 @@ static const CGFloat MGLScaleBarMinimumBarWidth = 30.0; // Arbitrary
     CGContextSetLineJoin(context, kCGLineJoinRound);
     
     CGContextSetTextDrawingMode(context, kCGTextStroke);
-    self.textColor = [UIColor whiteColor];
+    if (_shouldShowDarkStyles) {
+        self.textColor = [UIColor blackColor];
+    } else {
+        self.textColor = [UIColor whiteColor];
+    }
     [super drawTextInRect:rect];
     
     CGContextSetTextDrawingMode(context, kCGTextFill);
-    self.textColor = [UIColor blackColor];
+    if (self.shouldShowDarkStyles) {
+        self.textColor = [UIColor whiteColor];
+    } else {
+        self.textColor = [UIColor blackColor];
+    }
     self.shadowOffset = CGSizeMake(0, 0);
     [super drawTextInRect:rect];
     
@@ -168,6 +187,7 @@ static const CGFloat MGLScaleBarMinimumBarWidth = 30.0; // Arbitrary
     _prototypeLabel               = [[MGLScaleBarLabel alloc] init];
     _prototypeLabel.font          = [UIFont systemFontOfSize:8 weight:UIFontWeightMedium];
     _prototypeLabel.clipsToBounds = NO;
+    _prototypeLabel.shouldShowDarkStyles = _shouldShowDarkStyles;
 
     NSUInteger numberOfLabels = 4;
     NSMutableArray *labelViews = [NSMutableArray arrayWithCapacity:numberOfLabels];
@@ -281,6 +301,23 @@ static const CGFloat MGLScaleBarMinimumBarWidth = 30.0; // Arbitrary
     // Didn't find it, just return the first.
     return *table;
 }
+
+
+#pragma mark - Dark Mode Changes
+
+- (void)setShouldShowDarkStyles:(BOOL)shouldShowDarkStyles {
+    
+    if (_shouldShowDarkStyles != shouldShowDarkStyles) {
+        _shouldShowDarkStyles = shouldShowDarkStyles;
+        
+        // Redraw labels
+        _prototypeLabel.shouldShowDarkStyles = shouldShowDarkStyles;
+        [self resetLabelImageCache];
+        [self updateLabels];
+        
+    }
+}
+
 
 #pragma mark - Setters
 


### PR DESCRIPTION
This includes enhancements to the `scaleBar` that allow updating labels colors to better work with dark maps, and also allowing the user to control if the `scaleBar` is using metric.

## Dark Mode Enhancement

Light map with white outlined labels and black text:

![mi](https://user-images.githubusercontent.com/30858/124829682-c1084880-df2d-11eb-9056-708e0089008f.png)

Dark map with black outlined labels and white text:

![dark](https://user-images.githubusercontent.com/30858/124829740-dda48080-df2d-11eb-95cd-2fe416d9328e.png)

`MGLMapView` includes a new property, `scaleBarShouldShowDarkStyles` to update the `scaleBar`.

## Metric Enhancement

Imperial units:

![mi](https://user-images.githubusercontent.com/30858/124829902-0c225b80-df2e-11eb-98d0-1a2e5206df95.png)

Metric units:

![km](https://user-images.githubusercontent.com/30858/124829934-16445a00-df2e-11eb-92c8-1c4e12360cc6.png)

`MGLMapView` includes a new property, `scaleBarUsesMetricSystem` to update the `scaleBar`.
