### PR TITLE
Add additional 'toString' specialisation

### DIFF
--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -57,6 +57,11 @@ inline std::string toString(unsigned long long t) {
     return toString(static_cast<uint64_t>(t));
 }
 
+template <typename = std::enable_if<!std::is_same<int64_t, long long>::value>>
+inline std::string toString(long long t) {
+    return toString(static_cast<int64_t>(t));
+}
+
 inline std::string toString(float t, bool decimal = false) {
     return toString(static_cast<double>(t), decimal);
 }


### PR DESCRIPTION
Add additional `toString` specialisation for `int64_t` as I had problems with some combination of compilers (I think on Android).