### PR TITLE
Egl option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(MBGL_WITH_QT "Build Mapbox GL Qt bindings" OFF)
 option(MBGL_WITH_SANITIZER "Use [address|thread|undefined] here" OFF)
 option(MBGL_WITH_RTTI "Compile with runtime type information" OFF)
 option(MBGL_WITH_OPENGL "Build with OpenGL renderer" ON)
+option(MBGL_WITH_EGL "Build with EGL renderer" OFF)
 option(MBGL_WITH_WERROR "Make all compilation warnings errors" ON)
 
 add_library(

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -52,7 +52,6 @@ int main(int argc, char *argv[]) {
         exit(2);
     }
 
-    std::string style = styleValue ? args::get(styleValue) : mbgl::ResourceOptions().tileServerOptions().defaultStyle();
     const double lat = latValue ? args::get(latValue) : 0;
     const double lon = lonValue ? args::get(lonValue) : 0;
     const double zoom = zoomValue ? args::get(zoomValue) : 0;
@@ -74,12 +73,15 @@ int main(int argc, char *argv[]) {
 
     using namespace mbgl;
 
+    auto mapTilerConfiguration = mbgl::TileServerOptions::MapTilerConfiguration();
+    std::string style = styleValue ? args::get(styleValue) : mapTilerConfiguration.defaultStyles().at(0).getUrl();
+
     util::RunLoop loop;
 
     HeadlessFrontend frontend({ width, height }, pixelRatio);
     Map map(frontend, MapObserver::nullObserver(),
             MapOptions().withMapMode(MapMode::Static).withSize(frontend.getSize()).withPixelRatio(pixelRatio),
-            ResourceOptions().withCachePath(cache_file).withAssetPath(asset_root).withApiKey(std::string(apikey)));
+            ResourceOptions().withCachePath(cache_file).withAssetPath(asset_root).withApiKey(apikey).withTileServerOptions(mapTilerConfiguration));
 
     if (style.find("://") == std::string::npos) {
         style = std::string("file://") + style;

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -2,7 +2,6 @@
 #include <mbgl/map/map_options.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/run_loop.hpp>
-#include <mbgl/util/default_styles.hpp>
 
 #include <mbgl/gfx/backend.hpp>
 #include <mbgl/gfx/headless_frontend.hpp>
@@ -53,7 +52,7 @@ int main(int argc, char *argv[]) {
         exit(2);
     }
 
-    std::string style = styleValue ? args::get(styleValue) : mbgl::util::default_styles::streets.url;
+    std::string style = styleValue ? args::get(styleValue) : mbgl::ResourceOptions().tileServerOptions().defaultStyle();
     const double lat = latValue ? args::get(latValue) : 0;
     const double lon = lonValue ? args::get(lonValue) : 0;
     const double zoom = zoomValue ? args::get(zoomValue) : 0;

--- a/platform/default/src/mbgl/storage/http_file_source.cpp
+++ b/platform/default/src/mbgl/storage/http_file_source.cpp
@@ -1,5 +1,4 @@
 #include <mbgl/storage/http_file_source.hpp>
-#include <mbgl/storage/file_source_impl_base.hpp>
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/response.hpp>
@@ -233,14 +232,14 @@ int HTTPFileSource::Impl::startTimeout(CURLM * /* multi */, long timeout_ms, voi
     return 0;
 }
 
-void HTTPFileSource::setResourceOptions(ResourceOptions options) {
+void HTTPFileSource::Impl::setResourceOptions(ResourceOptions options) {
     std::lock_guard<std::mutex> lock(resourceOptionsMutex);
     resourceOptions = options;
 }
 
-ResourceOptions& HTTPFileSource::getResourceOptions() {
+ResourceOptions HTTPFileSource::Impl::getResourceOptions() {
     std::lock_guard<std::mutex> lock(resourceOptionsMutex);
-    return resourceOptions;
+    return resourceOptions.clone();
 }
 
 HTTPRequest::HTTPRequest(HTTPFileSource::Impl* context_, Resource resource_, FileSource::Callback callback_)
@@ -439,7 +438,7 @@ void HTTPFileSource::setResourceOptions(ResourceOptions options) {
     impl->setResourceOptions(options.clone());
 }
 
-ResourceOptions& HTTPFileSource::getResourceOptions() {
+ResourceOptions HTTPFileSource::getResourceOptions() {
     return impl->getResourceOptions();
 }
 

--- a/platform/glfw/CMakeLists.txt
+++ b/platform/glfw/CMakeLists.txt
@@ -29,6 +29,13 @@ if(MBGL_WITH_OPENGL)
     )
 endif()
 
+if(MBGL_WITH_EGL)
+    target_compile_definitions(
+        mbgl-glfw
+        PRIVATE MBGL_WITH_EGL=1
+    )
+endif()
+
 target_include_directories(
     mbgl-glfw
     PRIVATE

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -2,7 +2,6 @@ find_package(CURL REQUIRED)
 find_package(ICU OPTIONAL_COMPONENTS i18n)
 find_package(ICU OPTIONAL_COMPONENTS uc)
 find_package(JPEG REQUIRED)
-find_package(OpenGL REQUIRED GLX)
 find_package(PNG REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(X11 REQUIRED)
@@ -50,8 +49,33 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/timer.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/utf.cpp
         ${PROJECT_SOURCE_DIR}/platform/linux/src/gl_functions.cpp
-        ${PROJECT_SOURCE_DIR}/platform/linux/src/headless_backend_glx.cpp
 )
+
+if(MBGL_WITH_EGL)
+    find_package(OpenGL REQUIRED EGL)
+    target_sources(
+        mbgl-core
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/platform/linux/src/headless_backend_egl.cpp
+    )
+    target_link_libraries(
+        mbgl-core
+        PRIVATE
+            OpenGL::EGL
+    )
+else()
+    find_package(OpenGL REQUIRED GLX)
+    target_sources(
+        mbgl-core
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/platform/linux/src/headless_backend_glx.cpp
+    )
+    target_link_libraries(
+        mbgl-core
+        PRIVATE
+            OpenGL::GLX
+    )
+endif()
 
 # FIXME: Should not be needed, but now needed by node because of the headless frontend.
 target_include_directories(
@@ -91,7 +115,6 @@ target_link_libraries(
         $<$<NOT:$<BOOL:${MBGL_USE_BUILTIN_ICU}>>:ICU::i18n>
         $<$<NOT:$<BOOL:${MBGL_USE_BUILTIN_ICU}>>:ICU::uc>
         $<$<BOOL:${MBGL_USE_BUILTIN_ICU}>:mbgl-vendor-icu>
-        OpenGL::GLX
         PNG::PNG
         mbgl-vendor-nunicode
         mbgl-vendor-sqlite

--- a/render-test/file_source.cpp
+++ b/render-test/file_source.cpp
@@ -79,8 +79,8 @@ void ProxyFileSource::setResourceOptions(ResourceOptions options) {
    resourceOptions = options;
 }
 
-ResourceOptions& ProxyFileSource::getResourceOptions() {
-    return resourceOptions;
+ResourceOptions ProxyFileSource::getResourceOptions() {
+    return resourceOptions.clone();
 }
 
 


### PR DESCRIPTION
Add an option to build on linux with egl backend.

This pull requests depends on #133. Only the last commit is actually part of this pull request.

We had problems running a renderserver with mbgl-core and xvfb under OpenSuse 15.2 as maplibre-gl-native initialisation triggered a bug in the installed xvfb. Using the egl backend on the other hand works fine. So there is at least some value in this option. Moreover a test on MBGL_WITH_EGL already existed in platform/glfw/glfw_view.cpp, suggesting that this option once existed.