### PR TITLE
Fix logging format strings

### DIFF
--- a/platform/darwin/src/native_apple_interface.m
+++ b/platform/darwin/src/native_apple_interface.m
@@ -53,13 +53,21 @@ static MGLNativeNetworkManager *instance = nil;
 }
 
 - (void)debugLog:(NSString *)format, ... {
-    // TODO: Replace with existing mbgl logging handling.
-    [self.delegate debugLog:format];
+    va_list formatList;
+    va_start(formatList, format);
+    NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:formatList];
+    va_end(formatList);
+
+    [self.delegate debugLog:formattedMessage];
 }
 
 - (void)errorLog:(NSString *)format, ... {
-    // TODO: Replace with existing mbgl logging handling.
-    [self.delegate errorLog:format];
+    va_list formatList;
+    va_start(formatList, format);
+    NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:formatList];
+    va_end(formatList);
+
+    [self.delegate errorLog:formattedMessage];
 }
 
 @end

--- a/platform/ios/platform/darwin/src/MGLNetworkConfiguration.mm
+++ b/platform/ios/platform/darwin/src/MGLNetworkConfiguration.mm
@@ -122,11 +122,21 @@ NSString * const kMGLDownloadPerformanceEvent = @"mobile.performance_trace";
 }
 
 - (void)debugLog:(NSString *)format, ... {
-    MGLLogDebug(format);
+    va_list formatList;
+    va_start(formatList, format);
+    NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:formatList];
+    va_end(formatList);
+
+    MGLLogDebug(formattedMessage);
 }
 
 - (void)errorLog:(NSString *)format, ... {
-    MGLLogError(format);
+    va_list formatList;
+    va_start(formatList, format);
+    NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:formatList];
+    va_end(formatList);
+
+    MGLLogError(formattedMessage);
 }
 
 #pragma mark - Event management


### PR DESCRIPTION
Setting up MGLLogger I noticed that some Log messages contained format strings like "Network error error: @"

I ended up realizing that some of the Log messages in the app are not actually formatted. This change makes it so the strings are now formatted.

Previously: Requesting: Requesting: %@ failed with error: %@ failed with error: <MGLNetworkConfiguration: 0x600001820b40>

Now: Requesting: (null) failed with error: Error Domain=NSURLErrorDomain Code=-1009 \"The Internet connection appears to be offline.\" UserInfo={_kCFStreamErrorCodeKey=50, NSUnderlyingError=0x600003c44420 {Error Domain=kCFErrorDomainCFNetwork Code=-1009 \"(null)\" UserInfo={_NSURLErrorNWPathKey=unsatisfied (No network route), _kCFStreamErrorCodeKey=50, _kCFStreamErrorDomainKey=1}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <EC18DF77-C421-456D-AA08-C1A1EDD9A2F3>.<78>, _NSURLErrorRelatedURLSessionTaskErrorKey=(\n \"LocalDataTask <EC18DF77-C421-456D-AA08-C1A1EDD9A2F3>.<78>\"\n), NSLocalizedDescription=The Internet connection appears to be offline., NSErrorFailingURLStringKey=https://d34hkqyc0uusyp.cloudfront.net/tiles/1:1.0.0:qxcrxz/11/323/803.pbf, NSErrorFailingURLKey=https://d34hkqyc0uusyp.cloudfront.net/tiles/1:1.0.0:qxcrxz/11/323/803.pbf, _kCFStreamErrorDomainKey=1}