### PR TITLE
MGLNetworkConfiguration.sessionDelegate

### DIFF
--- a/platform/darwin/include/mbgl/interface/native_apple_interface.h
+++ b/platform/darwin/include/mbgl/interface/native_apple_interface.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSURLSessionConfiguration *)sessionConfiguration;
 
+- (id<NSURLSessionDelegate>)sessionDelegate;
+
 - (void)startDownloadEvent:(NSString *)event type:(NSString *)type;
 
 - (void)cancelDownloadEventForResponse:(NSURLResponse *)response;
@@ -35,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) id<MGLNativeNetworkDelegate> delegate;
 
 @property (nonatomic, readonly) NSURLSessionConfiguration *sessionConfiguration;
+
+@property (nonatomic, readonly) id<NSURLSessionDelegate> sessionDelegate;
 
 - (void)startDownloadEvent:(NSString *)event type:(NSString *)type;
 

--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -86,7 +86,13 @@ public:
     Impl(const ResourceOptions& options): resourceOptions(options.clone()) {
         @autoreleasepool {
             NSURLSessionConfiguration *sessionConfig = MGLNativeNetworkManager.sharedManager.sessionConfiguration;
-            session = [NSURLSession sessionWithConfiguration:sessionConfig];
+            id<NSURLSessionDelegate> sessionDelegate = MGLNativeNetworkManager.sharedManager.sessionDelegate;
+            
+            if (sessionDelegate) {
+                session = [NSURLSession sessionWithConfiguration:sessionConfig delegate:sessionDelegate delegateQueue:nil];
+            } else {
+                session = [NSURLSession sessionWithConfiguration:sessionConfig];
+            }
 
             userAgent = getUserAgent();
         }

--- a/platform/darwin/src/native_apple_interface.m
+++ b/platform/darwin/src/native_apple_interface.m
@@ -40,6 +40,10 @@ static MGLNativeNetworkManager *instance = nil;
     return configuration;
 }
 
+- (id<NSURLSessionDelegate>)sessionDelegate {
+    return self.delegate.sessionDelegate;
+}
+
 - (void)startDownloadEvent:(NSString *)event type:(NSString *)type {
     [self.delegate startDownloadEvent:event type:type];
 }

--- a/platform/ios/platform/darwin/src/MGLNetworkConfiguration.h
+++ b/platform/ios/platform/darwin/src/MGLNetworkConfiguration.h
@@ -63,6 +63,15 @@ MGL_EXPORT
  */
 @property (atomic, strong, null_resettable) NSURLSessionConfiguration *sessionConfiguration;
 
+/**
+ The session delegate that is used by the `NSURLSession` objects
+ in this SDK.
+ 
+ Assign this object before instantiating any `MGLMapView` object, or using
+ `MGLOfflineStorage`.
+ */
+@property (atomic, strong, null_resettable) id<NSURLSessionDelegate> sessionDelegate;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/ios/platform/darwin/src/MGLNetworkConfiguration.mm
+++ b/platform/ios/platform/darwin/src/MGLNetworkConfiguration.mm
@@ -21,11 +21,13 @@ NSString * const kMGLDownloadPerformanceEvent = @"mobile.performance_trace";
 @implementation MGLNetworkConfiguration
 {
     NSURLSessionConfiguration *_sessionConfig;
+    id<NSURLSessionDelegate> _sessionDelegate;
 }
 
 - (instancetype)init {
     if (self = [super init]) {
         self.sessionConfiguration = nil;
+        self.sessionDelegate = nil;
         _events = [NSMutableDictionary dictionary];
         _eventsQueue = dispatch_queue_create("com.mapbox.network-configuration", DISPATCH_QUEUE_CONCURRENT);
     }
@@ -102,6 +104,20 @@ NSString * const kMGLDownloadPerformanceEvent = @"mobile.performance_trace";
         } else {
             _sessionConfig = sessionConfiguration;
         }
+    }
+}
+
+- (id<NSURLSessionDelegate>)sessionDelegate {
+    id<NSURLSessionDelegate> sessionDelegate = nil;
+    @synchronized (self) {
+        sessionDelegate = _sessionDelegate;
+    }
+    return sessionDelegate;
+}
+
+- (void)setSessionDelegate:(id<NSURLSessionDelegate>)sessionDelegate {
+    @synchronized (self) {
+        _sessionDelegate = sessionDelegate;
     }
 }
 


### PR DESCRIPTION
Add MGLNetworkConfiguration.sessionDelegate to configure a custom NSURLSessionDelegate.

Closes #156 