### PR TITLE
[ci] Refresh Ubuntu repositories to avoid stale states

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -62,6 +62,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          sudo apt-get update
           sudo apt-get install -y \
             ccache \
             cmake \


### PR DESCRIPTION
Refresh Ubuntu repositories to avoid stale states. This should hopefully fix failing Node CI. If yes, it should be merged ASAP.

FYI @jutaz 