### PR TITLE
Avoid using deprecated std::result_of

### DIFF
--- a/include/mbgl/actor/actor_ref.hpp
+++ b/include/mbgl/actor/actor_ref.hpp
@@ -38,7 +38,7 @@ public:
     template <typename Fn, class... Args>
     auto ask(Fn fn, Args&&... args) const {
         // Result type is deduced from the function's return type
-        using ResultType = typename std::result_of<decltype(fn)(Object, Args...)>::type;
+        using ResultType = typename std::invoke_result<decltype(fn), Object, Args...>::type;
 
         std::promise<ResultType> promise;
         auto future = promise.get_future();


### PR DESCRIPTION
Avoid using deprecated `std::result_of`. Use `std::invoke_result` instead.

This fixes building with new compilers as we moved to C++17.