### PR TITLE
[msvc] Fix compilation errors and warnings

### DIFF
--- a/include/mbgl/style/expression/interpolator.hpp
+++ b/include/mbgl/style/expression/interpolator.hpp
@@ -15,12 +15,12 @@ public:
     double base;
     
     double interpolationFactor(const Range<double>& inputLevels, const double input) const {
-        return util::interpolationFactor(base,
+        return util::interpolationFactor(static_cast<float>(base),
                                          Range<float> {
                                             static_cast<float>(inputLevels.min),
                                             static_cast<float>(inputLevels.max)
                                          },
-                                         input);
+                                         static_cast<float>(input));
     }
     
     bool operator==(const ExponentialInterpolator& rhs) const {
@@ -33,12 +33,12 @@ public:
     CubicBezierInterpolator(double x1_, double y1_, double x2_, double y2_) : ub(x1_, y1_, x2_, y2_) {}
     
     double interpolationFactor(const Range<double>& inputLevels, const double input) const {
-        return ub.solve(util::interpolationFactor(1.0,
+        return ub.solve(util::interpolationFactor(1.0f,
                                                   Range<float> {
                                                       static_cast<float>(inputLevels.min),
                                                       static_cast<float>(inputLevels.max)
                                                   },
-                                                  input),
+                                                  static_cast<float>(input)),
                         1e-6);
     }
     

--- a/include/mbgl/tile/tile_id.hpp
+++ b/include/mbgl/tile/tile_id.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/util/constants.hpp>
 
+#include <cmath>
 #include <cstdint>
 #include <array>
 #include <tuple>
@@ -199,7 +200,7 @@ inline OverscaledTileID OverscaledTileID::unwrapTo(int16_t newWrap) const {
 }
 
 inline UnwrappedTileID::UnwrappedTileID(uint8_t z_, int64_t x_, int64_t y_)
-    : wrap((x_ < 0 ? x_ - (1ll << z_) + 1 : x_) / (1ll << z_)),
+    : wrap(static_cast<int16_t>((x_ < 0 ? x_ - (1ll << z_) + 1 : x_) / (1ll << z_))),
       canonical(
           z_,
           static_cast<uint32_t>(x_ - wrap * (1ll << z_)),
@@ -247,7 +248,7 @@ inline OverscaledTileID UnwrappedTileID::overscaleTo(const uint8_t overscaledZ) 
 }
 
 inline float UnwrappedTileID::pixelsToTileUnits(const float pixelValue, const float zoom) const {
-    return pixelValue * (util::EXTENT / (util::tileSize * std::pow(2, zoom - canonical.z)));
+    return pixelValue * (static_cast<float>(util::EXTENT) / (static_cast<float>(util::tileSize) * std::pow(2.f, zoom - canonical.z)));
 }
 
 } // namespace mbgl

--- a/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
@@ -15,7 +15,12 @@
 #include <mbgl/util/chrono.hpp>
 
 #include <mbgl/storage/sqlite3.hpp>
+
+#if defined(__QT__) && defined(_WIN32) && !defined(__GNUC__)
+#include <QtZlib/zlib.h>
+#else
 #include <zlib.h>
+#endif
 
 namespace {
 //TODO: replace by mbgl::util::MBTILES_PROTOCOL

--- a/platform/default/src/mbgl/storage/offline_database.cpp
+++ b/platform/default/src/mbgl/storage/offline_database.cpp
@@ -137,7 +137,7 @@ void OfflineDatabase::handleError(const char* action) {
         handleError(ex, action);
     } catch (const util::IOException& ex) {
         handleError(ex, action);
-    } catch (const MapboxTileLimitExceededException& ex) {
+    } catch (const MapboxTileLimitExceededException&) {
         throw; // This is ours and must be handled on client side.
     } catch (const std::runtime_error& ex) {
         handleError(ex, action);

--- a/platform/qt/src/http_request.cpp
+++ b/platform/qt/src/http_request.cpp
@@ -31,7 +31,7 @@ HTTPRequest::~HTTPRequest()
 
 QUrl HTTPRequest::requestUrl() const
 {
-    return QUrl::fromPercentEncoding(QByteArray(m_resource.url.data(), m_resource.url.size()));
+    return QUrl::fromPercentEncoding(QByteArray(m_resource.url.data(), static_cast<int>(m_resource.url.size())));
 }
 
 QNetworkRequest HTTPRequest::networkRequest() const
@@ -44,7 +44,7 @@ QNetworkRequest HTTPRequest::networkRequest() const
 
     if (m_resource.priorEtag) {
         const auto etag = m_resource.priorEtag;
-        req.setRawHeader("If-None-Match", QByteArray(etag->data(), etag->size()));
+        req.setRawHeader("If-None-Match", QByteArray(etag->data(), static_cast<int>(etag->size())));
     } else if (m_resource.priorModified) {
         req.setRawHeader("If-Modified-Since", util::rfc1123(*m_resource.priorModified).c_str());
     }

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1450,7 +1450,7 @@ QVector<QString> QMapboxGL::layerIds() const
     const auto &layers = d_ptr->mapObj->getStyle().getLayers();
 
     QVector<QString> layerIds;
-    layerIds.reserve(layers.size());
+    layerIds.reserve(static_cast<int>(layers.size()));
 
     for (const mbgl::style::Layer *layer : layers) {
         layerIds.append(QString::fromStdString(layer->getID()));
@@ -1543,7 +1543,7 @@ QVariant QVariantFromValue(const mbgl::Value &value) {
             return QColor(value_.r, value_.g, value_.b, value_.a);
         }, [&](const std::vector<mbgl::Value> &vector) {
             QVariantList list;
-            list.reserve(vector.size());
+            list.reserve(static_cast<int>(vector.size()));
             for (const auto &value_ : vector) {
                 list.push_back(QVariantFromValue(value_));
             }

--- a/platform/qt/src/qt_conversion.hpp
+++ b/platform/qt/src/qt_conversion.hpp
@@ -31,7 +31,7 @@ public:
     }
 
     static QVariant arrayMember(const QVariant& value, std::size_t i) {
-        return value.toList()[i];
+        return value.toList()[static_cast<int>(i)];
     }
 
     static bool isObject(const QVariant& value) {

--- a/platform/qt/src/qt_image.cpp
+++ b/platform/qt/src/qt_image.cpp
@@ -37,7 +37,7 @@ PremultipliedImage decodeImage(const std::string& string) {
 #endif
 
     QImage image =
-        QImage::fromData(data, size)
+        QImage::fromData(data, static_cast<int>(size))
         .rgbSwapped()
         .convertToFormat(QImage::Format_ARGB32_Premultiplied);
 

--- a/platform/qt/src/sqlite3.cpp
+++ b/platform/qt/src/sqlite3.cpp
@@ -295,7 +295,7 @@ void Query::bind(int offset, const char* value, std::size_t length, bool /* reta
     }
 
     // Field numbering starts at 0.
-    stmt.impl->query.bindValue(offset - 1, QString(QByteArray(value, length)), QSql::In);
+    stmt.impl->query.bindValue(offset - 1, QString(QByteArray(value, static_cast<int>(length))), QSql::In);
 
     checkQueryError(stmt.impl->query);
 }
@@ -313,8 +313,8 @@ void Query::bindBlob(int offset, const void* value_, std::size_t length, bool re
     }
 
     // Field numbering starts at 0.
-    stmt.impl->query.bindValue(offset - 1, retain ? QByteArray(value, length) :
-            QByteArray::fromRawData(value, length), QSql::In | QSql::Binary);
+    stmt.impl->query.bindValue(offset - 1, retain ? QByteArray(value, static_cast<int>(length)) :
+            QByteArray::fromRawData(value, static_cast<int>(length)), QSql::In | QSql::Binary);
 
     checkQueryError(stmt.impl->query);
 }

--- a/platform/qt/src/string_stdlib.cpp
+++ b/platform/qt/src/string_stdlib.cpp
@@ -9,13 +9,13 @@ namespace mbgl {
 namespace platform {
 
 std::string uppercase(const std::string& str) {
-    auto upper = QString::fromUtf8(str.data(), str.length()).toUpper().toUtf8();
+    auto upper = QString::fromUtf8(str.data(), static_cast<int>(str.length())).toUpper().toUtf8();
 
     return std::string(upper.constData(), upper.size());
 }
 
 std::string lowercase(const std::string& str) {
-    auto lower = QString::fromUtf8(str.data(), str.length()).toLower().toUtf8();
+    auto lower = QString::fromUtf8(str.data(), static_cast<int>(str.length())).toLower().toUtf8();
 
     return std::string(lower.constData(), lower.size());
 }

--- a/platform/qt/src/utf.cpp
+++ b/platform/qt/src/utf.cpp
@@ -6,7 +6,7 @@ namespace mbgl {
 namespace util {
 
 std::u16string convertUTF8ToUTF16(std::string const& utf8) {
-    auto utf16 = QString::fromUtf8(utf8.data(), utf8.length());
+    auto utf16 = QString::fromUtf8(utf8.data(), static_cast<int>(utf8.length()));
 
     // Newers Qt have QString::toStdU16String(), but this is how it is
     // implemented. Do it here to keep compatibility with older versions.

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -17,6 +17,11 @@
 // Note: LayerManager::annotationsEnabled is defined
 // at compile time, so that linker (with LTO on) is able
 // to optimize out the unreachable code.
+#define CHECK_ANNOTATIONS_ENABLED_AND_RETURN_NOARG() \
+if (!LayerManager::annotationsEnabled) {             \
+    assert(false);                                   \
+    return;                                          \
+}
 #define CHECK_ANNOTATIONS_ENABLED_AND_RETURN(result) \
 if (!LayerManager::annotationsEnabled) {             \
     assert(false);                                   \
@@ -38,12 +43,12 @@ AnnotationManager::AnnotationManager(Style& style_)
 AnnotationManager::~AnnotationManager() = default;
 
 void AnnotationManager::setStyle(Style& style_) {
-    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN_NOARG();
     style = style_;
 }
 
 void AnnotationManager::onStyleLoaded() {
-    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN_NOARG();
     updateStyle();
 }
 
@@ -68,7 +73,7 @@ bool AnnotationManager::updateAnnotation(const AnnotationID& id, const Annotatio
 }
 
 void AnnotationManager::removeAnnotation(const AnnotationID& id) {
-    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN_NOARG();
     std::lock_guard<std::mutex> lock(mutex);
     remove(id);
     dirty = true;
@@ -134,13 +139,13 @@ void AnnotationManager::update(const AnnotationID& id, const FillAnnotation& ann
 }
 
 void AnnotationManager::remove(const AnnotationID& id) {
-    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN_NOARG();
     if (symbolAnnotations.find(id) != symbolAnnotations.end()) {
         symbolTree.remove(symbolAnnotations.at(id));
         symbolAnnotations.erase(id);
     } else if (shapeAnnotations.find(id) != shapeAnnotations.end()) {
         auto it = shapeAnnotations.find(id);
-        *style.get().impl->removeLayer(it->second->layerID);
+        (void)*style.get().impl->removeLayer(it->second->layerID);
         shapeAnnotations.erase(it);
     } else {
         assert(false); // Should never happen
@@ -211,7 +216,7 @@ void AnnotationManager::updateStyle() {
 }
 
 void AnnotationManager::updateData() {
-    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN_NOARG();
     std::lock_guard<std::mutex> lock(mutex);
     if (dirty) {
         for (auto& tile : tiles) {
@@ -222,14 +227,14 @@ void AnnotationManager::updateData() {
 }
 
 void AnnotationManager::addTile(AnnotationTile& tile) {
-    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN_NOARG();
     std::lock_guard<std::mutex> lock(mutex);
     tiles.insert(&tile);
     tile.setData(getTileData(tile.id.canonical));
 }
 
 void AnnotationManager::removeTile(AnnotationTile& tile) {
-    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN_NOARG();
     std::lock_guard<std::mutex> lock(mutex);
     tiles.erase(&tile);
 }
@@ -241,7 +246,7 @@ static std::string prefixedImageID(const std::string& id) {
 }
 
 void AnnotationManager::addImage(std::unique_ptr<style::Image> image) {
-    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN_NOARG();
     std::lock_guard<std::mutex> lock(mutex);
     const std::string id = prefixedImageID(image->getID());
     images.erase(id);
@@ -251,7 +256,7 @@ void AnnotationManager::addImage(std::unique_ptr<style::Image> image) {
 }
 
 void AnnotationManager::removeImage(const std::string& id_) {
-    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN_NOARG();
     std::lock_guard<std::mutex> lock(mutex);
     const std::string id = prefixedImageID(id_);
     images.erase(id);

--- a/src/mbgl/geometry/dem_data.cpp
+++ b/src/mbgl/geometry/dem_data.cpp
@@ -90,9 +90,9 @@ int32_t DEMData::get(const int32_t x, const int32_t y) const {
 
 const std::array<float, 4>& DEMData::getUnpackVector() const {
     // https://www.mapbox.com/help/access-elevation-data/#mapbox-terrain-rgb
-    static const std::array<float, 4> unpackMapbox = {{ 6553.6, 25.6, 0.1, 10000.0 }};
+    static const std::array<float, 4> unpackMapbox = {{ 6553.6f, 25.6f, 0.1f, 10000.0f }};
     // https://aws.amazon.com/public-datasets/terrain/
-    static const std::array<float, 4> unpackTerrarium = {{ 256.0, 1.0, 1.0 / 256.0, 32768.0 }};
+    static const std::array<float, 4> unpackTerrarium = {{ 256.0f, 1.0f, 1.0f / 256.0f, 32768.0f }};
 
     return encoding == Tileset::DEMEncoding::Terrarium ? unpackTerrarium : unpackMapbox;
 }

--- a/src/mbgl/gfx/context.hpp
+++ b/src/mbgl/gfx/context.hpp
@@ -87,7 +87,7 @@ public:
 
     virtual const RenderingStats& renderingStats() const = 0;
 
-#if not defined(NDEBUG)
+#if !defined(NDEBUG)
 public:
     virtual void visualizeStencilBuffer() = 0;
     virtual void visualizeDepthBuffer(float depthRangeSize) = 0;

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -316,7 +316,7 @@ std::unique_ptr<uint8_t[]> Context::readFramebuffer(const Size size, const gfx::
     return data;
 }
 
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
 void Context::drawPixels(const Size size, const void* data, gfx::TexturePixelType format) {
     pixelStoreUnpack = { 1 };
     // TODO
@@ -486,7 +486,7 @@ void Context::setDirtyState() {
     activeTextureUnit.setDirty();
     pixelStorePack.setDirty();
     pixelStoreUnpack.setDirty();
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
     pointSize.setDirty();
     pixelZoom.setDirty();
     rasterPos.setDirty();
@@ -610,7 +610,7 @@ void Context::draw(const gfx::DrawMode& drawMode,
                    std::size_t indexLength) {
     switch (drawMode.type) {
     case gfx::DrawModeType::Points:
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
         // In OpenGL ES 2, the point size is set in the vertex shader.
         pointSize = drawMode.size;
 #endif // MBGL_USE_GLES2
@@ -725,7 +725,7 @@ void Context::reduceMemoryUsage() {
     MBGL_CHECK_ERROR(glFinish());
 }
 
-#if not defined(NDEBUG)
+#if !defined(NDEBUG)
 void Context::visualizeStencilBuffer() {
 #if not MBGL_USE_GLES2
     setStencilMode(gfx::StencilMode::disabled());

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -74,7 +74,7 @@ public:
         return { size, readFramebuffer(size, format, flip) };
     }
 
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
     template <typename Image>
     void drawPixels(const Image& image) {
         auto format = image.channels == 4 ? gfx::TexturePixelType::RGBA : gfx::TexturePixelType::Alpha;
@@ -154,7 +154,7 @@ public:
     State<value::PixelStorePack> pixelStorePack;
     State<value::PixelStoreUnpack> pixelStoreUnpack;
 
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
     State<value::PixelZoom> pixelZoom;
     State<value::RasterPos> rasterPos;
     State<value::PixelTransferDepth> pixelTransferDepth;
@@ -183,7 +183,7 @@ private:
     State<value::CullFace> cullFace;
     State<value::CullFaceSide> cullFaceSide;
     State<value::CullFaceWinding> cullFaceWinding;
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
     State<value::PointSize> pointSize;
 #endif // MBGL_USE_GLES2
 
@@ -198,7 +198,7 @@ private:
 
     UniqueFramebuffer createFramebuffer();
     std::unique_ptr<uint8_t[]> readFramebuffer(Size, gfx::TexturePixelType, bool flip);
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
     void drawPixels(Size size, const void* data, gfx::TexturePixelType);
 #endif // MBGL_USE_GLES2
 
@@ -227,7 +227,7 @@ public:
     // For testing
     bool disableVAOExtension = false;
 
-#if not defined(NDEBUG)
+#if !defined(NDEBUG)
 public:
     void visualizeStencilBuffer() override;
     void visualizeDepthBuffer(float depthRangeSize) override;

--- a/src/mbgl/gl/enum.cpp
+++ b/src/mbgl/gl/enum.cpp
@@ -286,7 +286,7 @@ platform::GLenum Enum<gfx::TextureChannelDataType>::to(const gfx::TextureChannel
 template <>
 gfx::RenderbufferPixelType Enum<gfx::RenderbufferPixelType>::from(const platform::GLint value) {
     switch (value) {
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
         case GL_RGBA8: return gfx::RenderbufferPixelType::RGBA;
         case GL_DEPTH_COMPONENT: return gfx::RenderbufferPixelType::Depth;
         case GL_DEPTH24_STENCIL8: return gfx::RenderbufferPixelType::DepthStencil;
@@ -302,7 +302,7 @@ gfx::RenderbufferPixelType Enum<gfx::RenderbufferPixelType>::from(const platform
 template <>
 platform::GLenum Enum<gfx::RenderbufferPixelType>::to(const gfx::RenderbufferPixelType value) {
     switch (value) {
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
         case gfx::RenderbufferPixelType::RGBA: return GL_RGBA8;
         case gfx::RenderbufferPixelType::Depth: return GL_DEPTH_COMPONENT;
         case gfx::RenderbufferPixelType::DepthStencil: return GL_DEPTH24_STENCIL8;

--- a/src/mbgl/gl/offscreen_texture.cpp
+++ b/src/mbgl/gl/offscreen_texture.cpp
@@ -60,7 +60,7 @@ bool OffscreenTexture::isRenderable() {
     try {
         getResource<OffscreenTextureResource>().bind();
         return true;
-    } catch (const std::runtime_error& ex) {
+    } catch (const std::runtime_error&) {
         return false;
     }
 }

--- a/src/mbgl/gl/value.cpp
+++ b/src/mbgl/gl/value.cpp
@@ -533,7 +533,7 @@ PixelStoreUnpack::Type PixelStoreUnpack::Get() {
     return value;
 }
 
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
 
 const constexpr PointSize::Type PointSize::Default;
 

--- a/src/mbgl/gl/value.hpp
+++ b/src/mbgl/gl/value.hpp
@@ -283,7 +283,7 @@ struct PixelStoreUnpack {
     static Type Get();
 };
 
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
 
 struct PointSize {
     using Type = float;

--- a/src/mbgl/gl/vertex_array.cpp
+++ b/src/mbgl/gl/vertex_array.cpp
@@ -16,7 +16,7 @@ void VertexArray::bind(Context& context,
     // NOLINTNEXTLINE(bugprone-too-small-loop-variable)
     for (AttributeLocation location = 0; location < bindings.size(); ++location) {
         if (state->bindings.size() <= location) {
-            state->bindings.emplace_back(context, AttributeLocation(location));
+            state->bindings.emplace_back(context, std::move(AttributeLocation(location)));
         }
         state->bindings[location] = bindings[location];
     }

--- a/src/mbgl/layout/circle_layout.hpp
+++ b/src/mbgl/layout/circle_layout.hpp
@@ -130,7 +130,7 @@ private:
 
                 auto& segment = segments.back();
                 assert(segment.vertexLength <= std::numeric_limits<uint16_t>::max());
-                uint16_t index = segment.vertexLength;
+                auto index = static_cast<uint16_t>(segment.vertexLength);
 
                 // 1, 2, 3
                 // 1, 4, 3

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -974,7 +974,7 @@ size_t SymbolLayout::addSymbol(SymbolBucket::Buffer& buffer,
     // coordinate in this polygon.
     auto& segment = buffer.segments.back();
     assert(segment.vertexLength <= std::numeric_limits<uint16_t>::max());
-    uint16_t index = segment.vertexLength;
+    auto index = static_cast<uint16_t>(segment.vertexLength);
 
     // coordinates (2 triangles)
     buffer.vertices.emplace_back(SymbolSDFIconProgram::layoutVertex(labelAnchor.point,
@@ -1092,7 +1092,7 @@ void SymbolLayout::addToDebugBuffers(SymbolBucket& bucket) {
                 }
 
                 auto& segment = collisionBuffer.segments.back();
-                uint16_t index = segment.vertexLength;
+                auto index = static_cast<uint16_t>(segment.vertexLength);
 
                 collisionBuffer.vertices.emplace_back(CollisionBoxProgram::layoutVertex(anchor, symbolInstance.anchor.point, tl));
                 collisionBuffer.vertices.emplace_back(CollisionBoxProgram::layoutVertex(anchor, symbolInstance.anchor.point, tr));

--- a/src/mbgl/layout/symbol_projection.cpp
+++ b/src/mbgl/layout/symbol_projection.cpp
@@ -169,10 +169,10 @@ namespace mbgl {
             // The label needs to be flipped to keep text upright.
             // Iterate in the reverse direction.
             dir *= -1;
-            angle = M_PI;
+            angle = static_cast<float>(M_PI);
         }
 
-        if (dir < 0) angle += M_PI;
+        if (dir < 0) angle += static_cast<float>(M_PI);
 
         int32_t currentIndex = dir > 0 ? anchorSegment : anchorSegment + 1;
 
@@ -248,10 +248,10 @@ namespace mbgl {
         const float firstGlyphOffset = symbol.glyphOffsets.front();
         const float lastGlyphOffset = symbol.glyphOffsets.back();;
 
-        optional<PlacedGlyph> firstPlacedGlyph = placeGlyphAlongLine(fontScale * firstGlyphOffset, lineOffsetX, lineOffsetY, flip, anchorPoint, tileAnchorPoint, symbol.segment, symbol.line, symbol.tileDistances, labelPlaneMatrix,  returnTileDistance);
+        optional<PlacedGlyph> firstPlacedGlyph = placeGlyphAlongLine(fontScale * firstGlyphOffset, lineOffsetX, lineOffsetY, flip, anchorPoint, tileAnchorPoint, static_cast<uint16_t>(symbol.segment), symbol.line, symbol.tileDistances, labelPlaneMatrix, returnTileDistance);
         if (!firstPlacedGlyph) return {};
 
-        optional<PlacedGlyph> lastPlacedGlyph = placeGlyphAlongLine(fontScale * lastGlyphOffset, lineOffsetX, lineOffsetY, flip, anchorPoint, tileAnchorPoint, symbol.segment, symbol.line, symbol.tileDistances, labelPlaneMatrix, returnTileDistance);
+        optional<PlacedGlyph> lastPlacedGlyph = placeGlyphAlongLine(fontScale * lastGlyphOffset, lineOffsetX, lineOffsetY, flip, anchorPoint, tileAnchorPoint, static_cast<uint16_t>(symbol.segment), symbol.line, symbol.tileDistances, labelPlaneMatrix, returnTileDistance);
         if (!lastPlacedGlyph) return {};
 
         return std::make_pair(*firstPlacedGlyph, *lastPlacedGlyph);
@@ -316,7 +316,7 @@ namespace mbgl {
             for (size_t glyphIndex = 1; glyphIndex < symbol.glyphOffsets.size() - 1; glyphIndex++) {
                 const float glyphOffsetX = symbol.glyphOffsets[glyphIndex];
                 // Since first and last glyph fit on the line, we're sure that the rest of the glyphs can be placed
-                auto placedGlyph = placeGlyphAlongLine(glyphOffsetX * fontScale, lineOffsetX, lineOffsetY, flip, projectedAnchorPoint, symbol.anchorPoint, symbol.segment, symbol.line, symbol.tileDistances, labelPlaneMatrix, false);
+                auto placedGlyph = placeGlyphAlongLine(glyphOffsetX * fontScale, lineOffsetX, lineOffsetY, flip, projectedAnchorPoint, symbol.anchorPoint, static_cast<uint16_t>(symbol.segment), symbol.line, symbol.tileDistances, labelPlaneMatrix, false);
                 if (placedGlyph) {
                     placedGlyphs.push_back(*placedGlyph);
                 } else {
@@ -344,7 +344,7 @@ namespace mbgl {
                 }
             }
             const float glyphOffsetX = symbol.glyphOffsets.front();
-            optional<PlacedGlyph> singleGlyph = placeGlyphAlongLine(fontScale * glyphOffsetX, lineOffsetX, lineOffsetY, flip, projectedAnchorPoint, symbol.anchorPoint, symbol.segment,
+            optional<PlacedGlyph> singleGlyph = placeGlyphAlongLine(fontScale * glyphOffsetX, lineOffsetX, lineOffsetY, flip, projectedAnchorPoint, symbol.anchorPoint, static_cast<uint16_t>(symbol.segment),
                 symbol.line, symbol.tileDistances, labelPlaneMatrix, false);
             if (!singleGlyph)
                 return PlacementResult::NotEnoughRoom;

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -698,7 +698,7 @@ TileCoordinate TransformState::screenCoordinateToTileCoordinate(const ScreenCoor
 
 LatLng TransformState::screenCoordinateToLatLng(const ScreenCoordinate& point, LatLng::WrapMode wrapMode) const {
     auto coord = screenCoordinateToTileCoordinate(point, 0);
-    return Projection::unproject(coord.p, 1 / util::tileSize, wrapMode);
+    return Projection::unproject(coord.p, 1. / util::tileSize, wrapMode);
 }
 
 mat4 TransformState::coordinatePointMatrix(const mat4& projMatrix) const {

--- a/src/mbgl/renderer/buckets/debug_bucket.cpp
+++ b/src/mbgl/renderer/buckets/debug_bucket.cpp
@@ -40,8 +40,8 @@ DebugBucket::DebugBucket(const OverscaledTileID& id,
                     vertices.emplace_back(FillProgram::layoutVertex(p));
 
                     if (prev) {
-                        indices.emplace_back(vertices.elements() - 2,
-                                             vertices.elements() - 1);
+                        indices.emplace_back(static_cast<uint16_t>(vertices.elements() - 2),
+                                             static_cast<uint16_t>(vertices.elements() - 1));
                     }
 
                     prev = p;

--- a/src/mbgl/renderer/buckets/fill_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_bucket.cpp
@@ -75,14 +75,14 @@ void FillBucket::addFeature(const GeometryTileFeature& feature,
 
             auto& lineSegment = lineSegments.back();
             assert(lineSegment.vertexLength <= std::numeric_limits<uint16_t>::max());
-            uint16_t lineIndex = lineSegment.vertexLength;
+            const auto lineIndex = static_cast<uint16_t>(lineSegment.vertexLength);
 
             vertices.emplace_back(FillProgram::layoutVertex(ring[0]));
-            lines.emplace_back(lineIndex + nVertices - 1, lineIndex);
+            lines.emplace_back(static_cast<uint16_t>(lineIndex + nVertices - 1), lineIndex);
 
             for (std::size_t i = 1; i < nVertices; i++) {
                 vertices.emplace_back(FillProgram::layoutVertex(ring[i]));
-                lines.emplace_back(lineIndex + i - 1, lineIndex + i);
+                lines.emplace_back(static_cast<uint16_t>(lineIndex + i - 1), static_cast<uint16_t>(lineIndex + i));
             }
 
             lineSegment.vertexLength += nVertices;
@@ -100,7 +100,7 @@ void FillBucket::addFeature(const GeometryTileFeature& feature,
 
         auto& triangleSegment = triangleSegments.back();
         assert(triangleSegment.vertexLength <= std::numeric_limits<uint16_t>::max());
-        uint16_t triangleIndex = triangleSegment.vertexLength;
+        const auto triangleIndex = static_cast<uint16_t>(triangleSegment.vertexLength);
 
         for (std::size_t i = 0; i < nIndicies; i += 3) {
             triangles.emplace_back(triangleIndex + indices[i],

--- a/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
@@ -83,7 +83,7 @@ void FillExtrusionBucket::addFeature(const GeometryTileFeature& feature,
 
         auto& triangleSegment = triangleSegments.back();
         assert(triangleSegment.vertexLength <= std::numeric_limits<uint16_t>::max());
-        uint16_t triangleIndex = triangleSegment.vertexLength;
+        auto triangleIndex = static_cast<uint16_t>(triangleSegment.vertexLength);
 
         assert(triangleIndex + (5 * (totalVertices - 1) + 1) <=
                std::numeric_limits<uint16_t>::max());
@@ -100,7 +100,7 @@ void FillExtrusionBucket::addFeature(const GeometryTileFeature& feature,
                 const auto& p1 = ring[i];
 
                 vertices.emplace_back(
-                    FillExtrusionProgram::layoutVertex(p1, 0, 0, 1, 1, edgeDistance));
+                    FillExtrusionProgram::layoutVertex(p1, 0, 0, 1, 1, static_cast<uint16_t>(edgeDistance)));
                 flatIndices.emplace_back(triangleIndex);
                 triangleIndex++;
 
@@ -117,16 +117,16 @@ void FillExtrusionBucket::addFeature(const GeometryTileFeature& feature,
                     }
 
                     vertices.emplace_back(
-                        FillExtrusionProgram::layoutVertex(p1, perp.x, perp.y, 0, 0, edgeDistance));
+                        FillExtrusionProgram::layoutVertex(p1, perp.x, perp.y, 0, 0, static_cast<uint16_t>(edgeDistance)));
                     vertices.emplace_back(
-                        FillExtrusionProgram::layoutVertex(p1, perp.x, perp.y, 0, 1, edgeDistance));
+                        FillExtrusionProgram::layoutVertex(p1, perp.x, perp.y, 0, 1, static_cast<uint16_t>(edgeDistance)));
 
                     edgeDistance += dist;
 
                     vertices.emplace_back(
-                        FillExtrusionProgram::layoutVertex(p2, perp.x, perp.y, 0, 0, edgeDistance));
+                        FillExtrusionProgram::layoutVertex(p2, perp.x, perp.y, 0, 0, static_cast<uint16_t>(edgeDistance)));
                     vertices.emplace_back(
-                        FillExtrusionProgram::layoutVertex(p2, perp.x, perp.y, 0, 1, edgeDistance));
+                        FillExtrusionProgram::layoutVertex(p2, perp.x, perp.y, 0, 1, static_cast<uint16_t>(edgeDistance)));
 
                     // ┌──────┐
                     // │ 0  1 │ Counter-Clockwise winding order.

--- a/src/mbgl/renderer/buckets/heatmap_bucket.cpp
+++ b/src/mbgl/renderer/buckets/heatmap_bucket.cpp
@@ -78,7 +78,7 @@ void HeatmapBucket::addFeature(const GeometryTileFeature& feature,
 
             auto& segment = segments.back();
             assert(segment.vertexLength <= std::numeric_limits<uint16_t>::max());
-            uint16_t index = segment.vertexLength;
+            const auto index = static_cast<uint16_t>(segment.vertexLength);
 
             // 1, 2, 3
             // 1, 4, 3

--- a/src/mbgl/renderer/buckets/hillshade_bucket.cpp
+++ b/src/mbgl/renderer/buckets/hillshade_bucket.cpp
@@ -100,7 +100,7 @@ void HillshadeBucket::setMask(TileMask&& mask_) {
 
         auto& segment = segments.back();
         assert(segment.vertexLength <= std::numeric_limits<uint16_t>::max());
-        const uint16_t offset = segment.vertexLength;
+        const auto offset = static_cast<uint16_t>(segment.vertexLength);
 
         // 0, 1, 2
         // 1, 2, 3

--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -441,7 +441,7 @@ void LineBucket::addGeometry(const GeometryCoordinates& coordinates,
 
     auto& segment = segments.back();
     assert(segment.vertexLength <= std::numeric_limits<uint16_t>::max());
-    uint16_t index = segment.vertexLength;
+    const auto index = static_cast<uint16_t>(segment.vertexLength);
 
     for (const auto& triangle : triangleStore) {
         triangles.emplace_back(index + triangle.a, index + triangle.b, index + triangle.c);

--- a/src/mbgl/renderer/buckets/raster_bucket.cpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.cpp
@@ -92,7 +92,7 @@ void RasterBucket::setMask(TileMask&& mask_) {
 
         auto& segment = segments.back();
         assert(segment.vertexLength <= std::numeric_limits<uint16_t>::max());
-        const uint16_t offset = segment.vertexLength;
+        const auto offset = static_cast<uint16_t>(segment.vertexLength);
 
         // 0, 1, 2
         // 1, 2, 3

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -209,8 +209,8 @@ bool SymbolBucket::hasTextCollisionCircleData() const {
 void addPlacedSymbol(gfx::IndexVector<gfx::Triangles>& triangles, const PlacedSymbol& placedSymbol) {
     auto endIndex = placedSymbol.vertexStartIndex + placedSymbol.glyphOffsets.size() * 4;
     for (auto vertexIndex = placedSymbol.vertexStartIndex; vertexIndex < endIndex; vertexIndex += 4) {
-        triangles.emplace_back(vertexIndex + 0, vertexIndex + 1, vertexIndex + 2);
-        triangles.emplace_back(vertexIndex + 1, vertexIndex + 2, vertexIndex + 3);
+        triangles.emplace_back(static_cast<uint16_t>(vertexIndex + 0), static_cast<uint16_t>(vertexIndex + 1), static_cast<uint16_t>(vertexIndex + 2));
+        triangles.emplace_back(static_cast<uint16_t>(vertexIndex + 1), static_cast<uint16_t>(vertexIndex + 2), static_cast<uint16_t>(vertexIndex + 3));
     }
 }
 

--- a/src/mbgl/renderer/layers/render_location_indicator_layer.cpp
+++ b/src/mbgl/renderer/layers/render_location_indicator_layer.cpp
@@ -472,7 +472,7 @@ protected:
 
     void updateRadius(const mbgl::LocationIndicatorRenderParameters& params) {
         const TransformState& s = *params.state;
-        const unsigned long numVtxCircumference = circle.size() - 1;
+        const auto numVtxCircumference = static_cast<unsigned long>(circle.size() - 1);
         const float bearingStep = 360.0f / float(numVtxCircumference - 1); // first and last points are the same
         const mapbox::cheap_ruler::point centerPoint(params.puckPosition.longitude(), params.puckPosition.latitude());
         Point<double> center = project(params.puckPosition, s);

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -52,7 +52,7 @@ bool RenderRasterLayer::hasCrossfade() const {
 
 static float saturationFactor(float saturation) {
     if (saturation > 0) {
-        return 1 - 1 / (1.001 - saturation);
+        return 1.f - 1.f / (1.001f - saturation);
     } else {
         return -saturation;
     }

--- a/src/mbgl/renderer/paint_parameters.cpp
+++ b/src/mbgl/renderer/paint_parameters.cpp
@@ -23,7 +23,7 @@ TransformParameters::TransformParameters(const TransformState& state_)
     // to a tenth of the far value, so as not to waste depth buffer precision on
     // very close empty space, for layer types (fill-extrusion) that use the
     // depth buffer to emulate real-world space.
-    state.getProjMatrix(nearClippedProjMatrix, 0.1 * state.getCameraToCenterDistance());
+    state.getProjMatrix(nearClippedProjMatrix, static_cast<uint16_t>(0.1 * state.getCameraToCenterDistance()));
 }
 
 PaintParameters::PaintParameters(gfx::Context& context_,

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -322,7 +322,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
                         if (zoomFitsLayer) {
                             sourceNeedsRendering = true;
                             renderItemsEmplaceHint =
-                                layerRenderItems.emplace_hint(renderItemsEmplaceHint, layer, source, index);
+                                layerRenderItems.emplace_hint(renderItemsEmplaceHint, layer, source, static_cast<uint32_t>(index));
                         }
                     }
                 }
@@ -339,7 +339,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
                                   // items.
                     }
                 }
-                renderItemsEmplaceHint = layerRenderItems.emplace_hint(renderItemsEmplaceHint, layer, nullptr, index);
+                renderItemsEmplaceHint = layerRenderItems.emplace_hint(renderItemsEmplaceHint, layer, nullptr, static_cast<uint32_t>(index));
             }
         }
         source->update(sourceImpl,

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -184,7 +184,7 @@ void Renderer::Impl::render(const RenderTree& renderTree) {
         }
     }
 
-#if not defined(NDEBUG)
+#if !defined(NDEBUG)
     if (parameters.debugOptions & MapDebugOptions::StencilClip) {
         // Render tile clip boundaries, using stencil buffer to calculate fill color.
         parameters.context.visualizeStencilBuffer();

--- a/src/mbgl/style/layers/location_indicator_layer.cpp
+++ b/src/mbgl/style/layers/location_indicator_layer.cpp
@@ -301,7 +301,7 @@ TransitionOptions LocationIndicatorLayer::getLocationTransition() const {
 }
 
 PropertyValue<float> LocationIndicatorLayer::getDefaultPerspectiveCompensation() {
-    return {0.85};
+    return {0.85f};
 }
 
 const PropertyValue<float>& LocationIndicatorLayer::getPerspectiveCompensation() const {

--- a/src/mbgl/style/layers/location_indicator_layer_properties.hpp
+++ b/src/mbgl/style/layers/location_indicator_layer_properties.hpp
@@ -32,7 +32,7 @@ struct TopImage : LayoutProperty<expression::Image> {
 };
 
 struct AccuracyRadius : PaintProperty<float> {
-    static float defaultValue() { return 0; }
+    static float defaultValue() { return 0.f; }
 };
 
 struct AccuracyRadiusBorderColor : PaintProperty<Color> {
@@ -48,11 +48,11 @@ struct Bearing : PaintProperty<Rotation> {
 };
 
 struct BearingImageSize : PaintProperty<float> {
-    static float defaultValue() { return 1; }
+    static float defaultValue() { return 1.f; }
 };
 
 struct ImageTiltDisplacement : PaintProperty<float> {
-    static float defaultValue() { return 0; }
+    static float defaultValue() { return 0.f; }
 };
 
 struct Location : PaintProperty<std::array<double, 3>> {
@@ -60,15 +60,15 @@ struct Location : PaintProperty<std::array<double, 3>> {
 };
 
 struct PerspectiveCompensation : PaintProperty<float> {
-    static float defaultValue() { return 0.85; }
+    static float defaultValue() { return 0.85f; }
 };
 
 struct ShadowImageSize : PaintProperty<float> {
-    static float defaultValue() { return 1; }
+    static float defaultValue() { return 1.f; }
 };
 
 struct TopImageSize : PaintProperty<float> {
-    static float defaultValue() { return 1; }
+    static float defaultValue() { return 1.f; }
 };
 
 class LocationIndicatorLayoutProperties : public Properties<

--- a/src/mbgl/style/layers/symbol_layer_properties.hpp
+++ b/src/mbgl/style/layers/symbol_layer_properties.hpp
@@ -53,7 +53,7 @@ struct IconOptional : LayoutProperty<bool> {
 
 struct IconPadding : LayoutProperty<float> {
     static constexpr const char *name() { return "icon-padding"; }
-    static float defaultValue() { return 2; }
+    static float defaultValue() { return 2.f; }
 };
 
 struct IconPitchAlignment : LayoutProperty<AlignmentType> {
@@ -63,7 +63,7 @@ struct IconPitchAlignment : LayoutProperty<AlignmentType> {
 
 struct IconRotate : DataDrivenLayoutProperty<float> {
     static constexpr const char *name() { return "icon-rotate"; }
-    static float defaultValue() { return 0; }
+    static float defaultValue() { return 0.f; }
 };
 
 struct IconRotationAlignment : LayoutProperty<AlignmentType> {
@@ -73,7 +73,7 @@ struct IconRotationAlignment : LayoutProperty<AlignmentType> {
 
 struct IconSize : DataDrivenLayoutProperty<float> {
     static constexpr const char *name() { return "icon-size"; }
-    static float defaultValue() { return 1; }
+    static float defaultValue() { return 1.f; }
 };
 
 struct IconTextFit : LayoutProperty<IconTextFitType> {
@@ -83,7 +83,7 @@ struct IconTextFit : LayoutProperty<IconTextFitType> {
 
 struct IconTextFitPadding : LayoutProperty<std::array<float, 4>> {
     static constexpr const char *name() { return "icon-text-fit-padding"; }
-    static std::array<float, 4> defaultValue() { return {{0, 0, 0, 0}}; }
+    static std::array<float, 4> defaultValue() { return {{0.f, 0.f, 0.f, 0.f}}; }
 };
 
 struct SymbolAvoidEdges : LayoutProperty<bool> {
@@ -98,12 +98,12 @@ struct SymbolPlacement : LayoutProperty<SymbolPlacementType> {
 
 struct SymbolSortKey : DataDrivenLayoutProperty<float> {
     static constexpr const char *name() { return "symbol-sort-key"; }
-    static float defaultValue() { return 0; }
+    static float defaultValue() { return 0.f; }
 };
 
 struct SymbolSpacing : LayoutProperty<float> {
     static constexpr const char *name() { return "symbol-spacing"; }
-    static float defaultValue() { return 250; }
+    static float defaultValue() { return 250.f; }
 };
 
 struct SymbolZOrder : LayoutProperty<SymbolZOrderType> {
@@ -148,22 +148,22 @@ struct TextKeepUpright : LayoutProperty<bool> {
 
 struct TextLetterSpacing : DataDrivenLayoutProperty<float> {
     static constexpr const char *name() { return "text-letter-spacing"; }
-    static float defaultValue() { return 0; }
+    static float defaultValue() { return 0.f; }
 };
 
 struct TextLineHeight : LayoutProperty<float> {
     static constexpr const char *name() { return "text-line-height"; }
-    static float defaultValue() { return 1.2; }
+    static float defaultValue() { return 1.2f; }
 };
 
 struct TextMaxAngle : LayoutProperty<float> {
     static constexpr const char *name() { return "text-max-angle"; }
-    static float defaultValue() { return 45; }
+    static float defaultValue() { return 45.f; }
 };
 
 struct TextMaxWidth : DataDrivenLayoutProperty<float> {
     static constexpr const char *name() { return "text-max-width"; }
-    static float defaultValue() { return 10; }
+    static float defaultValue() { return 10.f; }
 };
 
 struct TextOffset : DataDrivenLayoutProperty<std::array<float, 2>> {
@@ -178,7 +178,7 @@ struct TextOptional : LayoutProperty<bool> {
 
 struct TextPadding : LayoutProperty<float> {
     static constexpr const char *name() { return "text-padding"; }
-    static float defaultValue() { return 2; }
+    static float defaultValue() { return 2.f; }
 };
 
 struct TextPitchAlignment : LayoutProperty<AlignmentType> {
@@ -188,12 +188,12 @@ struct TextPitchAlignment : LayoutProperty<AlignmentType> {
 
 struct TextRadialOffset : DataDrivenLayoutProperty<float> {
     static constexpr const char *name() { return "text-radial-offset"; }
-    static float defaultValue() { return 0; }
+    static float defaultValue() { return 0.f; }
 };
 
 struct TextRotate : DataDrivenLayoutProperty<float> {
     static constexpr const char *name() { return "text-rotate"; }
-    static float defaultValue() { return 0; }
+    static float defaultValue() { return 0.f; }
 };
 
 struct TextRotationAlignment : LayoutProperty<AlignmentType> {
@@ -203,7 +203,7 @@ struct TextRotationAlignment : LayoutProperty<AlignmentType> {
 
 struct TextSize : DataDrivenLayoutProperty<float> {
     static constexpr const char *name() { return "text-size"; }
-    static float defaultValue() { return 16; }
+    static float defaultValue() { return 16.f; }
 };
 
 struct TextTransform : DataDrivenLayoutProperty<TextTransformType> {
@@ -226,7 +226,7 @@ struct IconColor : DataDrivenPaintProperty<Color, attributes::fill_color, unifor
 };
 
 struct IconHaloBlur : DataDrivenPaintProperty<float, attributes::halo_blur, uniforms::halo_blur> {
-    static float defaultValue() { return 0; }
+    static float defaultValue() { return 0.f; }
 };
 
 struct IconHaloColor : DataDrivenPaintProperty<Color, attributes::halo_color, uniforms::halo_color> {
@@ -234,15 +234,15 @@ struct IconHaloColor : DataDrivenPaintProperty<Color, attributes::halo_color, un
 };
 
 struct IconHaloWidth : DataDrivenPaintProperty<float, attributes::halo_width, uniforms::halo_width> {
-    static float defaultValue() { return 0; }
+    static float defaultValue() { return 0.f; }
 };
 
 struct IconOpacity : DataDrivenPaintProperty<float, attributes::opacity, uniforms::opacity> {
-    static float defaultValue() { return 1; }
+    static float defaultValue() { return 1.f; }
 };
 
 struct IconTranslate : PaintProperty<std::array<float, 2>> {
-    static std::array<float, 2> defaultValue() { return {{0, 0}}; }
+    static std::array<float, 2> defaultValue() { return {{0.f, 0.f}}; }
 };
 
 struct IconTranslateAnchor : PaintProperty<TranslateAnchorType> {
@@ -257,7 +257,7 @@ struct TextColor : DataDrivenPaintProperty<Color, attributes::fill_color, unifor
 };
 
 struct TextHaloBlur : DataDrivenPaintProperty<float, attributes::halo_blur, uniforms::halo_blur> {
-    static float defaultValue() { return 0; }
+    static float defaultValue() { return 0.f; }
 };
 
 struct TextHaloColor : DataDrivenPaintProperty<Color, attributes::halo_color, uniforms::halo_color> {
@@ -265,15 +265,15 @@ struct TextHaloColor : DataDrivenPaintProperty<Color, attributes::halo_color, un
 };
 
 struct TextHaloWidth : DataDrivenPaintProperty<float, attributes::halo_width, uniforms::halo_width> {
-    static float defaultValue() { return 0; }
+    static float defaultValue() { return 0.f; }
 };
 
 struct TextOpacity : DataDrivenPaintProperty<float, attributes::opacity, uniforms::opacity> {
-    static float defaultValue() { return 1; }
+    static float defaultValue() { return 1.f; }
 };
 
 struct TextTranslate : PaintProperty<std::array<float, 2>> {
-    static std::array<float, 2> defaultValue() { return {{0, 0}}; }
+    static std::array<float, 2> defaultValue() { return {{0.f, 0.f}}; }
 };
 
 struct TextTranslateAnchor : PaintProperty<TranslateAnchorType> {

--- a/src/mbgl/style/light_impl.hpp
+++ b/src/mbgl/style/light_impl.hpp
@@ -32,7 +32,7 @@ struct LightAnchor : LightProperty<LightAnchorType> {
 
 struct LightPosition : LightProperty<Position> {
     static Position defaultValue() {
-        std::array<float, 3> default_ = { { 1.15, 210, 30 } };
+        std::array<float, 3> default_ = { { 1.15f, 210.f, 30.f } };
         return Position{ { default_ } };
     }
 };

--- a/src/mbgl/text/quads.cpp
+++ b/src/mbgl/text/quads.cpp
@@ -276,11 +276,11 @@ SymbolQuads getGlyphQuads(const Shaping& shapedText,
                 // for when glyph is rotated and translated.
 
                 const Point<float> center{-halfAdvance, halfAdvance - Shaping::yOffset};
-                const float verticalRotation = -M_PI_2;
+                const float verticalRotation = static_cast<float>(-M_PI_2);
 
                 // xHalfWidhtOffsetcorrection is a difference between full-width and half-width
                 // advance, should be 0 for full-width glyphs and will pull up half-width glyphs.
-                const float xHalfWidhtOffsetcorrection = util::ONE_EM / 2 - halfAdvance;
+                const float xHalfWidhtOffsetcorrection = util::ONE_EM / 2.f - halfAdvance;
                 const float yImageOffsetCorrection = positionedGlyph.imageID ? xHalfWidhtOffsetcorrection : 0.0f;
                 const Point<float> xOffsetCorrection{5.0f - Shaping::yOffset - xHalfWidhtOffsetcorrection,
                                                      -yImageOffsetCorrection};

--- a/src/mbgl/util/tile_coordinate.hpp
+++ b/src/mbgl/util/tile_coordinate.hpp
@@ -37,10 +37,10 @@ public:
         const double scale = std::pow(2.0, tileID.canonical.z);
         auto zoomed = TileCoordinate { point, 0 }.zoomTo(tileID.canonical.z);
         return {
-            int16_t(util::clamp<int64_t>((zoomed.p.x - tileID.canonical.x - tileID.wrap * scale) * util::EXTENT,
+            int16_t(util::clamp<int64_t>(static_cast<int64_t>(zoomed.p.x - tileID.canonical.x - tileID.wrap * scale) * util::EXTENT,
                         std::numeric_limits<int16_t>::min(),
                         std::numeric_limits<int16_t>::max())),
-            int16_t(util::clamp<int64_t>((zoomed.p.y - tileID.canonical.y) * util::EXTENT,
+            int16_t(util::clamp<int64_t>(static_cast<int64_t>(zoomed.p.y - tileID.canonical.y) * util::EXTENT,
                         std::numeric_limits<int16_t>::min(),
                         std::numeric_limits<int16_t>::max()))
         };

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -1300,7 +1300,7 @@ TEST(Map, PrefetchDeltaOverrideCustomSource) {
     };
 
     auto layer = test.map.getStyle().removeLayer("custom");
-    std::move(test.map.getStyle().removeSource("custom"));
+    test.map.getStyle().removeSource("custom");
     test.map.getStyle().addLayer(std::move(layer));
     test.map.getStyle().addSource(makeCustomSource());
     test.runLoop.run();

--- a/test/map/map_snapshotter.test.cpp
+++ b/test/map/map_snapshotter.test.cpp
@@ -119,7 +119,7 @@ TEST(MapSnapshotter, TEST_REQUIRES_SERVER(runtimeStyling)) {
     observer.didFinishLoadingStyleCallback = [&snapshotter, &runLoop] {
         auto fillLayer = std::make_unique<style::FillLayer>("green_fill", "mapbox");
         fillLayer->setSourceLayer("water");
-        fillLayer->setFillColor(Color(0.25, 0.88, 0.82, 1.0));
+        fillLayer->setFillColor(Color(0.25f, 0.88f, 0.82f, 1.0f));
         snapshotter.getStyle().addLayer(std::move(fillLayer));
         snapshotter.snapshot([&runLoop](std::exception_ptr ptr,
                                         mbgl::PremultipliedImage image,

--- a/test/style/property_expression.test.cpp
+++ b/test/style/property_expression.test.cpp
@@ -45,15 +45,15 @@ auto createOverride(expression::type::Type exprType,
 }
 
 TEST(PropertyExpression, Constant) {
-    EXPECT_EQ(2.0f, evaluate(PropertyValue<float>(2.0), 0));
-    EXPECT_EQ(3.8f, evaluate(PropertyValue<float>(3.8), 0));
-    EXPECT_EQ(22.0f, evaluate(PropertyValue<float>(22.0), 0));
-    EXPECT_EQ(2.0f, evaluate(PropertyValue<float>(2.0), 4));
-    EXPECT_EQ(3.8f, evaluate(PropertyValue<float>(3.8), 4));
-    EXPECT_EQ(22.0f, evaluate(PropertyValue<float>(22.0), 4));
-    EXPECT_EQ(2.0f, evaluate(PropertyValue<float>(2.0), 22));
-    EXPECT_EQ(3.8f, evaluate(PropertyValue<float>(3.8), 22));
-    EXPECT_EQ(22.0f, evaluate(PropertyValue<float>(22.0), 22));
+    EXPECT_EQ(2.0f, evaluate(PropertyValue<float>(2.0f), 0));
+    EXPECT_EQ(3.8f, evaluate(PropertyValue<float>(3.8f), 0));
+    EXPECT_EQ(22.0f, evaluate(PropertyValue<float>(22.0f), 0));
+    EXPECT_EQ(2.0f, evaluate(PropertyValue<float>(2.0f), 4));
+    EXPECT_EQ(3.8f, evaluate(PropertyValue<float>(3.8f), 4));
+    EXPECT_EQ(22.0f, evaluate(PropertyValue<float>(22.0f), 4));
+    EXPECT_EQ(2.0f, evaluate(PropertyValue<float>(2.0f), 22));
+    EXPECT_EQ(3.8f, evaluate(PropertyValue<float>(3.8f), 22));
+    EXPECT_EQ(22.0f, evaluate(PropertyValue<float>(22.0f), 22));
 }
 
 TEST(PropertyExpression, Expression) {

--- a/test/text/get_anchors.test.cpp
+++ b/test/text/get_anchors.test.cpp
@@ -35,7 +35,7 @@ const float overscaling = 1.0f;
 
 TEST(getAnchors, NonContinuedLineShortLabels) {
     const Anchors anchors = getAnchors(
-        nonContinuedLine, bigSpacing, M_PI, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
+        nonContinuedLine, bigSpacing, static_cast<float>(M_PI), textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
     const Anchors expected_anchors = {Anchor(1.0f, 2.0f, 1.570796371f, 1u),
                                       Anchor(1.0f, 5.0f, 1.570796371f, 4u),
                                       Anchor(1.0f, 8.0f, 1.570796371f, 7u)};
@@ -46,7 +46,7 @@ TEST(getAnchors, NonContinuedLineShortLabels) {
 TEST(getAnchors, NonContinuedLineLongLabels) {
     const Anchors anchors = getAnchors(nonContinuedLine,
                                        smallSpacing,
-                                       M_PI,
+                                       static_cast<float>(M_PI),
                                        textLeft,
                                        textRight,
                                        iconLeft,
@@ -63,7 +63,7 @@ TEST(getAnchors, NonContinuedLineLongLabels) {
 
 TEST(getAnchors, ContinuedLineShortLabels) {
     const Anchors anchors = getAnchors(
-        continuedLine, bigSpacing, M_PI, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
+        continuedLine, bigSpacing, static_cast<float>(M_PI), textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
     const Anchors expected_anchors = {Anchor(1.0f, 2.0f, 1.570796371f, 1u),
                                       Anchor(1.0f, 5.0f, 1.570796371f, 4u),
                                       Anchor(1.0f, 8.0f, 1.570796371f, 7u)};
@@ -73,7 +73,7 @@ TEST(getAnchors, ContinuedLineShortLabels) {
 
 TEST(getAnchors, ContinuedLineLongLabels) {
     const Anchors anchors = getAnchors(
-        continuedLine, smallSpacing, M_PI, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
+        continuedLine, smallSpacing, static_cast<float>(M_PI), textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
     const Anchors expected_anchors = {Anchor(1.0f, 1.0f, 1.570796371f, 1u),
                                       Anchor(1.0f, 4.0f, 1.570796371f, 3u),
                                       Anchor(1.0f, 6.0f, 1.570796371f, 6u)};
@@ -83,10 +83,10 @@ TEST(getAnchors, ContinuedLineLongLabels) {
 
 TEST(getAnchors, OverscaledAnchorsInParent) {
     const Anchors anchors = getAnchors(
-        nonContinuedLine, bigSpacing, M_PI, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
+        nonContinuedLine, bigSpacing, static_cast<float>(M_PI), textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
     const Anchors childAnchors = getAnchors(nonContinuedLine,
                                             bigSpacing / 2,
-                                            M_PI,
+                                            static_cast<float>(M_PI),
                                             textLeft,
                                             textRight,
                                             iconLeft,
@@ -102,7 +102,7 @@ TEST(getAnchors, OverscaledAnchorsInParent) {
 TEST(getAnchors, UseMidpointForShortLine) {
     const GeometryCoordinates shortLine = {Point<int16_t>{1, 1}, Point<int16_t>{1, 3}};
     const Anchors anchors = getAnchors(
-        shortLine, smallSpacing, M_PI, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
+        shortLine, smallSpacing, static_cast<float>(M_PI), textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
     const Anchors expected_anchors = {Anchor(1.0f, 2.0f, 1.570796371f, 0u)};
 
     EXPECT_EQ(anchors, expected_anchors);
@@ -111,20 +111,20 @@ TEST(getAnchors, UseMidpointForShortLine) {
 TEST(getAnchors, GetCenterAnchor) {
     const GeometryCoordinates line = {
         Point<int16_t>{1, 1}, Point<int16_t>{1, 3}, Point<int16_t>{3, 6}, Point<int16_t>{4, 7}};
-    const auto anchor = getCenterAnchor(line, M_PI, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale);
+    const auto anchor = getCenterAnchor(line, static_cast<float>(M_PI), textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale);
     EXPECT_TRUE(anchor);
     EXPECT_EQ(*anchor, Anchor(2.0f, 4.0f, .982793748f, 1u));
 }
 
 TEST(getAnchors, GetCenterAnchorOutsideTileBounds) {
     const GeometryCoordinates line = {Point<int16_t>{-10, -10}, Point<int16_t>{5, 5}};
-    const auto anchor = getCenterAnchor(line, M_PI, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale);
+    const auto anchor = getCenterAnchor(line, static_cast<float>(M_PI), textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale);
     EXPECT_TRUE(anchor);
     EXPECT_EQ(*anchor, Anchor(-3.0f, -3.0f, .785398185f, 0u));
 }
 
 TEST(getAnchors, GetCenterAnchorFailMaxAngle) {
     const GeometryCoordinates line = {Point<int16_t>{1, 1}, Point<int16_t>{1, 3}, Point<int16_t>{3, 3}};
-    const auto anchor = getCenterAnchor(line, M_PI / 4, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale);
+    const auto anchor = getCenterAnchor(line, static_cast<float>(M_PI) / 4, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale);
     EXPECT_FALSE(anchor);
 }

--- a/test/text/glyph_manager.test.cpp
+++ b/test/text/glyph_manager.test.cpp
@@ -255,7 +255,7 @@ TEST(GlyphManager, LoadLocalCJKGlyph) {
 
 TEST(GlyphManager, LoadLocalCJKGlyphAfterLoadingRangeFromURL) {
     GlyphManagerTest test;
-    int firstGlyphResponse = false;
+    bool firstGlyphResponse = false;
 
     test.fileSource.glyphsResponse = [&] (const Resource&) {
         firstGlyphResponse = true;

--- a/test/text/quads.test.cpp
+++ b/test/text/quads.test.cpp
@@ -86,13 +86,13 @@ TEST(getIconQuads, style) {
         ASSERT_EQ(quads.size(), 1);
         const auto& quad = quads[0];
 
-        EXPECT_FLOAT_EQ(quad.tl.x, -64.4444427);
+        EXPECT_FLOAT_EQ(quad.tl.x, -64.4444427f);
         EXPECT_FLOAT_EQ(quad.tl.y, 0);
-        EXPECT_FLOAT_EQ(quad.tr.x, 24.4444427);
+        EXPECT_FLOAT_EQ(quad.tr.x, 24.4444427f);
         EXPECT_FLOAT_EQ(quad.tr.y, 0);
-        EXPECT_FLOAT_EQ(quad.bl.x, -64.4444427);
+        EXPECT_FLOAT_EQ(quad.bl.x, -64.4444427f);
         EXPECT_FLOAT_EQ(quad.bl.y, 20);
-        EXPECT_FLOAT_EQ(quad.br.x, 24.4444427);
+        EXPECT_FLOAT_EQ(quad.br.x, 24.4444427f);
         EXPECT_FLOAT_EQ(quad.br.y, 20);
     }
 
@@ -105,13 +105,13 @@ TEST(getIconQuads, style) {
         ASSERT_EQ(quads.size(), 1);
         const auto& quad = quads[0];
 
-        EXPECT_FLOAT_EQ(quad.tl.x, -32.2222214);
+        EXPECT_FLOAT_EQ(quad.tl.x, -32.2222214f);
         EXPECT_FLOAT_EQ(quad.tl.y, -5);
-        EXPECT_FLOAT_EQ(quad.tr.x, 12.2222214);
+        EXPECT_FLOAT_EQ(quad.tr.x, 12.2222214f);
         EXPECT_FLOAT_EQ(quad.tr.y, -5);
-        EXPECT_FLOAT_EQ(quad.bl.x, -32.2222214);
+        EXPECT_FLOAT_EQ(quad.bl.x, -32.2222214f);
         EXPECT_FLOAT_EQ(quad.bl.y, 15);
-        EXPECT_FLOAT_EQ(quad.br.x, 12.2222214);
+        EXPECT_FLOAT_EQ(quad.br.x, 12.2222214f);
         EXPECT_FLOAT_EQ(quad.br.y, 15);
     }
 
@@ -124,13 +124,13 @@ TEST(getIconQuads, style) {
         ASSERT_EQ(quads.size(), 1);
         const auto& quad = quads[0];
 
-        EXPECT_FLOAT_EQ(quad.tl.x, -43.3333321);
+        EXPECT_FLOAT_EQ(quad.tl.x, -43.3333321f);
         EXPECT_FLOAT_EQ(quad.tl.y, -5);
-        EXPECT_FLOAT_EQ(quad.tr.x, 23.3333321);
+        EXPECT_FLOAT_EQ(quad.tr.x, 23.3333321f);
         EXPECT_FLOAT_EQ(quad.tr.y, -5);
-        EXPECT_FLOAT_EQ(quad.bl.x, -43.3333321);
+        EXPECT_FLOAT_EQ(quad.bl.x, -43.3333321f);
         EXPECT_FLOAT_EQ(quad.bl.y, 15);
-        EXPECT_FLOAT_EQ(quad.br.x, 23.3333321);
+        EXPECT_FLOAT_EQ(quad.br.x, 23.3333321f);
         EXPECT_FLOAT_EQ(quad.br.y, 15);
     }
 
@@ -144,13 +144,13 @@ TEST(getIconQuads, style) {
         const auto& quad = quads[0];
 
         EXPECT_FLOAT_EQ(quad.tl.x, -30);
-        EXPECT_FLOAT_EQ(quad.tl.y, -12.2222214);
+        EXPECT_FLOAT_EQ(quad.tl.y, -12.2222214f);
         EXPECT_FLOAT_EQ(quad.tr.x, -10);
-        EXPECT_FLOAT_EQ(quad.tr.y, -12.2222214);
+        EXPECT_FLOAT_EQ(quad.tr.y, -12.2222214f);
         EXPECT_FLOAT_EQ(quad.bl.x, -30);
-        EXPECT_FLOAT_EQ(quad.bl.y, 32.2222214);
+        EXPECT_FLOAT_EQ(quad.bl.y, 32.2222214f);
         EXPECT_FLOAT_EQ(quad.br.x, -10);
-        EXPECT_FLOAT_EQ(quad.br.y, 32.2222214);
+        EXPECT_FLOAT_EQ(quad.br.y, 32.2222214f);
     }
 
     // height x textSize
@@ -164,13 +164,13 @@ TEST(getIconQuads, style) {
         const auto& quad = quads[0];
 
         EXPECT_FLOAT_EQ(quad.tl.x, -20);
-        EXPECT_FLOAT_EQ(quad.tl.y, -6.11111069);
+        EXPECT_FLOAT_EQ(quad.tl.y, -6.11111069f);
         EXPECT_FLOAT_EQ(quad.tr.x, 0);
-        EXPECT_FLOAT_EQ(quad.tr.y, -6.11111069);
+        EXPECT_FLOAT_EQ(quad.tr.y, -6.11111069f);
         EXPECT_FLOAT_EQ(quad.bl.x, -20);
-        EXPECT_FLOAT_EQ(quad.bl.y, 16.1111107);
+        EXPECT_FLOAT_EQ(quad.bl.y, 16.1111107f);
         EXPECT_FLOAT_EQ(quad.br.x, 0);
-        EXPECT_FLOAT_EQ(quad.br.y, 16.1111107);
+        EXPECT_FLOAT_EQ(quad.br.y, 16.1111107f);
     }
 
     // height x textSize + padding
@@ -183,13 +183,13 @@ TEST(getIconQuads, style) {
         const auto& quad = quads[0];
 
         EXPECT_FLOAT_EQ(quad.tl.x, -20);
-        EXPECT_FLOAT_EQ(quad.tl.y, -11.666666);
+        EXPECT_FLOAT_EQ(quad.tl.y, -11.666666f);
         EXPECT_FLOAT_EQ(quad.tr.x, 0);
-        EXPECT_FLOAT_EQ(quad.tr.y, -11.666666);
+        EXPECT_FLOAT_EQ(quad.tr.y, -11.666666f);
         EXPECT_FLOAT_EQ(quad.bl.x, -20);
-        EXPECT_FLOAT_EQ(quad.bl.y, 21.666666);
+        EXPECT_FLOAT_EQ(quad.bl.y, 21.666666f);
         EXPECT_FLOAT_EQ(quad.br.x, 0);
-        EXPECT_FLOAT_EQ(quad.br.y, 21.666666);
+        EXPECT_FLOAT_EQ(quad.br.y, 21.666666f);
     }
 
     // both
@@ -201,14 +201,14 @@ TEST(getIconQuads, style) {
         ASSERT_EQ(quads.size(), 1);
         const auto& quad = quads[0];
 
-        EXPECT_FLOAT_EQ(quad.tl.x, -64.4444427);
-        EXPECT_FLOAT_EQ(quad.tl.y, -12.2222214);
-        EXPECT_FLOAT_EQ(quad.tr.x, 24.4444427);
-        EXPECT_FLOAT_EQ(quad.tr.y, -12.2222214);
-        EXPECT_FLOAT_EQ(quad.bl.x, -64.4444427);
-        EXPECT_FLOAT_EQ(quad.bl.y, 32.2222214);
-        EXPECT_FLOAT_EQ(quad.br.x, 24.4444427);
-        EXPECT_FLOAT_EQ(quad.br.y, 32.2222214);
+        EXPECT_FLOAT_EQ(quad.tl.x, -64.4444427f);
+        EXPECT_FLOAT_EQ(quad.tl.y, -12.2222214f);
+        EXPECT_FLOAT_EQ(quad.tr.x, 24.4444427f);
+        EXPECT_FLOAT_EQ(quad.tr.y, -12.2222214f);
+        EXPECT_FLOAT_EQ(quad.bl.x, -64.4444427f);
+        EXPECT_FLOAT_EQ(quad.bl.y, 32.2222214f);
+        EXPECT_FLOAT_EQ(quad.br.x, 24.4444427f);
+        EXPECT_FLOAT_EQ(quad.br.y, 32.2222214f);
     }
 
     // both x textSize
@@ -220,14 +220,14 @@ TEST(getIconQuads, style) {
         ASSERT_EQ(quads.size(), 1);
         const auto& quad = quads[0];
 
-        EXPECT_FLOAT_EQ(quad.tl.x, -32.2222214);
-        EXPECT_FLOAT_EQ(quad.tl.y, -6.11111069);
-        EXPECT_FLOAT_EQ(quad.tr.x, 12.2222214);
-        EXPECT_FLOAT_EQ(quad.tr.y, -6.11111069);
-        EXPECT_FLOAT_EQ(quad.bl.x, -32.2222214);
-        EXPECT_FLOAT_EQ(quad.bl.y, 16.1111107);
-        EXPECT_FLOAT_EQ(quad.br.x, 12.2222214);
-        EXPECT_FLOAT_EQ(quad.br.y, 16.1111107);
+        EXPECT_FLOAT_EQ(quad.tl.x, -32.2222214f);
+        EXPECT_FLOAT_EQ(quad.tl.y, -6.11111069f);
+        EXPECT_FLOAT_EQ(quad.tr.x, 12.2222214f);
+        EXPECT_FLOAT_EQ(quad.tr.y, -6.11111069f);
+        EXPECT_FLOAT_EQ(quad.bl.x, -32.2222214f);
+        EXPECT_FLOAT_EQ(quad.bl.y, 16.1111107f);
+        EXPECT_FLOAT_EQ(quad.br.x, 12.2222214f);
+        EXPECT_FLOAT_EQ(quad.br.y, 16.1111107f);
     }
 
     // both x textSize + padding
@@ -239,14 +239,14 @@ TEST(getIconQuads, style) {
         ASSERT_EQ(quads.size(), 1);
         const auto& quad = quads[0];
 
-        EXPECT_FLOAT_EQ(quad.tl.x, -43.3333321);
-        EXPECT_FLOAT_EQ(quad.tl.y, -11.666666);
-        EXPECT_FLOAT_EQ(quad.tr.x, 23.3333321);
-        EXPECT_FLOAT_EQ(quad.tr.y, -11.666666);
-        EXPECT_FLOAT_EQ(quad.bl.x, -43.3333321);
-        EXPECT_FLOAT_EQ(quad.bl.y, 21.666666);
-        EXPECT_FLOAT_EQ(quad.br.x, 23.3333321);
-        EXPECT_FLOAT_EQ(quad.br.y, 21.666666);
+        EXPECT_FLOAT_EQ(quad.tl.x, -43.3333321f);
+        EXPECT_FLOAT_EQ(quad.tl.y, -11.666666f);
+        EXPECT_FLOAT_EQ(quad.tr.x, 23.3333321f);
+        EXPECT_FLOAT_EQ(quad.tr.y, -11.666666f);
+        EXPECT_FLOAT_EQ(quad.bl.x, -43.3333321f);
+        EXPECT_FLOAT_EQ(quad.bl.y, 21.666666f);
+        EXPECT_FLOAT_EQ(quad.br.x, 23.3333321f);
+        EXPECT_FLOAT_EQ(quad.br.y, 21.666666f);
     }
 
     // both x textSize + padding t/r/b/l
@@ -260,13 +260,13 @@ TEST(getIconQuads, style) {
         ASSERT_EQ(quads.size(), 1);
         const auto& quad = quads[0];
 
-        EXPECT_FLOAT_EQ(quad.tl.x, -48.3333321);
-        EXPECT_FLOAT_EQ(quad.tl.y, -6.66666603);
-        EXPECT_FLOAT_EQ(quad.tr.x, 18.3333321);
-        EXPECT_FLOAT_EQ(quad.tr.y, -6.66666603);
-        EXPECT_FLOAT_EQ(quad.bl.x, -48.3333321);
-        EXPECT_FLOAT_EQ(quad.bl.y, 26.666666);
-        EXPECT_FLOAT_EQ(quad.br.x, 18.3333321);
-        EXPECT_FLOAT_EQ(quad.br.y, 26.666666);
+        EXPECT_FLOAT_EQ(quad.tl.x, -48.3333321f);
+        EXPECT_FLOAT_EQ(quad.tl.y, -6.66666603f);
+        EXPECT_FLOAT_EQ(quad.tr.x, 18.3333321f);
+        EXPECT_FLOAT_EQ(quad.tr.y, -6.66666603f);
+        EXPECT_FLOAT_EQ(quad.bl.x, -48.3333321f);
+        EXPECT_FLOAT_EQ(quad.bl.y, 26.666666f);
+        EXPECT_FLOAT_EQ(quad.br.x, 18.3333321f);
+        EXPECT_FLOAT_EQ(quad.br.y, 26.666666f);
     }
 }

--- a/test/util/memory.test.cpp
+++ b/test/util/memory.test.cpp
@@ -161,14 +161,14 @@ TEST(Memory, Footprint) {
     std::vector<std::unique_ptr<FrontendAndMap>> maps;
     unsigned runs = 15;
 
-    long vectorInitialRSS = mbgl::test::getCurrentRSS();
+    size_t vectorInitialRSS = mbgl::test::getCurrentRSS();
     for (unsigned i = 0; i < runs; ++i) {
         maps.emplace_back(std::make_unique<FrontendAndMap>(test, "maptiler://maps/streets"));
     }
 
     double vectorFootprint = (mbgl::test::getCurrentRSS() - vectorInitialRSS) / double(runs);
 
-    long rasterInitialRSS = mbgl::test::getCurrentRSS();
+    size_t rasterInitialRSS = mbgl::test::getCurrentRSS();
     for (unsigned i = 0; i < runs; ++i) {
         maps.emplace_back(std::make_unique<FrontendAndMap>(test, "maptiler://maps/hybrid"));
     }


### PR DESCRIPTION
This MR fixes many MSVC compilation warnings, mainly:
 - unnecessary type conversions (mainly `float` -> `double`), adding a few `static_cast`s to help
 - not supporting `not` keyword in preprocessor
 - unused variables

This MR might make the code a tiny bit faster, especially when compiler optimisations are not enabled.

FYI @dpaulat 