### PR TITLE
Fix street label appearance while animating near zoom level threshhold

### DIFF
--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -16,6 +16,17 @@ LatLng latLngFromMercator(Point<double> mercatorCoordinate, LatLng::WrapMode wra
             mercatorCoordinate.x * 360.0 - 180.0,
             wrapMode};
 }
+const double kEpsilon = 1e-9;
+// To avoid flickering issue due to "zoom = 13.9999999..".
+double roundForAccuracy(double x) {
+    double round_x = round(x);
+    double diff = fabs(round_x - x);
+    if (diff < kEpsilon && diff > 0 ){
+        return round_x;
+    } else {
+        return x;
+    }
+}
 } // namespace
 
 TransformState::TransformState(ConstrainMode constrainMode_, ViewportMode viewportMode_)
@@ -639,11 +650,11 @@ bool TransformState::isGestureInProgress() const {
 #pragma mark - Projection
 
 double TransformState::zoomScale(double zoom) const {
-    return std::pow(2.0, zoom);
+    return roundForAccuracy(std::pow(2.0, zoom));
 }
 
 double TransformState::scaleZoom(double s) const {
-    return util::log2(s);
+    return roundForAccuracy(util::log2(s));
 }
 
 ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng) const {

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -16,11 +16,11 @@ LatLng latLngFromMercator(Point<double> mercatorCoordinate, LatLng::WrapMode wra
             mercatorCoordinate.x * 360.0 - 180.0,
             wrapMode};
 }
-const double kEpsilon = 1e-9;
+constexpr double kEpsilon = 1e-9;
 // To avoid flickering issue due to "zoom = 13.9999999..".
 double roundForAccuracy(double x) {
-    double round_x = round(x);
-    double diff = fabs(round_x - x);
+    double round_x = std::round(x);
+    double diff = std::abs(round_x - x);
     if (diff < kEpsilon && diff > 0 ){
         return round_x;
     } else {


### PR DESCRIPTION
We were seeing some issues while following the users location along a route in the map view that some screen elements (for the most part the labels of street names on the map) would flash in and out.

While it took a long time to determine why this was happening we determined that the issue was simple. We were animating the map camera at a specific zoom level (zoom levels are from 1-25 floats) and the map SDK was sometimes finding us at zoom level 10.0 and sometimes finding us at zoom level 9.9999

This would generally not be a problem except at that particular zoom level we had our map style show the street labels on the map. So when we were at 9.9999 it would hide them, and on the next frame it would have us at 10.0.
The ultimate fix was fairly simple and the zoom level is basically rounded if it is close enough to a rounded zoom level.

This is the issue that was previously reporting this: https://github.com/maplibre/maplibre-gl-native/issues/137