### PR TITLE
[core] fix perf regression in cached tiles of tile pyramid

### DIFF
--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -170,10 +170,10 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
         if (!tile) {
             tile = createTile(tileID);
             if (!tile) return nullptr;
+            tile->setObserver(observer);
+            tile->setLayers(layers);
         }
 
-        tile->setObserver(observer);
-        tile->setLayers(layers);
         return tiles.emplace(tileID, std::move(tile)).first->second.get();
     };
 


### PR DESCRIPTION
It seems https://github.com/maplibre/maplibre-gl-native/commit/ac6c5d9ce09b76f0de3872589437b22c1c4984ac introduced a performance regression (apparently during refactoring) in which `setLayers` (and by extent `setObserver`) is called for cached tiles. This continuously triggers parsing for the cached tiles which significantly degrades the performance.

This PR reverts that change. In our benchmarks, this reduced the computation by ~2x in a hand-crafted looping zoom-in/zoom-out scenario.