### PR TITLE
use hardcoded style url for simple test in StyleBuilderTest.kt

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/StyleBuilderTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/StyleBuilderTest.kt
@@ -20,7 +20,7 @@ class StyleBuilderTest {
 
     @Test
     fun testFromUrl() {
-        val expected = Style.getPredefinedStyle("Streets")
+        val expected = "https://demotiles.maplibre.org/style.json"
         val builder = Style.Builder()
         builder.fromUrl(expected)
         assertEquals(expected, builder.uri)


### PR DESCRIPTION
This test works for me when running the tests for the second time in the same checkout. It never works for me when I only run this specific test file and it failed in all recent android-ci-pull workflows. I assume there is a dependency on some setup code which is not always run, given the exception the tests throws:

```com.mapbox.mapboxsdk.exceptions.MapboxConfigurationException: 
Using MapView requires calling Mapbox.getInstance(Context context, String apiKey) before inflating or creating the view.
	at com.mapbox.mapboxsdk.Mapbox.validateMapbox(Mapbox.java:237)
	at com.mapbox.mapboxsdk.Mapbox.getPredefinedStyle(Mapbox.java:173)
	at com.mapbox.mapboxsdk.maps.Style.getPredefinedStyle(Style.java:1426)
	at com.mapbox.mapboxsdk.maps.StyleBuilderTest.testFromUrl(StyleBuilderTest.kt:23)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.robolectric.RobolectricTestRunner$HelperTestRunner$1.evaluate(RobolectricTestRunner.java:546)
	at org.robolectric.internal.SandboxTestRunner$2.lambda$evaluate$0(SandboxTestRunner.java:252)
	at org.robolectric.internal.bytecode.Sandbox.lambda$runOnMainThread$0(Sandbox.java:89)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

As the tested functionality is very simple and no actual web requests are ever made, I opted to just hardcode the used url for this test to "https://demotiles.maplibre.org/style.json" and completely get rid of this dependency. This should hopefully fix the failing android-ci-pull workflows in the other pull requests.