### PR TITLE
Align remote and local glyph baselines

### DIFF
--- a/platform/darwin/src/local_glyph_rasterizer.mm
+++ b/platform/darwin/src/local_glyph_rasterizer.mm
@@ -256,7 +256,7 @@ PremultipliedImage drawGlyphBitmap(GlyphID glyphID, CTFontRef font, GlyphMetrics
     
     // Mimic glyph PBF metrics.
     metrics.left = Glyph::borderSize;
-    metrics.top = -1;
+    metrics.top = 4;
     
     // Move the text upward to avoid clipping off descenders.
     CGFloat descent;


### PR DESCRIPTION
The baseline of the remote glyph and the local glyph are out of alignment.
<img width="108" alt="glyph1" src="https://user-images.githubusercontent.com/437640/125101730-83661400-e115-11eb-819a-da4bd5cfd0a1.png">
The black line is the local glyph(Hiragino Sans) and the red line is the remote glyph(Noto Sans).
<img width="111" alt="glyph2" src="https://user-images.githubusercontent.com/437640/125101786-911b9980-e115-11eb-9c3e-0a4d52d2a1b0.png">
The modified version is below.
<img width="110" alt="glyph3" src="https://user-images.githubusercontent.com/437640/125102522-55cd9a80-e116-11eb-9726-3a5967122749.png">