### PR TITLE
mapbox -> maplibre, fix broken links

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-Each Mapbox GL Native SDK has a separate changelog that highlights changes relevant to their respective platforms:
+Each MapLibre GL Native SDK has a separate changelog that highlights changes relevant to their respective platforms:
 
-* [Mapbox Maps SDK for Android](platform/android/CHANGELOG.md)
-* [Mapbox Maps SDK for iOS](platform/ios/CHANGELOG.md)
-* [Mapbox Maps SDK for macOS](platform/macos/CHANGELOG.md)
-* [node-mapbox-gl-native](platform/node/CHANGELOG.md)
+* [MapLibre Maps SDK for Android](../../platform/android/CHANGELOG.md)
+* [MapLibre Maps SDK for iOS](platform/ios/CHANGELOG.md)
+* [MapLibre Maps SDK for macOS](platform/macos/CHANGELOG.md)
+* [node-maplibre-gl-native](../../platform/node/CHANGELOG.md)


### PR DESCRIPTION
I assume that such rename is desired and should be applied, but link targets still carry Mapbox name

BTW, links were broken and I fixed them