### PR TITLE
chore: rename master -> main in CI and build scripts

### DIFF
--- a/.github/workflows/android-ci-pull.yml
+++ b/.github/workflows/android-ci-pull.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - "platform/ios/**"
       - "platform/qt/**"

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -13,7 +13,7 @@ on:
       - ".gitignore"
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - "platform/android/**"
       - "platform/qt/**"

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -12,10 +12,10 @@ on:
       - "README.md"
       - ".gitignore"
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - "platform/android/**"
       - "platform/qt/**"

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -11,10 +11,10 @@ on:
       - "platform/qt/**"
       - ".gitignore"
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - "platform/android/**"
       - "platform/ios/**"
@@ -31,7 +31,7 @@ jobs:
           - ubuntu-18.04
     runs-on: ${{ matrix.os }}
     env:
-      BUILDTYPE: ${{github.ref == 'refs/heads/master' && 'Release' || 'Debug'}}
+      BUILDTYPE: ${{github.ref == 'refs/heads/main' && 'Release' || 'Debug'}}
 
     defaults:
       run:
@@ -127,13 +127,13 @@ jobs:
 
       # On PRs make sure that the npm package can be packaged.
       - name: Pack
-        if: github.ref != 'refs/heads/master'
+        if: github.ref != 'refs/heads/main'
         run: |
           npm pack --dry-run
 
       # Uncomment to start publishing the package
       # @TODO: Figure out the binary distribution method.
       # - name: Publish package
-      #   if: github.ref == 'refs/heads/master'
+      #   if: github.ref == 'refs/heads/main'
       #   run: |
       #     npm publish

--- a/.github/workflows/qt-ci-windows.yml
+++ b/.github/workflows/qt-ci-windows.yml
@@ -15,7 +15,7 @@ on:
       - ".gitignore"
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - "platform/android/**"
       - "platform/darwin/**"

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -14,7 +14,7 @@ on:
       - ".gitignore"
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - "platform/android/**"
       - "platform/darwin/**"

--- a/platform/android/Makefile
+++ b/platform/android/Makefile
@@ -1,6 +1,6 @@
 export BUILDTYPE ?= Debug
 export IS_LOCAL_DEVELOPMENT ?= true
-export TARGET_BRANCH ?= master
+export TARGET_BRANCH ?= main
 
 CMAKE ?= cmake
 

--- a/platform/android/scripts/metrics.sh
+++ b/platform/android/scripts/metrics.sh
@@ -12,7 +12,7 @@ scripts/check_binary_size.js "MapboxGLAndroidSDK/build/intermediates/intermediat
 # Track overall library size
 scripts/check_binary_size.js "MapboxGLAndroidSDK/build/outputs/aar/MapboxGLAndroidSDK-release.aar" "Android AAR"
 
-if [[ $CIRCLE_BRANCH == master ]]; then
+if [[ $CIRCLE_BRANCH == main ]]; then
   # Build source data for http://mapbox.github.io/mapbox-gl-native/metrics/binary-size/
   # and log binary sizes to metrics warehouse
   scripts/publish_binary_size.js

--- a/platform/android/scripts/release-notes.js
+++ b/platform/android/scripts/release-notes.js
@@ -54,7 +54,7 @@ const bestReleaseNotesForCurrentVersion = semver.minSatisfying(versionsInRelease
 const currentReleaseNotes = _.find(releaseNotes, { version: bestReleaseNotesForCurrentVersion });
 
 if (!currentReleaseNotes) {
-    console.error('Could not find a release section satisfying %s in %s — did you forget to rename the "master" section to %s?', currentVersion, changelogPath, currentVersion.split("-")[0]);
+    console.error('Could not find a release section satisfying %s in %s — did you forget to rename the "main" section to %s?', currentVersion, changelogPath, currentVersion.split("-")[0]);
     process.exit(1);
 }
 

--- a/platform/android/scripts/release.py
+++ b/platform/android/scripts/release.py
@@ -3,31 +3,31 @@ Utility to schedule SDK builds on CircleCI.
 
 Examples:
 
-- Publish a snapshot from master (release.py uses the current branch)
+- Publish a snapshot from main (release.py uses the current branch)
 
 	$ git branch
-	* master
+	* main
 	  1234-fix-crash
 	$ python release.py --stage snapshot
 
 - Publish a snapshot from a feature branch (same as before, just switch branchs with git):
 
 	$ git branch
-	  master
+	  main
 	* 1234-fix-crash
 	$ python release.py --stage snapshot
 
 - Publish a beta from a pre-release branch:
 
 	$ git branch
-	  master
+	  main
 	* release-android-420-beta1
 	$ python release.py --stage beta --version 4.2.0-beta.1
 
 - Publish a beta from a release branch:
 
 	$ git branch
-	  master
+	  main
 	* release-android-420
 	$ python release.py --stage final --version 4.2.0
 
@@ -97,13 +97,13 @@ def validate_branch(stage):
 	branch = git_get_current_branch()
 	if not branch:
 		abort_with_message('The current folder is not a git repository.')
-	if branch == 'master' and stage != 'snapshot':
+	if branch == 'main' and stage != 'snapshot':
 		abort_with_message('You need to swtich to a release branch for a beta or a final release.')
 	return branch
 
 def validate_version(stage, branch, version):
-	if stage == 'snapshot' and branch == 'master' and version != CURRENT_VERSION_TAG:
-		abort_with_message('You cannot specify a custom version if you are building a snapshot from master.')
+	if stage == 'snapshot' and branch == 'main' and version != CURRENT_VERSION_TAG:
+		abort_with_message('You cannot specify a custom version if you are building a snapshot from main.')
 
 	if not version or version == CURRENT_VERSION_TAG:
 		version = get_current_version(file_path=GRADLE_PROPERTIES_PATH, file_var=GRADLE_TOKEN)
@@ -122,7 +122,7 @@ def validate_version(stage, branch, version):
 
 def publish_snapshot(branch, version):
 	click.echo('Publishing snapshot for branch: %s (version: %s).' % (branch, version))
-	if branch != 'master':
+	if branch != 'main':
 		dirty_gradle = update_current_version(file_path=GRADLE_PROPERTIES_PATH, file_var=GRADLE_TOKEN, version=version)
 		if dirty_gradle:
 			git_add(path=GRADLE_PROPERTIES_PATH)

--- a/platform/ios/Makefile
+++ b/platform/ios/Makefile
@@ -1,6 +1,6 @@
 export BUILDTYPE ?= Debug
 export IS_LOCAL_DEVELOPMENT ?= true
-export TARGET_BRANCH ?= master
+export TARGET_BRANCH ?= main
 export CI ?= 0
 
 CMAKE ?= cmake

--- a/platform/ios/platform/ios/scripts/metrics.sh
+++ b/platform/ios/platform/ios/scripts/metrics.sh
@@ -18,7 +18,7 @@ scripts/check_binary_size.js "build/ios/pkg/dynamic/Mapbox-stripped-x86_64"  "iO
 # Track overall library size
 scripts/check_binary_size.js "build/ios/pkg/dynamic/Mapbox-stripped"         "iOS Dynamic"
 
-if [[ $CIRCLE_BRANCH == master ]]; then
+if [[ $CIRCLE_BRANCH == main ]]; then
   # Build source data for http://mapbox.github.io/mapbox-gl-native/metrics/binary-size/
   # and log binary sizes to metrics warehouse
   scripts/publish_binary_size.js

--- a/platform/ios/platform/ios/scripts/release-notes.js
+++ b/platform/ios/platform/ios/scripts/release-notes.js
@@ -63,7 +63,7 @@ const bestReleaseNotesForCurrentVersion = semver.minSatisfying(versionsInRelease
 const currentReleaseNotes = _.find(releaseNotes, { version: bestReleaseNotesForCurrentVersion });
 
 if (!currentReleaseNotes) {
-    console.error('Could not find a release section satisfying %s in %s — did you forget to rename the "master" section to %s?', currentVersion, changelogPath, currentVersion.split("-")[0]);
+    console.error('Could not find a release section satisfying %s in %s — did you forget to rename the "main" section to %s?', currentVersion, changelogPath, currentVersion.split("-")[0]);
     process.exit(1);
 }
 

--- a/platform/ios/platform/macos/CHANGELOG.md
+++ b/platform/ios/platform/macos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Mapbox Maps SDK for macOS
 
-MapLibre welcomes participation and contributions from everyone. Please read [`Contributing Guide`](https://github.com/maplibre/maplibre-gl-native/blob/master/CONTRIBUTING.md) to get started.
+MapLibre welcomes participation and contributions from everyone. Please read [`Contributing Guide`](https://github.com/maplibre/maplibre-gl-native/blob/main/CONTRIBUTING.md) to get started.
 
 ## 0.19.1 - September 06, 2021
 

--- a/platform/ios/platform/macos/scripts/release-notes.js
+++ b/platform/ios/platform/macos/scripts/release-notes.js
@@ -63,7 +63,7 @@ const bestReleaseNotesForCurrentVersion = semver.minSatisfying(versionsInRelease
 const currentReleaseNotes = _.find(releaseNotes, { version: bestReleaseNotesForCurrentVersion });
 
 if (!currentReleaseNotes) {
-    console.error('Could not find a release section satisfying %s in %s — did you forget to rename the "master" section to %s?', currentVersion, changelogPath, currentVersion.split("-")[0]);
+    console.error('Could not find a release section satisfying %s in %s — did you forget to rename the "main" section to %s?', currentVersion, changelogPath, currentVersion.split("-")[0]);
     process.exit(1);
 }
 

--- a/platform/ios/scripts/environment.js
+++ b/platform/ios/scripts/environment.js
@@ -24,7 +24,7 @@ if (pr) {
 } else {
     const head = process.env['GITHUB_SHA'];
     for (const sha of execSync(`git rev-list --max-count=500 ${head}`).toString().trim().split('\n')) {
-        const base = execSync(`git branch -r --contains ${sha} origin/master origin/release-*`).toString().split('\n')[0].trim().replace(/^origin\//, '');
+        const base = execSync(`git branch -r --contains ${sha} origin/main origin/release-*`).toString().split('\n')[0].trim().replace(/^origin\//, '');
         if (base) {
             const mergeBase = execSync(`git merge-base origin/${base} ${head}`).toString().trim();
             console.log(`export GITHUB_TARGET_BRANCH=${base}`);

--- a/platform/ios/scripts/nitpick/submodule-pin.js
+++ b/platform/ios/scripts/nitpick/submodule-pin.js
@@ -6,8 +6,8 @@ const child_process = require('child_process');
 const head = child_process.execSync('git -C maplibre-gl-js rev-parse HEAD').toString().trim();
 const revs = child_process.execSync(`git -C maplibre-gl-js branch -a --contains ${head}`).toString().split('\n');
 
-if (revs.indexOf('  remotes/origin/master') >= 0) {
-    nitpick.ok(`maplibre-gl-js submodule pin is merged to master`);
+if (revs.indexOf('  remotes/origin/main') >= 0) {
+    nitpick.ok(`maplibre-gl-js submodule pin is merged to main`);
 } else {
-    nitpick.fail(`maplibre-gl-js submodule is pinned to ${head}, which isn't merged to master`);
+    nitpick.fail(`maplibre-gl-js submodule is pinned to ${head}, which isn't merged to main`);
 }

--- a/platform/ios/scripts/publish_binary_size.js
+++ b/platform/ios/scripts/publish_binary_size.js
@@ -56,7 +56,7 @@ function query(after) {
         },
         query: `query {
               repository(owner: "mapbox", name: "mapbox-gl-native") {
-                ref(qualifiedName: "master") {
+                ref(qualifiedName: "main") {
                   target {
                     ... on Commit {
                       history(first: 100, before: "36c6a8ea79bbd2596abb58ffb58debf65a4ea13d" ${after ? `, after: "${after}"` : ''}) {

--- a/platform/ios/scripts/publish_doxygen_coverage.js
+++ b/platform/ios/scripts/publish_doxygen_coverage.js
@@ -67,7 +67,7 @@ github.apps.createInstallationToken({installation_id: SIZE_CHECK_APP_INSTALLATIO
             }
         })];
 
-        if (process.env['CIRCLE_BRANCH'] === 'master') {
+        if (process.env['CIRCLE_BRANCH'] === 'main') {
             promises.push(new AWS.S3({region: 'us-east-1'}).putObject({
                 Body: zlib.gzipSync(JSON.stringify({
                     'created_at': date,

--- a/platform/ios/scripts/update-boost.sh
+++ b/platform/ios/scripts/update-boost.sh
@@ -23,7 +23,7 @@ popd
 
 echo "If everything works, run:"
 echo ""
-echo "    git -C vendor/boost checkout master"
+echo "    git -C vendor/boost checkout main"
 echo "    git -C vendor/boost commit -m \"update boost to ${VERSION/_/.}\""
 echo "    git -C vendor/boost push"
 echo "    git add vendor/boost"

--- a/platform/linux/scripts/after_success.sh
+++ b/platform/linux/scripts/after_success.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-if [ "${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}" = "master" ] && [ "${BUILDTYPE}" = "Release" ]; then
+if [ "${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}" = "main" ] && [ "${BUILDTYPE}" = "Release" ]; then
     CLOUDWATCH=true platform/linux/scripts/metrics.sh
 else
     echo "Not logging binary size for branch or Debug build"

--- a/platform/node/DEVELOPING.md
+++ b/platform/node/DEVELOPING.md
@@ -90,7 +90,7 @@ npm test
 
 ## Merging your pull request
 
-To clean up your pull request and prepare it for merging, update your local `master` branch, then run `git rebase -i master` from your pull request branch to squash/fixup commits as needed. When your work is ready to be merged, you can run `git merge --ff-only YOUR_BRANCH` from `master` or click the green merge button in the GitHub UI, which will automatically squash your branch down into a single commit before merging it.
+To clean up your pull request and prepare it for merging, update your local `main` branch, then run `git rebase -i main` from your pull request branch to squash/fixup commits as needed. When your work is ready to be merged, you can run `git merge --ff-only YOUR_BRANCH` from `main` or click the green merge button in the GitHub UI, which will automatically squash your branch down into a single commit before merging it.
 
 ## Publishing
 
@@ -112,4 +112,4 @@ If everything looks good:
 
 ### Preleases
 
-Publishing a prerelease binary can be useful for testing downstream integrations - the workflow is pretty much the same except that you'll be making your version number commit and `git tag node-v{VERSION}` (like `git tag node-v3.3.2-pre.1`) on a pull request branch before merging it rather than on `master`.
+Publishing a prerelease binary can be useful for testing downstream integrations - the workflow is pretty much the same except that you'll be making your version number commit and `git tag node-v{VERSION}` (like `git tag node-v3.3.2-pre.1`) on a pull request branch before merging it rather than on `main`.

--- a/platform/node/README.md
+++ b/platform/node/README.md
@@ -109,7 +109,7 @@ The `request()` method handles a request for a resource. The `ratio` sets the sc
 }
 ```
 
-The `kind` is an enum and defined in [`mbgl.Resource`](https://github.com/maplibre/maplibre-gl-native/blob/master/include/mbgl/storage/resource.hpp):
+The `kind` is an enum and defined in [`mbgl.Resource`](https://github.com/maplibre/maplibre-gl-native/blob/main/include/mbgl/storage/resource.hpp):
 
 ```json
 {

--- a/scripts/environment.js
+++ b/scripts/environment.js
@@ -24,7 +24,7 @@ if (pr) {
 } else {
     const head = process.env['CIRCLE_SHA1'];
     for (const sha of execSync(`git rev-list --max-count=500 ${head}`).toString().trim().split('\n')) {
-        const base = execSync(`git branch -r --contains ${sha} origin/master origin/release-*`).toString().split('\n')[0].trim().replace(/^origin\//, '');
+        const base = execSync(`git branch -r --contains ${sha} origin/main origin/release-*`).toString().split('\n')[0].trim().replace(/^origin\//, '');
         if (base) {
             const mergeBase = execSync(`git merge-base origin/${base} ${head}`).toString().trim();
             console.log(`export CIRCLE_TARGET_BRANCH=${base}`);

--- a/scripts/nitpick/submodule-pin.js
+++ b/scripts/nitpick/submodule-pin.js
@@ -6,8 +6,8 @@ const child_process = require('child_process');
 const head = child_process.execSync('git -C maplibre-gl-js rev-parse HEAD').toString().trim();
 const revs = child_process.execSync(`git -C maplibre-gl-js branch -a --contains ${head}`).toString().split('\n');
 
-if (revs.indexOf('  remotes/origin/master') >= 0) {
-    nitpick.ok(`maplibre-gl-js submodule pin is merged to master`);
+if (revs.indexOf('  remotes/origin/main') >= 0) {
+    nitpick.ok(`maplibre-gl-js submodule pin is merged to main`);
 } else {
-    nitpick.fail(`maplibre-gl-js submodule is pinned to ${head}, which isn't merged to master`);
+    nitpick.fail(`maplibre-gl-js submodule is pinned to ${head}, which isn't merged to main`);
 }

--- a/scripts/publish_binary_size.js
+++ b/scripts/publish_binary_size.js
@@ -56,7 +56,7 @@ function query(after) {
         },
         query: `query {
               repository(owner: "mapbox", name: "mapbox-gl-native") {
-                ref(qualifiedName: "master") {
+                ref(qualifiedName: "main") {
                   target {
                     ... on Commit {
                       history(first: 100, before: "36c6a8ea79bbd2596abb58ffb58debf65a4ea13d" ${after ? `, after: "${after}"` : ''}) {

--- a/scripts/publish_doxygen_coverage.js
+++ b/scripts/publish_doxygen_coverage.js
@@ -67,7 +67,7 @@ github.apps.createInstallationToken({installation_id: SIZE_CHECK_APP_INSTALLATIO
             }
         })];
 
-        if (process.env['CIRCLE_BRANCH'] === 'master') {
+        if (process.env['CIRCLE_BRANCH'] === 'main') {
             promises.push(new AWS.S3({region: 'us-east-1'}).putObject({
                 Body: zlib.gzipSync(JSON.stringify({
                     'created_at': date,

--- a/scripts/update-boost.sh
+++ b/scripts/update-boost.sh
@@ -23,7 +23,7 @@ popd
 
 echo "If everything works, run:"
 echo ""
-echo "    git -C vendor/boost checkout master"
+echo "    git -C vendor/boost checkout main"
 echo "    git -C vendor/boost commit -m \"update boost to ${VERSION/_/.}\""
 echo "    git -C vendor/boost push"
 echo "    git add vendor/boost"


### PR DESCRIPTION
Issue:
https://github.com/maplibre/maplibre/issues/11

Changes:
This PR makes a best effort to change all CI and related build scripts from using `master` to `main`.

Explicitly excluded from changes:
- `**/vendor`
- Any  `**/mapbox/**` links. While the majority of these could be renamed already, it would make more sense to handle these changes while updating the links to point at `maplibre`.
- Any occurrences of `master` in links to third party licenses.
- Any occurrences of `master` in functional code.

Once this is merged, we can take the remaining steps listed in the linked issue to complete the rename.