### PR TITLE
[ios] patch to fix MGLReachability.m compiler error

### DIFF
--- a/platform/ios/platform/darwin/src/MGLReachability.m
+++ b/platform/ios/platform/darwin/src/MGLReachability.m
@@ -466,9 +466,8 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 - (NSString *) description
 {
     NSString *description = [
-        NSString stringWithFormat:@"<%@: %#x (%@)>",
+        NSString stringWithFormat:@"<%@: (%@)>",
         NSStringFromClass([self class]),
-        (unsigned int) self,
         [self currentReachabilityFlags]
     ];
     return description;


### PR DESCRIPTION
Fixes `Cast to smaller integer type 'unsigned int' from 'MGLReachability *'` compiler error in `darwin/src/MGLReachability.m` existing on `metal-support` branch.