### PR TITLE
[android] Fix some test classes

### DIFF
--- a/platform/android/src/test/http_file_source_test_stub.cpp
+++ b/platform/android/src/test/http_file_source_test_stub.cpp
@@ -7,9 +7,18 @@ namespace mbgl {
 
 class HTTPFileSource::Impl {};
 
-HTTPFileSource::HTTPFileSource() : impl(std::make_unique<Impl>()) {}
+HTTPFileSource::HTTPFileSource(const ResourceOptions& /*options*/)
+    : impl(std::make_unique<Impl>()) {
+}
 
 HTTPFileSource::~HTTPFileSource() = default;
+
+void HTTPFileSource::setResourceOptions(ResourceOptions /*options*/) {
+}
+
+ResourceOptions HTTPFileSource::getResourceOptions() {
+    return ResourceOptions::Default();
+}
 
 std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource&, Callback) {
     return std::make_unique<AsyncRequest>();


### PR DESCRIPTION
When building Qt for Android I noticed some classes did not build. Not sure if they should be enabled or not, but why not fix them instead.