### PR TITLE
[msvc] Fix warnings, mainly casting to smaller types

### DIFF
--- a/expression-test/expression_test_parser.cpp
+++ b/expression-test/expression_test_parser.cpp
@@ -470,7 +470,7 @@ Value toValue(const Compiled& compiled) {
 optional<Value> toValue(const expression::Value& exprValue) {
     return exprValue.match(
         [](const Color& c) -> optional<Value> {
-            std::vector<Value> color { double(c.r), double(c.g), double(c.b), double(c.a) };
+            std::vector<Value> color { static_cast<double>(c.r), static_cast<double>(c.g), static_cast<double>(c.b), static_cast<double>(c.a) };
             return {Value{std::move(color)}};
         },
         [](const expression::Formatted& formatted) -> optional<Value> { return {formatted.toObject()}; },

--- a/include/mbgl/style/expression/distance.hpp
+++ b/include/mbgl/style/expression/distance.hpp
@@ -1,6 +1,17 @@
 #pragma once
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4244)
+#pragma warning(disable: 4267)
+#endif
+
 #include <mapbox/cheap_ruler.hpp>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #include <mbgl/style/expression/expression.hpp>
 #include <mbgl/util/geojson.hpp>
 

--- a/include/mbgl/style/position.hpp
+++ b/include/mbgl/style/position.hpp
@@ -52,8 +52,8 @@ private:
     void calculateCartesian() {
         // We abstract "north"/"up" (compass-wise) to be 0° when really this is 90° (π/2): we
         // correct for that here
-        const float _a = (azimuthal + 90) * util::DEG2RAD;
-        const float _p = polar * util::DEG2RAD;
+        const float _a = (azimuthal + 90) * util::DEG2RAD_F;
+        const float _p = polar * util::DEG2RAD_F;
 
         x = radial * std::cos(_a) * std::sin(_p);
         y = radial * std::sin(_a) * std::sin(_p);

--- a/include/mbgl/style/sources/custom_geometry_source.hpp
+++ b/include/mbgl/style/sources/custom_geometry_source.hpp
@@ -24,7 +24,7 @@ class CustomGeometrySource final : public Source {
 public:
     struct TileOptions {
         double tolerance = 0.375;
-        uint16_t tileSize = util::tileSize;
+        uint16_t tileSize = util::tileSize_I;
         uint16_t buffer = 128;
         bool clip = false;
         bool wrap = false;

--- a/include/mbgl/style/sources/geojson_source.hpp
+++ b/include/mbgl/style/sources/geojson_source.hpp
@@ -21,7 +21,7 @@ struct GeoJSONOptions {
     // GeoJSON-VT options
     uint8_t minzoom = 0;
     uint8_t maxzoom = 18;
-    uint16_t tileSize = util::tileSize;
+    uint16_t tileSize = util::tileSize_I;
     uint16_t buffer = 128;
     double tolerance = 0.375;
     bool lineMetrics = false;

--- a/include/mbgl/tile/tile_id.hpp
+++ b/include/mbgl/tile/tile_id.hpp
@@ -248,7 +248,7 @@ inline OverscaledTileID UnwrappedTileID::overscaleTo(const uint8_t overscaledZ) 
 }
 
 inline float UnwrappedTileID::pixelsToTileUnits(const float pixelValue, const float zoom) const {
-    return pixelValue * (static_cast<float>(util::EXTENT) / (static_cast<float>(util::tileSize) * std::pow(2.f, zoom - canonical.z)));
+    return pixelValue * (static_cast<float>(util::EXTENT) / (static_cast<float>(util::tileSize_D) * std::pow(2.f, zoom - canonical.z)));
 }
 
 } // namespace mbgl

--- a/include/mbgl/util/constants.hpp
+++ b/include/mbgl/util/constants.hpp
@@ -11,7 +11,8 @@ namespace mbgl {
 
 namespace util {
 
-constexpr double tileSize = 512;
+constexpr double tileSize_D = 512;
+constexpr uint16_t tileSize_I = 512;
 
 /*
  * The maximum extent of a feature that can be safely stored in the buffer.
@@ -26,8 +27,10 @@ constexpr double tileSize = 512;
  */
 constexpr int32_t EXTENT = 8192;
 
-constexpr double DEG2RAD = M_PI / 180.0;
-constexpr double RAD2DEG = 180.0 / M_PI;
+constexpr double DEG2RAD_D = M_PI / 180.0;
+constexpr double RAD2DEG_D = 180.0 / M_PI;
+constexpr float DEG2RAD_F = static_cast<float>(M_PI) / 180.0F;
+constexpr float RAD2DEG_F = 180.0F / static_cast<float>(M_PI);
 constexpr double M2PI = M_PI * 2;
 constexpr double EARTH_RADIUS_M = 6378137;
 constexpr double LATITUDE_MAX = 85.051128779806604;

--- a/include/mbgl/util/feature.hpp
+++ b/include/mbgl/util/feature.hpp
@@ -32,9 +32,9 @@ public:
 
 template <class T>
 optional<T> numericValue(const Value& value) {
-    return value.match([](uint64_t t) { return optional<T>(t); },
-                       [](int64_t t) { return optional<T>(t); },
-                       [](double t) { return optional<T>(t); },
+    return value.match([](uint64_t t) { return optional<T>(static_cast<T>(t)); },
+                       [](int64_t t) { return optional<T>(static_cast<T>(t)); },
+                       [](double t) { return optional<T>(static_cast<T>(t)); },
                        [](const auto&) { return optional<T>(); });
 }
 

--- a/include/mbgl/util/geometry.hpp
+++ b/include/mbgl/util/geometry.hpp
@@ -41,7 +41,7 @@ using Geometry = mapbox::geometry::geometry<T>;
 
 template <class S, class T>
 Point<S> convertPoint(const Point<T>& p) {
-    return Point<S>(p.x, p.y);
+    return Point<S>(static_cast<S>(p.x), static_cast<S>(p.y));
 }
 
 struct ToFeatureType {

--- a/include/mbgl/util/projection.hpp
+++ b/include/mbgl/util/projection.hpp
@@ -41,14 +41,14 @@ class Projection {
 public:
     // Map pixel width at given scale.
     static double worldSize(double scale) {
-        return scale * util::tileSize;
+        return scale * util::tileSize_D;
     }
 
     static double getMetersPerPixelAtLatitude(double lat, double zoom) {
         const double constrainedZoom = util::clamp(zoom, util::MIN_ZOOM, util::MAX_ZOOM);
         const double constrainedScale = std::pow(2.0, constrainedZoom);
         const double constrainedLatitude = util::clamp(lat, -util::LATITUDE_MAX, util::LATITUDE_MAX);
-        return std::cos(constrainedLatitude * util::DEG2RAD) * util::M2PI * util::EARTH_RADIUS_M / worldSize(constrainedScale);
+        return std::cos(constrainedLatitude * util::DEG2RAD_D) * util::M2PI * util::EARTH_RADIUS_M / worldSize(constrainedScale);
     }
 
     static ProjectedMeters projectedMetersForLatLng(const LatLng& latLng) {
@@ -56,17 +56,17 @@ public:
         const double constrainedLongitude = util::clamp(latLng.longitude(), -util::LONGITUDE_MAX, util::LONGITUDE_MAX);
 
         const double m = 1 - 1e-15;
-        const double f = util::clamp(std::sin(util::DEG2RAD * constrainedLatitude), -m, m);
+        const double f = util::clamp(std::sin(util::DEG2RAD_D * constrainedLatitude), -m, m);
 
-        const double easting  = util::EARTH_RADIUS_M * constrainedLongitude * util::DEG2RAD;
+        const double easting  = util::EARTH_RADIUS_M * constrainedLongitude * util::DEG2RAD_D;
         const double northing = 0.5 * util::EARTH_RADIUS_M * std::log((1 + f) / (1 - f));
 
         return {northing, easting};
     }
 
     static LatLng latLngForProjectedMeters(const ProjectedMeters& projectedMeters) {
-        double latitude = (2 * std::atan(std::exp(projectedMeters.northing() / util::EARTH_RADIUS_M)) - (M_PI / 2.0)) * util::RAD2DEG;
-        double longitude = projectedMeters.easting() * util::RAD2DEG / util::EARTH_RADIUS_M;
+        double latitude = (2 * std::atan(std::exp(projectedMeters.northing() / util::EARTH_RADIUS_M)) - (M_PI / 2.0)) * util::RAD2DEG_D;
+        double longitude = projectedMeters.easting() * util::RAD2DEG_D / util::EARTH_RADIUS_M;
 
         latitude = util::clamp(latitude, -util::LATITUDE_MAX, util::LATITUDE_MAX);
         longitude = util::clamp(longitude, -util::LONGITUDE_MAX, util::LONGITUDE_MAX);
@@ -86,7 +86,7 @@ public:
     static LatLng unproject(const Point<double>& p, double scale, LatLng::WrapMode wrapMode = LatLng::Unwrapped) {
         auto p2 = p * util::DEGREES_MAX / worldSize(scale);
         return LatLng {
-            util::DEGREES_MAX / M_PI * std::atan(std::exp((util::LONGITUDE_MAX - p2.y) * util::DEG2RAD)) - 90.0,
+            util::DEGREES_MAX / M_PI * std::atan(std::exp((util::LONGITUDE_MAX - p2.y) * util::DEG2RAD_D)) - 90.0,
             p2.x - util::LONGITUDE_MAX,
             wrapMode
         };
@@ -97,7 +97,7 @@ private:
         const double latitude = util::clamp(latLng.latitude(), -util::LATITUDE_MAX, util::LATITUDE_MAX);
         return Point<double> {
             util::LONGITUDE_MAX + latLng.longitude(),
-            util::LONGITUDE_MAX - util::RAD2DEG * std::log(std::tan(M_PI / 4 + latitude * M_PI / util::DEGREES_MAX))
+            util::LONGITUDE_MAX - util::RAD2DEG_D * std::log(std::tan(M_PI / 4 + latitude * M_PI / util::DEGREES_MAX))
         } * (worldSize / util::DEGREES_MAX);
     }
 };

--- a/include/mbgl/util/variant.hpp
+++ b/include/mbgl/util/variant.hpp
@@ -1,6 +1,15 @@
 #pragma once
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#endif
+
 #include <mapbox/variant.hpp>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 namespace mbgl {
 

--- a/platform/android/MapboxGLAndroidSDK/src/cpp/native_map_view.cpp
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/native_map_view.cpp
@@ -784,7 +784,7 @@ void NativeMapView::addAnnotationIcon(JNIEnv& env, const jni::String& symbol, ji
 
     jni::GetArrayRegion(env, *jpixels, 0, size, reinterpret_cast<jbyte*>(premultipliedImage.data.get()));
     map->addAnnotationImage(std::make_unique<mbgl::style::Image>(
-        symbolName, std::move(premultipliedImage), float(scale)));
+        symbolName, std::move(premultipliedImage), static_cast<float>(scale)));
 }
 
 void NativeMapView::removeAnnotationIcon(JNIEnv& env, const jni::String& symbol) {
@@ -1097,7 +1097,7 @@ void NativeMapView::addImage(JNIEnv& env, const jni::String& name, const jni::Ob
     map->getStyle().addImage(std::make_unique<mbgl::style::Image>(
         jni::Make<std::string>(env, name),
         std::move(premultipliedImage),
-        float(scale),
+        static_cast<float>(scale),
         sdf)
     );
 }

--- a/platform/default/src/mbgl/storage/offline.cpp
+++ b/platform/default/src/mbgl/storage/offline.cpp
@@ -80,7 +80,7 @@ OfflineRegionDefinition decodeOfflineRegionDefinition(const std::string& region)
     std::string styleURL { doc["style_url"].GetString(), doc["style_url"].GetStringLength() };
     double minZoom = doc["min_zoom"].GetDouble();
     double maxZoom = doc.HasMember("max_zoom") ? doc["max_zoom"].GetDouble() : INFINITY;
-    float pixelRatio = doc["pixel_ratio"].GetDouble();
+    auto pixelRatio = static_cast<float>(doc["pixel_ratio"].GetDouble());
     bool includeIdeographs = doc.HasMember("include_ideographs") ? doc["include_ideographs"].GetBool() : true;
     
     if (doc.HasMember("bounds")) {

--- a/platform/default/src/mbgl/storage/offline_download.cpp
+++ b/platform/default/src/mbgl/storage/offline_download.cpp
@@ -75,7 +75,7 @@ uint64_t tileCount(const OfflineRegionDefinition& definition, style::SourceType 
     const Range<uint8_t> clampedZoomRange =
             definition.match([&](auto& reg) { return coveringZoomRange(reg, type, tileSize, zoomRange); });
 
-    unsigned long result = 0;;
+    uint64_t result{};
     for (uint8_t z = clampedZoomRange.min; z <= clampedZoomRange.max; z++) {
         result += definition.match(
                 [&](const OfflineTilePyramidRegionDefinition& reg){ return util::tileCount(reg.bounds, z); },
@@ -174,7 +174,7 @@ OfflineRegionStatus OfflineDownload::getStatus() const {
         switch (type) {
         case SourceType::Vector: {
             const auto& vectorSource = *source->as<VectorSource>();
-            handleTiledSource(vectorSource.getURLOrTileset(), util::tileSize);
+            handleTiledSource(vectorSource.getURLOrTileset(), util::tileSize_I);
             break;
         }
 
@@ -284,7 +284,7 @@ void OfflineDownload::activateDownload() {
             switch (type) {
                 case SourceType::Vector: {
                     const auto& vectorSource = *source->as<VectorSource>();
-                    handleTiledSource(vectorSource.getURLOrTileset(), util::tileSize);
+                    handleTiledSource(vectorSource.getURLOrTileset(), util::tileSize_I);
                     break;
                 }
 

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -26,9 +26,19 @@
 #include <mbgl/util/platform.hpp>
 #include <mbgl/util/string.hpp>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#pragma warning(disable : 4267)
+#endif
+
 #include <mapbox/cheap_ruler.hpp>
 #include <mapbox/geometry.hpp>
 #include <mapbox/geojson.hpp>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #if MBGL_USE_GLES2
 #define GLFW_INCLUDE_ES2
@@ -294,11 +304,11 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
             view->nextOrientation();
             break;
         case GLFW_KEY_Q: {
-            auto result = view->rendererFrontend->getRenderer()->queryPointAnnotations({ {}, { double(view->getSize().width), double(view->getSize().height) } });
+            auto result = view->rendererFrontend->getRenderer()->queryPointAnnotations({ {}, { static_cast<double>(view->getSize().width), static_cast<double>(view->getSize().height) } });
             printf("visible point annotations: %lu\n", result.size());
             auto features = view->rendererFrontend->getRenderer()->queryRenderedFeatures(
-                mbgl::ScreenBox{{double(view->getSize().width * 0.5), double(view->getSize().height * 0.5)},
-                                {double(view->getSize().width * 0.5 + 1), double(view->getSize().height * 0.5 + 1)}},
+                mbgl::ScreenBox{{view->getSize().width * 0.5, view->getSize().height * 0.5},
+                                {view->getSize().width * 0.5 + 1.0, view->getSize().height * 0.5 + 1}},
                 {});
             printf("Rendered features at the center of the screen: %lu\n", features.size());
         } break;
@@ -470,8 +480,8 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
         } break;
         case GLFW_KEY_U: {
             auto bounds = view->map->getBounds();
-            if (bounds.minPitch == mbgl::util::PITCH_MIN * mbgl::util::RAD2DEG &&
-                bounds.maxPitch == mbgl::util::PITCH_MAX * mbgl::util::RAD2DEG) {
+            if (bounds.minPitch == mbgl::util::PITCH_MIN * mbgl::util::RAD2DEG_D &&
+                bounds.maxPitch == mbgl::util::PITCH_MAX * mbgl::util::RAD2DEG_D) {
                 mbgl::Log::Info(mbgl::Event::General, "Limiting pitch bounds to [30, 40] degrees");
                 view->map->setBounds(mbgl::BoundOptions().withMinPitch(30).withMaxPitch(40));
             } else {
@@ -562,24 +572,24 @@ void GLFWView::updateFreeCameraDemo() {
 }
 
 mbgl::Color GLFWView::makeRandomColor() const {
-    const float r = 1.0f * float(std::rand()) / float(RAND_MAX);
-    const float g = 1.0f * float(std::rand()) / float(RAND_MAX);
-    const float b = 1.0f * float(std::rand()) / float(RAND_MAX);
+    const auto r = static_cast<float>(std::rand()) / RAND_MAX;
+    const auto g = static_cast<float>(std::rand()) / RAND_MAX;
+    const auto b = static_cast<float>(std::rand()) / RAND_MAX;
     return { r, g, b, 1.0f };
 }
 
 mbgl::Point<double> GLFWView::makeRandomPoint() const {
-    const double x = width * double(std::rand()) / RAND_MAX;
-    const double y = height * double(std::rand()) / RAND_MAX;
+    const double x = width * static_cast<double>(std::rand()) / RAND_MAX;
+    const double y = height * static_cast<double>(std::rand()) / RAND_MAX;
     mbgl::LatLng latLng = map->latLngForPixel({ x, y });
     return { latLng.longitude(), latLng.latitude() };
 }
 
 std::unique_ptr<mbgl::style::Image>
 GLFWView::makeImage(const std::string& id, int width, int height, float pixelRatio) {
-    const int r = 255 * (double(std::rand()) / RAND_MAX);
-    const int g = 255 * (double(std::rand()) / RAND_MAX);
-    const int b = 255 * (double(std::rand()) / RAND_MAX);
+    const int r = 255 * (static_cast<double>(std::rand()) / RAND_MAX);
+    const int g = 255 * (static_cast<double>(std::rand()) / RAND_MAX);
+    const int b = 255 * (static_cast<double>(std::rand()) / RAND_MAX);
 
     const int w = std::ceil(pixelRatio * width);
     const int h = std::ceil(pixelRatio * height);
@@ -1100,7 +1110,7 @@ void GLFWView::onWillStartRenderingFrame() {
     puck = static_cast<mbgl::style::LocationIndicatorLayer *>(map->getStyle().getLayer("puck"));
     if (puck) {
         uint64_t ns = mbgl::Clock::now().time_since_epoch().count();
-        const double bearing = double(ns % 2000000000) / 2000000000.0 * 360.0;
+        const double bearing = static_cast<double>(ns % 2000000000) / 2000000000.0 * 360.0;
         puck->setBearing(mbgl::style::Rotation(bearing));
     }
 #endif

--- a/platform/ios/platform/darwin/src/MGLGeometry.mm
+++ b/platform/ios/platform/darwin/src/MGLGeometry.mm
@@ -57,7 +57,7 @@ double MGLZoomLevelForAltitude(CLLocationDistance altitude, CGFloat pitch, CLLoc
     CLLocationDistance metersTall = eyeAltitude * 2 * std::tan(MGLRadiansFromDegrees(MGLAngularFieldOfView) / 2.);
     CLLocationDistance metersPerPixel = metersTall / size.height;
     CGFloat mapPixelWidthAtZoom = std::cos(MGLRadiansFromDegrees(latitude)) * mbgl::util::M2PI * mbgl::util::EARTH_RADIUS_M / metersPerPixel;
-    return ::log2(mapPixelWidthAtZoom / mbgl::util::tileSize);
+    return ::log2(mapPixelWidthAtZoom / mbgl::util::tileSize_D);
 }
 
 MGLRadianDistance MGLDistanceBetweenRadianCoordinates(MGLRadianCoordinate2D from, MGLRadianCoordinate2D to) {

--- a/platform/node/src/node_feature.cpp
+++ b/platform/node/src/node_feature.cpp
@@ -92,11 +92,11 @@ struct ToValue {
     }
 
     v8::Local<v8::Value> operator()(int64_t t) {
-        return operator()(double(t));
+        return operator()(static_cast<double>(t));
     }
 
     v8::Local<v8::Value> operator()(uint64_t t) {
-        return operator()(double(t));
+        return operator()(static_cast<double>(t));
     }
 
     v8::Local<v8::Value> operator()(double t) {

--- a/render-test/parser.cpp
+++ b/render-test/parser.cpp
@@ -474,7 +474,7 @@ TestMetadata parseTestMetadata(const TestPaths& paths) {
         if (mapModeStr == "tile") {
             metadata.mapMode = mbgl::MapMode::Tile;
             // In the tile mode, map is showing exactly one tile.
-            metadata.size = {uint32_t(mbgl::util::tileSize), uint32_t(mbgl::util::tileSize)};
+            metadata.size = {mbgl::util::tileSize_I, mbgl::util::tileSize_I};
         } else if (mapModeStr == "continuous") {
             metadata.mapMode = mbgl::MapMode::Continuous;
             metadata.outputsImage = false;
@@ -974,7 +974,7 @@ TestOperations parseTestOperations(TestMetadata& metadata) {
             float tolerance = -1.0f;
             if (operationArray.Size() >= 3u) {
                 assert(operationArray[2].IsNumber());
-                tolerance = float(operationArray[2].GetDouble());
+                tolerance = static_cast<float>(operationArray[2].GetDouble());
             }
             result.emplace_back([mark, tolerance](TestContext& ctx) {
                 assert(AllocationIndex::isActive());

--- a/render-test/runner.cpp
+++ b/render-test/runner.cpp
@@ -658,12 +658,12 @@ void resetContext(const TestMetadata& metadata, TestContext& ctx) {
 
 LatLng getTileCenterCoordinates(const UnwrappedTileID& tileId) {
     double scale = (1 << tileId.canonical.z);
-    Point<double> tileCenter{(tileId.canonical.x + 0.5) * util::tileSize, (tileId.canonical.y + 0.5) * util::tileSize};
+    Point<double> tileCenter{(tileId.canonical.x + 0.5) * util::tileSize_D, (tileId.canonical.y + 0.5) * util::tileSize_D};
     return Projection::unproject(tileCenter, scale);
 }
 
 uint32_t getTileScreenPixelSize(float pixelRatio) {
-    return util::tileSize * pixelRatio;
+    return util::tileSize_D * pixelRatio;
 }
 
 uint32_t getImageTileOffset(const std::set<uint32_t>& dims, uint32_t dim, float pixelRatio) {

--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -34,7 +34,7 @@ void RenderAnnotationSource::update(Immutable<style::Source::Impl> baseImpl_,
         needsRelayout,
         parameters,
         *baseImpl,
-        util::tileSize,
+        util::tileSize_I,
         // Zoom level 16 is typically sufficient for annotations.
         // See https://github.com/mapbox/mapbox-gl-native/issues/10197
         {0, 16},

--- a/src/mbgl/geometry/dem_data.cpp
+++ b/src/mbgl/geometry/dem_data.cpp
@@ -85,7 +85,7 @@ void DEMData::backfillBorder(const DEMData& borderTileData, int8_t dx, int8_t dy
 int32_t DEMData::get(const int32_t x, const int32_t y) const {
     const auto& unpack = getUnpackVector();
     const uint8_t* value = image.data.get() + idx(x, y) * 4;
-    return value[0] * unpack[0] + value[1] * unpack[1] + value[2] * unpack[2] - unpack[3];
+    return static_cast<int32_t>(value[0] * unpack[0] + value[1] * unpack[1] + value[2] * unpack[2] - unpack[3]);
 }
 
 const std::array<float, 4>& DEMData::getUnpackVector() const {

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -66,8 +66,8 @@ void FeatureIndex::query(std::unordered_map<std::string, std::vector<Feature>>& 
     }
 
     // Determine query radius
-    const float pixelsToTileUnits = util::EXTENT / tileSize / scale;
-    const int16_t additionalPadding = std::min<int16_t>(util::EXTENT, additionalQueryPadding * pixelsToTileUnits);
+    const auto pixelsToTileUnits = static_cast<float>(util::EXTENT / tileSize / scale);
+    const int16_t additionalPadding = std::min<int16_t>(util::EXTENT, static_cast<int16_t>(additionalQueryPadding * pixelsToTileUnits));
 
     // Query the grid index
     mapbox::geometry::box<int16_t> box = mapbox::geometry::envelope(queryGeometry);
@@ -194,7 +194,7 @@ optional<GeometryCoordinates> FeatureIndex::translateQueryGeometry(
         return {};
     }
 
-    GeometryCoordinate translateVec(translate[0] * pixelsToTileUnits, translate[1] * pixelsToTileUnits);
+    GeometryCoordinate translateVec(static_cast<int16_t>(translate[0] * pixelsToTileUnits), static_cast<int16_t>(translate[1] * pixelsToTileUnits));
     if (anchorType == style::TranslateAnchorType::Viewport) {
         translateVec = util::rotate(translateVec, -bearing);
     }

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -727,7 +727,7 @@ void Context::reduceMemoryUsage() {
 
 #if !defined(NDEBUG)
 void Context::visualizeStencilBuffer() {
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
     setStencilMode(gfx::StencilMode::disabled());
     setDepthMode(gfx::DepthMode::disabled());
     setColorMode(gfx::ColorMode::unblended());
@@ -756,7 +756,7 @@ void Context::visualizeStencilBuffer() {
 
 void Context::visualizeDepthBuffer(const float depthRangeSize) {
     (void)depthRangeSize;
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
     setStencilMode(gfx::StencilMode::disabled());
     setDepthMode(gfx::DepthMode::disabled());
     setColorMode(gfx::ColorMode::unblended());

--- a/src/mbgl/gl/render_custom_layer.cpp
+++ b/src/mbgl/gl/render_custom_layer.cpp
@@ -86,7 +86,7 @@ void RenderCustomLayer::render(PaintParameters& paintParameters) {
     parameters.latitude = state.getLatLng().latitude();
     parameters.longitude = state.getLatLng().longitude();
     parameters.zoom = state.getZoom();
-    parameters.bearing = -state.getBearing() * util::RAD2DEG;
+    parameters.bearing = -state.getBearing() * util::RAD2DEG_D;
     parameters.pitch = state.getPitch();
     parameters.fieldOfView = state.getFieldOfView();
     mat4 projMatrix;

--- a/src/mbgl/gl/uniform.cpp
+++ b/src/mbgl/gl/uniform.cpp
@@ -12,6 +12,11 @@ namespace gl {
 
 using namespace platform;
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#endif
+
 UniformLocation uniformLocation(ProgramID id, const char* name) {
     return MBGL_CHECK_ERROR(glGetUniformLocation(id, name));
 }
@@ -91,6 +96,10 @@ template <>
 void bindUniform<std::array<uint16_t, 4>>(UniformLocation location, const std::array<uint16_t, 4>& t) {
     bindUniform(location, util::convert<float>(t));
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 // Add more as needed.
 

--- a/src/mbgl/gl/upload_pass.cpp
+++ b/src/mbgl/gl/upload_pass.cpp
@@ -21,13 +21,13 @@ std::unique_ptr<gfx::VertexBufferResource> UploadPass::createVertexBufferResourc
     BufferID id = 0;
     MBGL_CHECK_ERROR(glGenBuffers(1, &id));
     commandEncoder.context.renderingStats().numBuffers++;
-    commandEncoder.context.renderingStats().memVertexBuffers += size;
+    commandEncoder.context.renderingStats().memVertexBuffers += static_cast<int>(size);
     // NOLINTNEXTLINE(performance-move-const-arg)
     UniqueBuffer result{ std::move(id), { commandEncoder.context } };
     commandEncoder.context.vertexBuffer = result;
     MBGL_CHECK_ERROR(
         glBufferData(GL_ARRAY_BUFFER, size, data, Enum<gfx::BufferUsageType>::to(usage)));
-    return std::make_unique<gl::VertexBufferResource>(std::move(result), size);
+    return std::make_unique<gl::VertexBufferResource>(std::move(result), static_cast<int>(size));
 }
 
 void UploadPass::updateVertexBufferResource(gfx::VertexBufferResource& resource,
@@ -42,14 +42,14 @@ std::unique_ptr<gfx::IndexBufferResource> UploadPass::createIndexBufferResource(
     BufferID id = 0;
     MBGL_CHECK_ERROR(glGenBuffers(1, &id));
     commandEncoder.context.renderingStats().numBuffers++;
-    commandEncoder.context.renderingStats().memIndexBuffers += size;
+    commandEncoder.context.renderingStats().memIndexBuffers += static_cast<int>(size);
     // NOLINTNEXTLINE(performance-move-const-arg)
     UniqueBuffer result{ std::move(id), { commandEncoder.context } };
     commandEncoder.context.bindVertexArray = 0;
     commandEncoder.context.globalVertexArrayState.indexBuffer = result;
     MBGL_CHECK_ERROR(
         glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, data, Enum<gfx::BufferUsageType>::to(usage)));
-    return std::make_unique<gl::IndexBufferResource>(std::move(result), size);
+    return std::make_unique<gl::IndexBufferResource>(std::move(result), static_cast<int>(size));
 }
 
 void UploadPass::updateIndexBufferResource(gfx::IndexBufferResource& resource,

--- a/src/mbgl/gl/value.cpp
+++ b/src/mbgl/gl/value.cpp
@@ -489,6 +489,11 @@ GLint components(const gfx::AttributeDataType type) {
 
 } // namespace
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4312) // reinterpret_cast different size
+#endif
+
 void VertexAttribute::Set(const Type& binding, Context& context, AttributeLocation location) {
     if (binding) {
         context.vertexBuffer = reinterpret_cast<const gl::VertexBufferResource&>(*binding->vertexBufferResource).buffer;
@@ -504,6 +509,10 @@ void VertexAttribute::Set(const Type& binding, Context& context, AttributeLocati
         MBGL_CHECK_ERROR(glDisableVertexAttribArray(location));
     }
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 const constexpr PixelStorePack::Type PixelStorePack::Default;
 

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -84,13 +84,13 @@ SymbolLayout::SymbolLayout(const BucketParameters& parameters,
                            const LayoutParameters& layoutParameters)
     : bucketLeaderID(layers.front()->baseImpl->id),
       sourceLayer(std::move(sourceLayer_)),
-      overscaling(parameters.tileID.overscaleFactor()),
+      overscaling(static_cast<float>(parameters.tileID.overscaleFactor())),
       zoom(parameters.tileID.overscaledZ),
       canonicalID(parameters.tileID.canonical),
       mode(parameters.mode),
       pixelRatio(parameters.pixelRatio),
-      tileSize(util::tileSize * overscaling),
-      tilePixelRatio(float(util::EXTENT) / tileSize),
+      tileSize(static_cast<uint32_t>(util::tileSize_D * overscaling)),
+      tilePixelRatio(static_cast<float>(util::EXTENT) / tileSize),
       layout(createLayout(toSymbolLayerProperties(layers.at(0)).layerImpl().layout, zoom)) {
     const SymbolLayer::Impl& leader = toSymbolLayerProperties(layers.at(0)).layerImpl();
 
@@ -540,7 +540,7 @@ void SymbolLayout::addFeature(const std::size_t layoutFeatureIndex,
     const float symbolSpacing = tilePixelRatio * layout->get<SymbolSpacing>();
     const float textPadding = layout->get<TextPadding>() * tilePixelRatio;
     const float iconPadding = layout->get<IconPadding>() * tilePixelRatio;
-    const float textMaxAngle = layout->get<TextMaxAngle>() * util::DEG2RAD;
+    const float textMaxAngle = layout->get<TextMaxAngle>() * util::DEG2RAD_F;
     const float iconRotation = layout->evaluate<IconRotate>(zoom, feature, canonicalID);
     const float textRotation = layout->evaluate<TextRotate>(zoom, feature, canonicalID);
     std::array<float, 2> variableTextOffset;
@@ -689,8 +689,8 @@ void SymbolLayout::addFeature(const std::size_t layoutFeatureIndex,
             }
 
             // 1 pixel worth of precision, in tile coordinates
-            auto poi = mapbox::polylabel(poly, double(util::EXTENT / util::tileSize));
-            Anchor anchor(poi.x, poi.y, 0, minScale);
+            auto poi = mapbox::polylabel(poly, util::EXTENT / util::tileSize_D);
+            Anchor anchor(static_cast<float>(poi.x), static_cast<float>(poi.y), 0.0f, static_cast<size_t>(minScale));
             addSymbolInstance(anchor, createSymbolInstanceSharedData(polygon[0]));
         }
     } else if (type == FeatureType::LineString) {
@@ -698,13 +698,13 @@ void SymbolLayout::addFeature(const std::size_t layoutFeatureIndex,
             // Skip invalid LineStrings.
             if (line.empty()) continue;
 
-            Anchor anchor(line[0].x, line[0].y, 0, minScale);
+            Anchor anchor(static_cast<float>(line[0].x), static_cast<float>(line[0].y), 0.0f, static_cast<size_t>(minScale));
             addSymbolInstance(anchor, createSymbolInstanceSharedData(line));
         }
     } else if (type == FeatureType::Point) {
         for (const auto& points : feature.geometry) {
             for (const auto& point : points) {
-                Anchor anchor(point.x, point.y, 0, minScale);
+                Anchor anchor(static_cast<float>(point.x), static_cast<float>(point.y), 0.0f, static_cast<size_t>(minScale));
                 addSymbolInstance(anchor, createSymbolInstanceSharedData({point}));
             }
         }
@@ -799,7 +799,7 @@ void SymbolLayout::createBucket(const ImagePositions&,
                                                       std::vector<float>());
                 index = iconBuffer.placedSymbols.size() - 1;
                 PlacedSymbol& iconSymbol = iconBuffer.placedSymbols.back();
-                iconSymbol.angle = (allowVerticalPlacement && writingMode == WritingModeType::Vertical) ? M_PI_2 : 0;
+                iconSymbol.angle = (allowVerticalPlacement && writingMode == WritingModeType::Vertical) ? static_cast<float>(M_PI_2) : 0.0f;
                 iconSymbol.vertexStartIndex =
                     addSymbols(iconBuffer, sizeData, iconQuads, symbolInstance.anchor, iconSymbol, feature.sortKey);
             };
@@ -927,7 +927,7 @@ std::size_t SymbolLayout::addSymbolGlyphQuads(SymbolBucket& bucket,
                                            placedIconIndex);
     placedIndex = bucket.text.placedSymbols.size() - 1;
     PlacedSymbol& placedSymbol = bucket.text.placedSymbols.back();
-    placedSymbol.angle = (allowVerticalPlacement && writingMode == WritingModeType::Vertical) ? M_PI_2 : 0;
+    placedSymbol.angle = (allowVerticalPlacement && writingMode == WritingModeType::Vertical) ? static_cast<float>(M_PI_2) : 0.0f;
 
     bool firstSymbol = true;
     for (const auto& symbolQuad : glyphQuads) {

--- a/src/mbgl/layout/symbol_projection.cpp
+++ b/src/mbgl/layout/symbol_projection.cpp
@@ -111,8 +111,8 @@ namespace mbgl {
     }
 
     bool isVisible(const vec4& anchorPos, const std::array<double, 2>& clippingBuffer) {
-        const float x = anchorPos[0] / anchorPos[3];
-        const float y = anchorPos[1] / anchorPos[3];
+        const double x = anchorPos[0] / anchorPos[3];
+        const double y = anchorPos[1] / anchorPos[3];
         const bool inPaddedViewport = (
                 x >= -clippingBuffer[0] &&
                 x <= clippingBuffer[0] &&
@@ -366,11 +366,11 @@ namespace mbgl {
 			const mat4& posMatrix, bool pitchWithMap, bool rotateWithMap, bool keepUpright,
             const RenderTile& tile, const SymbolSizeBinder& sizeBinder, const TransformState& state) {
 
-        const ZoomEvaluatedSize partiallyEvaluatedSize = sizeBinder.evaluateForZoom(state.getZoom());
+        const ZoomEvaluatedSize partiallyEvaluatedSize = sizeBinder.evaluateForZoom(static_cast<float>(state.getZoom()));
 
         const std::array<double, 2> clippingBuffer = {{ 256.0 / state.getSize().width * 2.0 + 1.0, 256.0 / state.getSize().height * 2.0 + 1.0 }};
 
-        const float pixelsToTileUnits = tile.id.pixelsToTileUnits(1, state.getZoom());
+        const float pixelsToTileUnits = tile.id.pixelsToTileUnits(1.0f, static_cast<float>(state.getZoom()));
 
         const mat4 labelPlaneMatrix = getLabelPlaneMatrix(posMatrix, pitchWithMap,
                 rotateWithMap, state, pixelsToTileUnits);
@@ -401,8 +401,8 @@ namespace mbgl {
                 continue;
             }
 
-            const float cameraToAnchorDistance = anchorPos[3];
-            const float perspectiveRatio = 0.5 + 0.5 * (cameraToAnchorDistance / state.getCameraToCenterDistance());
+            const auto cameraToAnchorDistance = static_cast<float>(anchorPos[3]);
+            const float perspectiveRatio = 0.5f + 0.5f * (cameraToAnchorDistance / state.getCameraToCenterDistance());
 
             const float fontSize = evaluateSizeForFeature(partiallyEvaluatedSize, placedSymbol);
             const float pitchScaledFontSize = pitchWithMap ?

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -155,7 +155,7 @@ void Map::moveBy(const ScreenCoordinate& point, const AnimationOptions& animatio
 }
 
 void Map::pitchBy(double pitch, const AnimationOptions& animation) {
-    easeTo(CameraOptions().withPitch((impl->transform.getPitch() * util::RAD2DEG) - pitch), animation);
+    easeTo(CameraOptions().withPitch((impl->transform.getPitch() * util::RAD2DEG_D) - pitch), animation);
 }
 
 void Map::scaleBy(double scale, const optional<ScreenCoordinate>& anchor, const AnimationOptions& animation) {
@@ -206,8 +206,8 @@ CameraOptions cameraForLatLngs(const std::vector<LatLng>& latLngs, const Transfo
     // Calculate the zoom level.
     double minScale = INFINITY;
     if (width > 0 || height > 0) {
-        double scaleX = double(size.width) / width;
-        double scaleY = double(size.height) / height;
+        double scaleX = static_cast<double>(size.width) / width;
+        double scaleY = static_cast<double>(size.height) / height;
         scaleX -= (padding.left() + padding.right()) / width;
         scaleY -= (padding.top() + padding.bottom()) / height;
         minScale = util::min(scaleX, scaleY);
@@ -245,8 +245,8 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs,
     }
 
     return mbgl::cameraForLatLngs(latLngs, transform, padding)
-        .withBearing(-transform.getBearing() * util::RAD2DEG)
-        .withPitch(transform.getPitch() * util::RAD2DEG);
+        .withBearing(-transform.getBearing() * util::RAD2DEG_D)
+        .withPitch(transform.getPitch() * util::RAD2DEG_D);
 }
 
 CameraOptions Map::cameraForGeometry(const Geometry<double>& geometry,
@@ -267,7 +267,7 @@ LatLngBounds Map::latLngBoundsForCamera(const CameraOptions& camera) const {
     shallow.jumpTo(camera);
     return LatLngBounds::hull(
         shallow.screenCoordinateToLatLng({}),
-        shallow.screenCoordinateToLatLng({ double(size.width), double(size.height) })
+        shallow.screenCoordinateToLatLng({ static_cast<double>(size.width), static_cast<double>(size.height) })
     );
 }
 
@@ -277,10 +277,10 @@ LatLngBounds Map::latLngBoundsForCameraUnwrapped(const CameraOptions& camera) co
 
     shallow.jumpTo(camera);
     LatLng nw = shallow.screenCoordinateToLatLng({});
-    LatLng se = shallow.screenCoordinateToLatLng({double(size.width), double(size.height)});
-    LatLng ne = shallow.screenCoordinateToLatLng({double(size.width), 0.0});
-    LatLng sw = shallow.screenCoordinateToLatLng({0.0, double(size.height)});
-    LatLng center = shallow.screenCoordinateToLatLng({double(size.width) / 2, double(size.height) / 2});
+    LatLng se = shallow.screenCoordinateToLatLng({static_cast<double>(size.width), static_cast<double>(size.height)});
+    LatLng ne = shallow.screenCoordinateToLatLng({static_cast<double>(size.width), 0.0});
+    LatLng sw = shallow.screenCoordinateToLatLng({0.0, static_cast<double>(size.height)});
+    LatLng center = shallow.screenCoordinateToLatLng({static_cast<double>(size.width) / 2, static_cast<double>(size.height) / 2});
     nw.unwrapForShortestPath(center);
     se.unwrapForShortestPath(center);
     ne.unwrapForShortestPath(center);
@@ -345,8 +345,8 @@ BoundOptions Map::getBounds() const {
         .withLatLngBounds(impl->transform.getState().getLatLngBounds())
         .withMinZoom(impl->transform.getState().getMinZoom())
         .withMaxZoom(impl->transform.getState().getMaxZoom())
-        .withMinPitch(impl->transform.getState().getMinPitch() * util::RAD2DEG)
-        .withMaxPitch(impl->transform.getState().getMaxPitch() * util::RAD2DEG);
+        .withMinPitch(impl->transform.getState().getMinPitch() * util::RAD2DEG_D)
+        .withMaxPitch(impl->transform.getState().getMaxPitch() * util::RAD2DEG_D);
 }
 
 #pragma mark - Map options

--- a/src/mbgl/map/map_projection.cpp
+++ b/src/mbgl/map/map_projection.cpp
@@ -32,8 +32,8 @@ CameraOptions MapProjection::getCamera() const {
 void MapProjection::setVisibleCoordinates(const std::vector<LatLng>& latLngs,
                                           const EdgeInsets& padding) {
     transform->jumpTo(mbgl::cameraForLatLngs(latLngs, *transform, padding)
-                      .withBearing(-transform->getBearing() * util::RAD2DEG)
-                      .withPitch(transform->getPitch() * util::RAD2DEG));
+                      .withBearing(-transform->getBearing() * util::RAD2DEG_D)
+                      .withPitch(transform->getPitch() * util::RAD2DEG_D));
 }
 
 } // namespace mbgl

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -96,8 +96,8 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
     const LatLng& unwrappedLatLng = camera.center.value_or(startLatLng);
     const LatLng& latLng = state.getLatLngBounds() != LatLngBounds() ? unwrappedLatLng : unwrappedLatLng.wrapped();
     double zoom = camera.zoom.value_or(getZoom());
-    double bearing = camera.bearing ? -*camera.bearing * util::DEG2RAD : getBearing();
-    double pitch = camera.pitch ? *camera.pitch * util::DEG2RAD : getPitch();
+    double bearing = camera.bearing ? -*camera.bearing * util::DEG2RAD_D : getBearing();
+    double pitch = camera.pitch ? *camera.pitch * util::DEG2RAD_D : getPitch();
 
     if (std::isnan(zoom) || std::isnan(bearing) || std::isnan(pitch)) {
         if (animation.transitionFinishFn) {
@@ -178,8 +178,8 @@ void Transform::flyTo(const CameraOptions& camera, const AnimationOptions& anima
     const EdgeInsets& padding = camera.padding.value_or(state.getEdgeInsets());
     const LatLng& latLng = camera.center.value_or(getLatLng(LatLng::Unwrapped)).wrapped();
     double zoom = camera.zoom.value_or(getZoom());
-    double bearing = camera.bearing ? -*camera.bearing * util::DEG2RAD : getBearing();
-    double pitch = camera.pitch ? *camera.pitch * util::DEG2RAD : getPitch();
+    double bearing = camera.bearing ? -*camera.bearing * util::DEG2RAD_D : getBearing();
+    double pitch = camera.pitch ? *camera.pitch * util::DEG2RAD_D : getPitch();
 
     if (std::isnan(zoom) || std::isnan(bearing) || std::isnan(pitch) || state.getSize().isEmpty()) {
         if (animation.transitionFinishFn) {
@@ -382,22 +382,22 @@ void Transform::setMaxZoom(const double maxZoom) {
 
 void Transform::setMinPitch(const double minPitch) {
     if (std::isnan(minPitch)) return;
-    if (minPitch * util::DEG2RAD < util::PITCH_MIN) {
+    if (minPitch * util::DEG2RAD_D < util::PITCH_MIN) {
         Log::Warning(Event::General,
                      "Trying to set minimum pitch below the limit (%.0f degrees), the value will be clamped.",
-                     util::PITCH_MIN * util::RAD2DEG);
+                     util::PITCH_MIN * util::RAD2DEG_D);
     }
-    state.setMinPitch(minPitch * util::DEG2RAD);
+    state.setMinPitch(minPitch * util::DEG2RAD_D);
 }
 
 void Transform::setMaxPitch(const double maxPitch) {
     if (std::isnan(maxPitch)) return;
-    if (maxPitch * util::DEG2RAD > util::PITCH_MAX) {
+    if (maxPitch * util::DEG2RAD_D > util::PITCH_MAX) {
         Log::Warning(Event::General,
                      "Trying to set maximum pitch above the limit (%.0f degrees), the value will be clamped.",
-                     util::PITCH_MAX * util::RAD2DEG);
+                     util::PITCH_MAX * util::RAD2DEG_D);
     }
-    state.setMaxPitch(maxPitch * util::DEG2RAD);
+    state.setMaxPitch(maxPitch * util::DEG2RAD_D);
 }
 
 #pragma mark - Bearing
@@ -418,7 +418,7 @@ void Transform::rotateBy(const ScreenCoordinate& first,
         center.y = first.y + std::sin(rotateBearing) * heightOffset;
     }
 
-    const double bearing = -(state.getBearing() + util::angle_between(first - center, second - center)) * util::RAD2DEG;
+    const double bearing = -(state.getBearing() + util::angle_between(first - center, second - center)) * util::RAD2DEG_D;
     easeTo(CameraOptions().withBearing(bearing), animation);
 }
 
@@ -516,7 +516,7 @@ void Transform::startTransition(const CameraOptions& camera,
     transitionDuration = duration;
 
     transitionFrameFn = [isAnimated, animation, frame, anchor, anchorLatLng, this](const TimePoint now) {
-        float t = isAnimated ? (std::chrono::duration<float>(now - transitionStart) / transitionDuration) : 1.0;
+        float t = isAnimated ? (std::chrono::duration<float>(now - transitionStart) / transitionDuration) : 1.0f;
         if (t >= 1.0) {
             frame(1.0);
         } else {

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -12,7 +12,7 @@ namespace mbgl {
 
 namespace {
 LatLng latLngFromMercator(Point<double> mercatorCoordinate, LatLng::WrapMode wrapMode = LatLng::WrapMode::Unwrapped) {
-    return {util::RAD2DEG * (2 * std::atan(std::exp(M_PI - mercatorCoordinate.y * util::M2PI)) - M_PI_2),
+    return {util::RAD2DEG_D * (2 * std::atan(std::exp(M_PI - mercatorCoordinate.y * util::M2PI)) - M_PI_2),
             mercatorCoordinate.x * 360.0 - 180.0,
             wrapMode};
 }
@@ -115,7 +115,7 @@ void TransformState::getProjMatrix(mat4& projMatrix, uint16_t nearZ, bool aligne
 
     mat4 worldToCamera = camera.getWorldToCamera(scale, viewportMode == ViewportMode::FlippedY);
     mat4 cameraToClip =
-        camera.getCameraToClipPerspective(getFieldOfView(), double(size.width) / size.height, nearZ, farZ);
+        camera.getCameraToClipPerspective(getFieldOfView(), static_cast<double>(size.width) / size.height, nearZ, farZ);
 
     // Move the center of perspective to center of specified edgeInsets.
     // Values are in range [-1, 1] where the upper and lower range values
@@ -156,13 +156,13 @@ void TransformState::getProjMatrix(mat4& projMatrix, uint16_t nearZ, bool aligne
         const double dx = x - 0.5 * worldSize;
         const double dy = y - 0.5 * worldSize;
 
-        const float xShift = float(size.width % 2) / 2;
-        const float yShift = float(size.height % 2) / 2;
+        const auto xShift = static_cast<double>(size.width % 2) / 2.0;
+        const auto yShift = static_cast<double>(size.height % 2) / 2.0;
         const double bearingCos = std::cos(bearing);
         const double bearingSin = std::sin(bearing);
         double devNull;
-        const float dxa = -std::modf(dx, &devNull) + bearingCos * xShift + bearingSin * yShift;
-        const float dya = -std::modf(dy, &devNull) + bearingCos * yShift + bearingSin * xShift;
+        const double dxa = -std::modf(dx, &devNull) + bearingCos * xShift + bearingSin * yShift;
+        const double dya = -std::modf(dy, &devNull) + bearingCos * yShift + bearingSin * xShift;
         matrix::translate(projMatrix, projMatrix, dxa > 0.5 ? dxa - 1 : dxa, dya > 0.5 ? dya - 1 : dya, 0);
     }
 }
@@ -215,7 +215,7 @@ void TransformState::updateStateFromCamera() {
 
     // Compute zoom level from the camera altitude
     const double centerDistance = getCameraToCenterDistance();
-    const double zoom = util::log2(centerDistance / (position[2] / std::cos(newPitch) * util::tileSize));
+    const double zoom = util::log2(centerDistance / (position[2] / std::cos(newPitch) * util::tileSize_D));
     const double newScale = util::clamp(std::pow(2.0, zoom), min_scale, max_scale);
 
     // Compute center point of the map
@@ -409,8 +409,8 @@ CameraOptions TransformState::getCameraOptions(const optional<EdgeInsets>& paddi
         .withCenter(getLatLng())
         .withPadding(padding ? padding : edgeInsets)
         .withZoom(getZoom())
-        .withBearing(-bearing * util::RAD2DEG)
-        .withPitch(pitch * util::RAD2DEG);
+        .withBearing(-bearing * util::RAD2DEG_D)
+        .withPitch(pitch * util::RAD2DEG_D);
 }
 
 #pragma mark - EdgeInsets
@@ -425,7 +425,7 @@ void TransformState::setEdgeInsets(const EdgeInsets& val) {
 #pragma mark - Position
 
 LatLng TransformState::getLatLng(LatLng::WrapMode wrapMode) const {
-    return {util::RAD2DEG * (2 * std::atan(std::exp(y / Cc)) - 0.5 * M_PI), -x / Bc, wrapMode};
+    return {util::RAD2DEG_D * (2 * std::atan(std::exp(y / Cc)) - 0.5 * M_PI), -x / Bc, wrapMode};
 }
 
 double TransformState::pixel_x() const {
@@ -445,7 +445,7 @@ double TransformState::getZoom() const {
 }
 
 uint8_t TransformState::getIntegerZoom() const {
-    return getZoom();
+    return static_cast<uint8_t>(getZoom());
 }
 
 double TransformState::getZoomFraction() const {
@@ -564,11 +564,11 @@ void TransformState::setBearing(double val) {
 }
 
 float TransformState::getFieldOfView() const {
-    return fov;
+    return static_cast<float>(fov);
 }
 
 float TransformState::getCameraToCenterDistance() const {
-    return 0.5 * size.height / std::tan(fov / 2.0);
+    return static_cast<float>(0.5 * size.height / std::tan(fov / 2.0));
 }
 
 double TransformState::getPitch() const {
@@ -656,7 +656,7 @@ ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng, 
         return {};
     }
 
-    Point<double> pt = Projection::project(latLng, scale) / util::tileSize;
+    Point<double> pt = Projection::project(latLng, scale) / util::tileSize_D;
     vec4 c = {{pt.x, pt.y, 0, 1}};
     matrix::transformMat4(p, c, getCoordMatrix());
     return {p[0] / p[3], size.height - p[1] / p[3]};
@@ -698,12 +698,12 @@ TileCoordinate TransformState::screenCoordinateToTileCoordinate(const ScreenCoor
 
 LatLng TransformState::screenCoordinateToLatLng(const ScreenCoordinate& point, LatLng::WrapMode wrapMode) const {
     auto coord = screenCoordinateToTileCoordinate(point, 0);
-    return Projection::unproject(coord.p, 1. / util::tileSize, wrapMode);
+    return Projection::unproject(coord.p, 1. / util::tileSize_D, wrapMode);
 }
 
 mat4 TransformState::coordinatePointMatrix(const mat4& projMatrix) const {
     mat4 proj = projMatrix;
-    matrix::scale(proj, proj, util::tileSize, util::tileSize, 1);
+    matrix::scale(proj, proj, util::tileSize_D, util::tileSize_D, 1);
     matrix::multiply(proj, getPixelMatrix(), proj);
     return proj;
 }
@@ -729,16 +729,16 @@ void TransformState::constrain(double& scale_, double& x_, double& y_) const {
     }
 
     // Constrain scale to avoid zooming out far enough to show off-world areas on the Y axis.
-    const double ratioY = (rotatedNorth() ? size.width : size.height) / util::tileSize;
+    const double ratioY = (rotatedNorth() ? size.width : size.height) / util::tileSize_D;
     scale_ = util::max(scale_, ratioY);
 
     // Constrain min/max pan to avoid showing off-world areas on the Y axis.
-    double max_y = (scale_ * util::tileSize - (rotatedNorth() ? size.width : size.height)) / 2;
+    double max_y = (scale_ * util::tileSize_D - (rotatedNorth() ? size.width : size.height)) / 2;
     y_ = std::max(-max_y, std::min(y_, max_y));
 
     if (constrainMode == ConstrainMode::WidthAndHeight) {
         // Constrain min/max pan to avoid showing off-world areas on the X axis.
-        double max_x = (scale_ * util::tileSize - (rotatedNorth() ? size.height : size.width)) / 2;
+        double max_x = (scale_ * util::tileSize_D - (rotatedNorth() ? size.height : size.width)) / 2;
         x_ = std::max(-max_x, std::min(x_, max_x));
     }
 }
@@ -759,12 +759,12 @@ void TransformState::setLatLngZoom(const LatLng& latLng, double zoom) {
     constrained = bounds.constrain(latLng);
 
     double newScale = util::clamp(zoomScale(zoom), min_scale, max_scale);
-    const double newWorldSize = newScale * util::tileSize;
+    const double newWorldSize = newScale * util::tileSize_D;
     Bc = newWorldSize / util::DEGREES_MAX;
     Cc = newWorldSize / util::M2PI;
 
     const double m = 1 - 1e-15;
-    const double f = util::clamp(std::sin(util::DEG2RAD * constrained.latitude()), -m, m);
+    const double f = util::clamp(std::sin(util::DEG2RAD_D * constrained.latitude()), -m, m);
 
     ScreenCoordinate point = {
         -constrained.longitude() * Bc,
@@ -790,10 +790,10 @@ float TransformState::getCameraToTileDistance(const UnwrappedTileID& tileID) con
     mat4 tileProjectionMatrix;
     matrixFor(tileProjectionMatrix, tileID);
     matrix::multiply(tileProjectionMatrix, getProjectionMatrix(), tileProjectionMatrix);
-    vec4 tileCenter = {{util::tileSize / 2, util::tileSize / 2, 0, 1}};
+    vec4 tileCenter = {{util::tileSize_D / 2, util::tileSize_D / 2, 0, 1}};
     vec4 projectedCenter;
     matrix::transformMat4(projectedCenter, tileCenter, tileProjectionMatrix);
-    return projectedCenter[3];
+    return static_cast<float>(projectedCenter[3]);
 }
 
 float TransformState::maxPitchScaleFactor() const {
@@ -802,11 +802,11 @@ float TransformState::maxPitchScaleFactor() const {
     }
     auto latLng = screenCoordinateToLatLng({ 0, static_cast<float>(getSize().height) });
 
-    Point<double> pt = Projection::project(latLng, scale) / util::tileSize;
+    Point<double> pt = Projection::project(latLng, scale) / util::tileSize_D;
     vec4 p = {{ pt.x, pt.y, 0, 1 }};
     vec4 topPoint;
     matrix::transformMat4(topPoint, p, getCoordMatrix());
-    return topPoint[3] / getCameraToCenterDistance();
+    return static_cast<float>(topPoint[3]) / getCameraToCenterDistance();
 }
 
 } // namespace mbgl

--- a/src/mbgl/programs/background_program.cpp
+++ b/src/mbgl/programs/background_program.cpp
@@ -19,8 +19,8 @@ BackgroundPatternProgram::layoutUniformValues(mat4 matrix,
                                               const CrossfadeParameters& fading,
                                               const UnwrappedTileID& tileID,
                                               const TransformState& state) {
-    int32_t tileSizeAtNearestZoom = util::tileSize * state.zoomScale(state.getIntegerZoom() - tileID.canonical.z);
-    int32_t pixelX = tileSizeAtNearestZoom * (tileID.canonical.x + tileID.wrap * state.zoomScale(tileID.canonical.z));
+    int32_t tileSizeAtNearestZoom = static_cast<int32_t>(util::tileSize_D * state.zoomScale(state.getIntegerZoom() - tileID.canonical.z));
+    int32_t pixelX = static_cast<int32_t>(tileSizeAtNearestZoom * (tileID.canonical.x + tileID.wrap * state.zoomScale(tileID.canonical.z)));
     int32_t pixelY = tileSizeAtNearestZoom * tileID.canonical.y;
 
     return {
@@ -36,8 +36,8 @@ BackgroundPatternProgram::layoutUniformValues(mat4 matrix,
         uniforms::scale_a::Value( fading.fromScale ),
         uniforms::scale_b::Value( fading.toScale ),
         uniforms::mix::Value( fading.t ),
-        uniforms::pixel_coord_upper::Value( std::array<float, 2> {{ float(pixelX >> 16), float(pixelY >> 16) }}),
-        uniforms::pixel_coord_lower::Value( std::array<float, 2> {{ float(pixelX & 0xFFFF), float(pixelY & 0xFFFF)}}),
+        uniforms::pixel_coord_upper::Value( std::array<float, 2> {{ static_cast<float>(pixelX >> 16), static_cast<float>(pixelY >> 16) }}),
+        uniforms::pixel_coord_lower::Value( std::array<float, 2> {{ static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF)}}),
         uniforms::tile_units_to_pixels::Value( 1.0f / tileID.pixelsToTileUnits(1.0f, state.getIntegerZoom()) ),
     };
 }

--- a/src/mbgl/programs/fill_extrusion_program.cpp
+++ b/src/mbgl/programs/fill_extrusion_program.cpp
@@ -55,8 +55,8 @@ FillExtrusionPatternProgram::layoutUniformValues(mat4 matrix,
                                            const EvaluatedLight& light,
                                            const float verticalGradient) {
     const auto tileRatio = 1 / tileID.pixelsToTileUnits(1, state.getIntegerZoom());
-    int32_t tileSizeAtNearestZoom = util::tileSize * state.zoomScale(state.getIntegerZoom() - tileID.canonical.z);
-    int32_t pixelX = tileSizeAtNearestZoom * (tileID.canonical.x + tileID.wrap * state.zoomScale(tileID.canonical.z));
+    int32_t tileSizeAtNearestZoom = static_cast<int32_t>(util::tileSize_D * state.zoomScale(state.getIntegerZoom() - tileID.canonical.z));
+    int32_t pixelX = static_cast<int32_t>(tileSizeAtNearestZoom * (tileID.canonical.x + tileID.wrap * state.zoomScale(tileID.canonical.z)));
     int32_t pixelY = tileSizeAtNearestZoom * tileID.canonical.y;
 
     return {
@@ -65,8 +65,8 @@ FillExtrusionPatternProgram::layoutUniformValues(mat4 matrix,
         uniforms::scale::Value( {{pixelRatio, tileRatio, crossfade.fromScale, crossfade.toScale}} ),
         uniforms::texsize::Value( atlasSize ),
         uniforms::fade::Value( crossfade.t ),
-        uniforms::pixel_coord_upper::Value( std::array<float, 2>{{ float(pixelX >> 16), float(pixelY >> 16) }} ),
-        uniforms::pixel_coord_lower::Value( std::array<float, 2>{{ float(pixelX & 0xFFFF), float(pixelY & 0xFFFF) }} ),
+        uniforms::pixel_coord_upper::Value( std::array<float, 2>{{ static_cast<float>(pixelX >> 16), static_cast<float>(pixelY >> 16) }} ),
+        uniforms::pixel_coord_lower::Value( std::array<float, 2>{{ static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF) }} ),
         uniforms::height_factor::Value( heightFactor ),
         uniforms::lightcolor::Value( lightColor(light) ),
         uniforms::lightpos::Value( lightPosition(light, state) ),

--- a/src/mbgl/programs/fill_program.cpp
+++ b/src/mbgl/programs/fill_program.cpp
@@ -19,8 +19,8 @@ FillPatternProgram::layoutUniformValues(mat4 matrix,
                                         const TransformState& state,
                                         const float pixelRatio) {
     const auto tileRatio = 1 / tileID.pixelsToTileUnits(1, state.getIntegerZoom());
-    int32_t tileSizeAtNearestZoom = util::tileSize * state.zoomScale(state.getIntegerZoom() - tileID.canonical.z);
-    int32_t pixelX = tileSizeAtNearestZoom * (tileID.canonical.x + tileID.wrap * state.zoomScale(tileID.canonical.z));
+    int32_t tileSizeAtNearestZoom = static_cast<int32_t>(util::tileSize_D * state.zoomScale(state.getIntegerZoom() - tileID.canonical.z));
+    int32_t pixelX = static_cast<int32_t>(tileSizeAtNearestZoom * (tileID.canonical.x + tileID.wrap * state.zoomScale(tileID.canonical.z)));
     int32_t pixelY = tileSizeAtNearestZoom * tileID.canonical.y;
 
     return {
@@ -29,8 +29,8 @@ FillPatternProgram::layoutUniformValues(mat4 matrix,
         uniforms::texsize::Value( atlasSize ),
         uniforms::scale::Value({ {pixelRatio, tileRatio, crossfade.fromScale, crossfade.toScale} } ),
         uniforms::fade::Value( crossfade.t ),
-        uniforms::pixel_coord_upper::Value( std::array<float, 2> {{ float(pixelX >> 16), float(pixelY >> 16) }}),
-        uniforms::pixel_coord_lower::Value( std::array<float, 2> {{ float(pixelX & 0xFFFF), float(pixelY & 0xFFFF) }} )
+        uniforms::pixel_coord_upper::Value( std::array<float, 2> {{ static_cast<float>(pixelX >> 16), static_cast<float>(pixelY >> 16) }}),
+        uniforms::pixel_coord_lower::Value( std::array<float, 2> {{ static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF) }} )
     };
 }
 

--- a/src/mbgl/programs/line_program.cpp
+++ b/src/mbgl/programs/line_program.cpp
@@ -26,7 +26,7 @@ Values makeValues(const style::LinePaintProperties::PossiblyEvaluated& propertie
                                   properties.get<LineTranslateAnchor>(),
                                   state)
         ),
-        uniforms::ratio::Value( 1.0f / tile.id.pixelsToTileUnits(1.0, state.getZoom()) ),
+        uniforms::ratio::Value( 1.0f / tile.id.pixelsToTileUnits(1.0f, static_cast<float>(state.getZoom())) ),
         uniforms::units_to_pixels::Value({ {1.0f / pixelsToGLUnits[0], 1.0f / pixelsToGLUnits[1]} }),
         uniforms::device_pixel_ratio::Value( pixelRatio ),
         std::forward<Args>(args)...

--- a/src/mbgl/programs/symbol_program.cpp
+++ b/src/mbgl/programs/symbol_program.cpp
@@ -49,7 +49,7 @@ Values makeValues(const bool isText,
     std::array<float, 2> extrudeScale;
 
     if (values.pitchAlignment == AlignmentType::Map) {
-        extrudeScale.fill(tile.id.pixelsToTileUnits(1, state.getZoom()));
+        extrudeScale.fill(tile.id.pixelsToTileUnits(1.f, static_cast<float>(state.getZoom())));
     } else {
         extrudeScale = {{
             pixelsToGLUnits[0] * state.getCameraToCenterDistance(),
@@ -57,7 +57,7 @@ Values makeValues(const bool isText,
         }};
     }
 
-    const float pixelsToTileUnits = tile.id.pixelsToTileUnits(1.0, state.getZoom());
+    const float pixelsToTileUnits = tile.id.pixelsToTileUnits(1.f, static_cast<float>(state.getZoom()));
     const bool pitchWithMap = values.pitchAlignment == style::AlignmentType::Map;
     const bool rotateWithMap = values.rotationAlignment == style::AlignmentType::Map;
 
@@ -137,8 +137,8 @@ SymbolSDFProgram<Name, PaintProperties>::layoutUniformValues(const bool isText,
                                                        const float symbolFadeChange,
                                                        const SymbolSDFPart part) {
     const float gammaScale = (values.pitchAlignment == AlignmentType::Map
-                              ? std::cos(state.getPitch()) * state.getCameraToCenterDistance()
-                              : 1.0);
+                              ? static_cast<float>(std::cos(state.getPitch())) * state.getCameraToCenterDistance()
+                              : 1.0f);
 
     return makeValues<SymbolSDFProgram<Name, PaintProperties>::LayoutUniformValues>(
         isText,

--- a/src/mbgl/renderer/buckets/fill_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_bucket.cpp
@@ -5,7 +5,16 @@
 #include <mbgl/renderer/layers/render_fill_layer.hpp>
 #include <mbgl/util/math.hpp>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#endif
+
 #include <mapbox/earcut.hpp>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include <cassert>
 

--- a/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
@@ -6,7 +6,16 @@
 #include <mbgl/util/math.hpp>
 #include <mbgl/util/constants.hpp>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#endif
+
 #include <mapbox/earcut.hpp>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include <cassert>
 

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -72,7 +72,7 @@ void RenderBackgroundLayer::render(PaintParameters& parameters) {
             program.computeAllUniformValues(std::forward<decltype(uniformValues)>(uniformValues),
                                             paintAttributeData,
                                             properties,
-                                            parameters.state.getZoom());
+                                            static_cast<float>(parameters.state.getZoom()));
         const auto allAttributeBindings = program.computeAllAttributeBindings(
             *parameters.staticData.tileVertexBuffer,
             paintAttributeData,

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -96,15 +96,15 @@ void RenderCircleLayer::render(PaintParameters& parameters) {
                                                               parameters.state)),
                 uniforms::scale_with_map::Value(scaleWithMap),
                 uniforms::extrude_scale::Value(
-                    pitchWithMap ? std::array<float, 2>{{tile.id.pixelsToTileUnits(1, parameters.state.getZoom()),
-                                                         tile.id.pixelsToTileUnits(1, parameters.state.getZoom())}}
+                    pitchWithMap ? std::array<float, 2>{{tile.id.pixelsToTileUnits(1.0f, static_cast<float>(parameters.state.getZoom())),
+                                                         tile.id.pixelsToTileUnits(1.0f, static_cast<float>(parameters.state.getZoom()))}}
                                  : parameters.pixelsToGLUnits),
                 uniforms::device_pixel_ratio::Value(parameters.pixelRatio),
                 uniforms::camera_to_center_distance::Value(parameters.state.getCameraToCenterDistance()),
                 uniforms::pitch_with_map::Value(pitchWithMap)),
             paintPropertyBinders,
             evaluated,
-            parameters.state.getZoom());
+            static_cast<float>(parameters.state.getZoom()));
         const auto& allAttributeBindings =
             CircleProgram::computeAllAttributeBindings(*circleBucket.vertexBuffer, paintPropertyBinders, evaluated);
 
@@ -177,7 +177,7 @@ bool RenderCircleLayer::queryIntersectsFeature(const GeometryCoordinates& queryG
             queryGeometry,
             evaluated.get<style::CircleTranslate>(),
             evaluated.get<style::CircleTranslateAnchor>(),
-            transformState.getBearing(),
+            static_cast<float>(transformState.getBearing()),
             pixelsToTileUnits).value_or(queryGeometry);
 
     // Evaluate functions
@@ -206,9 +206,9 @@ bool RenderCircleLayer::queryIntersectsFeature(const GeometryCoordinates& queryG
             auto pitchScale = evaluated.evaluate<style::CirclePitchScale>(zoom, feature);
             auto pitchAlignment = evaluated.evaluate<style::CirclePitchAlignment>(zoom, feature);
             if (pitchScale == CirclePitchScaleType::Viewport && pitchAlignment == AlignmentType::Map) {
-                adjustedSize *= center[3] / transformState.getCameraToCenterDistance();
+                adjustedSize *= static_cast<float>(center[3] / transformState.getCameraToCenterDistance());
             } else if (pitchScale == CirclePitchScaleType::Map && pitchAlignment == AlignmentType::Viewport) {
-                adjustedSize *= transformState.getCameraToCenterDistance() / center[3];
+                adjustedSize *= static_cast<float>(transformState.getCameraToCenterDistance() / center[3]);
             }
 
             if (util::polygonIntersectsBufferedPoint(transformedQueryGeometry, transformedPoint, adjustedSize)) return true;

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -97,7 +97,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
             uniformValues,
             paintPropertyBinders,
             evaluated_,
-            parameters.state.getZoom()
+            static_cast<float>(parameters.state.getZoom())
         );
         const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
             *tileBucket.vertexBuffer,
@@ -199,7 +199,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
                         tile.id,
                         parameters.state,
                         evaluated.get<FillExtrusionOpacity>(),
-                        -std::pow(2, tile.id.canonical.z) / util::tileSize / 8.0f,
+                        static_cast<float>(-std::pow(2, tile.id.canonical.z) / util::tileSize_D / 8.0),
                         parameters.pixelRatio,
                         parameters.evaluatedLight,
                         evaluated.get<FillExtrusionVerticalGradient>()
@@ -235,7 +235,7 @@ bool RenderFillExtrusionLayer::queryIntersectsFeature(const GeometryCoordinates&
             queryGeometry,
             evaluated.get<style::FillExtrusionTranslate>(),
             evaluated.get<style::FillExtrusionTranslateAnchor>(),
-            transformState.getBearing(),
+            static_cast<float>(transformState.getBearing()),
             pixelsToTileUnits);
 
     return util::polygonIntersectsMultiPolygon(translatedQueryGeometry.value_or(queryGeometry), feature.getGeometries());

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -103,7 +103,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
                     },
                     paintPropertyBinders,
                     evaluated,
-                    parameters.state.getZoom()
+                    static_cast<float>(parameters.state.getZoom())
                 );
                 const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
                     *bucket.vertexBuffer,
@@ -196,7 +196,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
                     ),
                     paintPropertyBinders,
                     evaluated,
-                    parameters.state.getZoom()
+                    static_cast<float>(parameters.state.getZoom())
                 );
                 const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
                     *bucket.vertexBuffer,
@@ -254,7 +254,7 @@ bool RenderFillLayer::queryIntersectsFeature(const GeometryCoordinates& queryGeo
             queryGeometry,
             evaluated.get<style::FillTranslate>(),
             evaluated.get<style::FillTranslateAnchor>(),
-            transformState.getBearing(),
+            static_cast<float>(transformState.getBearing()),
             pixelsToTileUnits);
 
     return util::polygonIntersectsMultiPolygon(translatedQueryGeometry.value_or(queryGeometry), feature.getGeometries());

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -106,7 +106,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters) {
             auto& bucket = static_cast<HeatmapBucket&>(*renderData->bucket);
             const auto& evaluated = getEvaluated<HeatmapLayerProperties>(renderData->layerProperties);
 
-            const auto extrudeScale = tile.id.pixelsToTileUnits(1, parameters.state.getZoom());
+            const auto extrudeScale = tile.id.pixelsToTileUnits(1.0f, static_cast<float>(parameters.state.getZoom()));
 
             const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
 
@@ -119,7 +119,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters) {
                     uniforms::heatmap::extrude_scale::Value(extrudeScale)},
                 paintPropertyBinders,
                 evaluated,
-                parameters.state.getZoom());
+                static_cast<float>(parameters.state.getZoom()));
             const auto allAttributeBindings =
                 HeatmapProgram::computeAllAttributeBindings(*bucket.vertexBuffer, paintPropertyBinders, evaluated);
 
@@ -159,7 +159,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters) {
                     getEvaluated<HeatmapLayerProperties>(evaluatedProperties).get<HeatmapOpacity>())},
             paintAttributeData,
             properties,
-            parameters.state.getZoom());
+            static_cast<float>(parameters.state.getZoom()));
         const auto allAttributeBindings = HeatmapTextureProgram::computeAllAttributeBindings(
             *parameters.staticData.heatmapTextureVertexBuffer, paintAttributeData, properties);
 
@@ -199,10 +199,10 @@ void RenderHeatmapLayer::updateColorRamp() {
 
     for (uint32_t i = 0; i < length; i += 4) {
         const auto color = colorValue.evaluate(static_cast<double>(i) / length);
-        colorRamp.data[i + 0] = std::floor(color.r * 255);
-        colorRamp.data[i + 1] = std::floor(color.g * 255);
-        colorRamp.data[i + 2] = std::floor(color.b * 255);
-        colorRamp.data[i + 3] = std::floor(color.a * 255);
+        colorRamp.data[i + 0] = static_cast<uint8_t>(std::floor(color.r * 255.f));
+        colorRamp.data[i + 1] = static_cast<uint8_t>(std::floor(color.g * 255.f));
+        colorRamp.data[i + 2] = static_cast<uint8_t>(std::floor(color.b * 255.f));
+        colorRamp.data[i + 3] = static_cast<uint8_t>(std::floor(color.a * 255.f));
     }
 
     if (colorRampTexture) {

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -41,8 +41,8 @@ std::array<float, 2> RenderHillshadeLayer::getLatRange(const UnwrappedTileID& id
 
 std::array<float, 2> RenderHillshadeLayer::getLight(const PaintParameters& parameters) {
     const auto& evaluated = static_cast<const HillshadeLayerProperties&>(*evaluatedProperties).evaluated;
-    float azimuthal = evaluated.get<HillshadeIlluminationDirection>() * util::DEG2RAD;
-    if (evaluated.get<HillshadeIlluminationAnchor>() == HillshadeIlluminationAnchorType::Viewport) azimuthal = azimuthal - parameters.state.getBearing();
+    float azimuthal = evaluated.get<HillshadeIlluminationDirection>() * util::DEG2RAD_F;
+    if (evaluated.get<HillshadeIlluminationAnchor>() == HillshadeIlluminationAnchorType::Viewport) azimuthal = azimuthal - static_cast<float>(parameters.state.getBearing());
     return {{evaluated.get<HillshadeExaggeration>(), azimuthal}};
 }
 
@@ -100,7 +100,7 @@ void RenderHillshadeLayer::render(PaintParameters& parameters) {
             },
             paintAttributeData,
             evaluated,
-            parameters.state.getZoom());
+            static_cast<float>(parameters.state.getZoom()));
         const auto allAttributeBindings =
             HillshadeProgram::computeAllAttributeBindings(vertexBuffer, paintAttributeData, evaluated);
 
@@ -155,13 +155,13 @@ void RenderHillshadeLayer::render(PaintParameters& parameters) {
                 HillshadePrepareProgram::LayoutUniformValues{
                     uniforms::matrix::Value(mat),
                     uniforms::dimension::Value({{stride, stride}}),
-                    uniforms::zoom::Value(float(tile.id.canonical.z)),
-                    uniforms::maxzoom::Value(float(maxzoom)),
+                    uniforms::zoom::Value(static_cast<float>(tile.id.canonical.z)),
+                    uniforms::maxzoom::Value(static_cast<float>(maxzoom)),
                     uniforms::unpack::Value(bucket.getDEMData().getUnpackVector()),
                 },
                 paintAttributeData,
                 properties,
-                parameters.state.getZoom());
+                static_cast<float>(parameters.state.getZoom()));
             const auto allAttributeBindings = HillshadePrepareProgram::computeAllAttributeBindings(
                 *parameters.staticData.rasterVertexBuffer, paintAttributeData, properties);
 

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -118,7 +118,7 @@ void RenderLineLayer::render(PaintParameters& parameters) {
                 programInstance.computeAllUniformValues(std::forward<decltype(uniformValues)>(uniformValues),
                                                         paintPropertyBinders,
                                                         evaluated,
-                                                        parameters.state.getZoom());
+                                                        static_cast<float>(parameters.state.getZoom()));
             const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
                 *bucket.vertexBuffer,
                 paintPropertyBinders,
@@ -157,7 +157,7 @@ void RenderLineLayer::render(PaintParameters& parameters) {
                                                      dashPatternTexture.getFrom(),
                                                      dashPatternTexture.getTo(),
                                                      crossfade,
-                                                     dashPatternTexture.getSize().width),
+                                                     static_cast<float>(dashPatternTexture.getSize().width)),
                  {},
                  {},
                  LineSDFProgram::TextureBindings{
@@ -263,7 +263,7 @@ bool RenderLineLayer::queryIntersectsFeature(const GeometryCoordinates& queryGeo
             queryGeometry,
             evaluated.get<style::LineTranslate>(),
             evaluated.get<style::LineTranslateAnchor>(),
-            transformState.getBearing(),
+            static_cast<float>(transformState.getBearing()),
             pixelsToTileUnits);
 
     // Evaluate function
@@ -297,10 +297,10 @@ void RenderLineLayer::updateColorRamp() {
 
     for (uint32_t i = 0; i < length; i += 4) {
         const auto color = colorValue.evaluate(static_cast<double>(i) / length);
-        colorRamp.data[i] = std::floor(color.r * 255);
-        colorRamp.data[i + 1] = std::floor(color.g * 255);
-        colorRamp.data[i + 2] = std::floor(color.b * 255);
-        colorRamp.data[i + 3] = std::floor(color.a * 255);
+        colorRamp.data[i] = static_cast<uint8_t>(std::floor(color.r * 255.f));
+        colorRamp.data[i + 1] = static_cast<uint8_t>(std::floor(color.g * 255.f));
+        colorRamp.data[i + 2] = static_cast<uint8_t>(std::floor(color.b * 255.f));
+        colorRamp.data[i + 3] = static_cast<uint8_t>(std::floor(color.a * 255.f));
     }
 
     if (colorRampTexture) {

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -67,7 +67,7 @@ static float contrastFactor(float contrast) {
 }
 
 static std::array<float, 3> spinWeights(float spin) {
-    spin *= util::DEG2RAD;
+    spin *= util::DEG2RAD_F;
     float s = std::sin(spin);
     float c = std::cos(spin);
     std::array<float, 3> spin_weights = {{
@@ -116,7 +116,7 @@ void RenderRasterLayer::render(PaintParameters& parameters) {
             },
             paintAttributeData,
             evaluated,
-            parameters.state.getZoom());
+            static_cast<float>(parameters.state.getZoom()));
         const auto allAttributeBindings =
             RasterProgram::computeAllAttributeBindings(vertexBuffer, paintAttributeData, evaluated);
 

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -212,7 +212,7 @@ void drawText(const DrawFn& draw,
 
     if (bucket.iconsInText) {
         const ZoomEvaluatedSize partiallyEvaluatedTextSize =
-            bucket.textSizeBinder->evaluateForZoom(parameters.state.getZoom());
+            bucket.textSizeBinder->evaluateForZoom(static_cast<float>(parameters.state.getZoom()));
         const bool transformed = values.rotationAlignment == AlignmentType::Map || parameters.state.getPitch() != 0;
         const Size& iconTexSize = tile.getIconAtlasTexture().size;
         const gfx::TextureBinding iconTextureBinding{
@@ -363,7 +363,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters) {
             *symbolSizeBinder,
             binders,
             paintProperties,
-            parameters.state.getZoom()
+            static_cast<float>(parameters.state.getZoom())
         );
 
         const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
@@ -462,8 +462,8 @@ void RenderSymbolLayer::render(PaintParameters& parameters) {
 
             static const style::Properties<>::PossiblyEvaluated properties{};
             static const CollisionBoxProgram::Binders paintAttributeData(properties, 0);
-            auto pixelRatio = tile.id.pixelsToTileUnits(1, parameters.state.getZoom());
-            const float scale = std::pow(2, parameters.state.getZoom() - tile.getOverscaledTileID().overscaledZ);
+            const auto pixelRatio = tile.id.pixelsToTileUnits(1.0f, static_cast<float>(parameters.state.getZoom()));
+            const auto scale = static_cast<float>(std::pow(2, parameters.state.getZoom() - tile.getOverscaledTileID().overscaledZ));
             std::array<float,2> extrudeScale =
                 {{
                     parameters.pixelsToGLUnits[0] / (pixelRatio * scale),
@@ -498,7 +498,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters) {
                     paintAttributeData,
                     properties,
                     CollisionBoxProgram::TextureBindings{},
-                    parameters.state.getZoom(),
+                    static_cast<float>(parameters.state.getZoom()),
                     getID());
             }
             if (hasCollisionCircle) {
@@ -516,7 +516,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters) {
                                  ? tile.translatedMatrix(values.translate, values.translateAnchor, parameters.state)
                                  : tile.matrix)),
                         uniforms::extrude_scale::Value(extrudeScale),
-                        uniforms::overscale_factor::Value(float(tile.getOverscaledTileID().overscaleFactor())),
+                        uniforms::overscale_factor::Value(static_cast<float>(tile.getOverscaledTileID().overscaleFactor())),
                         uniforms::camera_to_center_distance::Value(parameters.state.getCameraToCenterDistance())
                     },
                     *collisionCircle->vertexBuffer,
@@ -526,7 +526,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters) {
                     paintAttributeData,
                     properties,
                     CollisionCircleProgram::TextureBindings{},
-                    parameters.state.getZoom(),
+                    static_cast<float>(parameters.state.getZoom()),
                     getID());
             }
         };

--- a/src/mbgl/renderer/paint_parameters.cpp
+++ b/src/mbgl/renderer/paint_parameters.cpp
@@ -149,7 +149,7 @@ void PaintParameters::renderTileClippingMasks(const RenderTiles& renderTiles) {
                          },
                          paintAttributeData,
                          properties,
-                         state.getZoom()),
+                         static_cast<float>(state.getZoom())),
                      ClippingMaskProgram::computeAllAttributeBindings(
                          *staticData.tileVertexBuffer, paintAttributeData, properties),
                      ClippingMaskProgram::TextureBindings{},

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -403,7 +403,7 @@ public:
         const float possiblyRoundedZoom = expression.useIntegerZoom ? std::floor(currentZoom) : currentZoom;
 
         return std::tuple<float>{
-            ::fmax(0.0, ::fmin(1.0, expression.interpolationFactor(zoomRange, possiblyRoundedZoom)))};
+            ::fmax(0.0f, ::fmin(1.0f, expression.interpolationFactor(zoomRange, possiblyRoundedZoom)))};
     }
 
     std::tuple<T> uniformValue(const PossiblyEvaluatedPropertyValue<T>& currentValue) const override {

--- a/src/mbgl/renderer/possibly_evaluated_property_value.hpp
+++ b/src/mbgl/renderer/possibly_evaluated_property_value.hpp
@@ -140,6 +140,16 @@ struct Interpolator<PossiblyEvaluatedPropertyValue<T>> {
             return { a };
         }
     }
+
+    PossiblyEvaluatedPropertyValue<T> operator()(const PossiblyEvaluatedPropertyValue<T>& a,
+                                                 const PossiblyEvaluatedPropertyValue<T>& b,
+                                                 const float t) const {
+        if (a.isConstant() && b.isConstant()) {
+            return { interpolate(*a.constant(), *b.constant(), t) };
+        } else {
+            return { a };
+        }
+    }
 };
 
 } // namespace util

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -151,7 +151,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
     }
 
     const bool zoomChanged =
-        zoomHistory.update(updateParameters->transformState.getZoom(), updateParameters->timePoint);
+        zoomHistory.update(static_cast<float>(updateParameters->transformState.getZoom()), updateParameters->timePoint);
 
     const TransitionOptions transitionOptions =
         isMapModeContinuous ? updateParameters->transitionOptions : TransitionOptions();
@@ -383,7 +383,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
     bool symbolBucketsChanged = false;
     bool symbolBucketsAdded = false;
     std::set<std::string> usedSymbolLayers;
-    auto longitude = updateParameters->transformState.getLatLng().longitude();
+    const auto longitude = static_cast<float>(updateParameters->transformState.getLatLng().longitude());
     for (auto it = layersNeedPlacement.crbegin(); it != layersNeedPlacement.crend(); ++it) {
         RenderLayer& layer = *it;
         auto result = crossTileSymbolIndex.addLayer(layer, longitude);
@@ -407,7 +407,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
         }
 
         renderTreeParameters->placementChanged = !placementController.placementIsRecent(
-            updateParameters->timePoint, updateParameters->transformState.getZoom(), placementUpdatePeriodOverride);
+            updateParameters->timePoint, static_cast<float>(updateParameters->transformState.getZoom()), placementUpdatePeriodOverride);
         symbolBucketsChanged |= renderTreeParameters->placementChanged;
         if (renderTreeParameters->placementChanged) {
             Mutable<Placement> placement = Placement::create(updateParameters, placementController.getPlacement());

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -32,8 +32,8 @@ mat4 RenderTile::translateVtxMatrix(const mat4& tileMatrix,
     mat4 vtxMatrix;
 
     const float angle = inViewportPixelUnits ?
-        (anchor == TranslateAnchorType::Map ? state.getBearing() : 0) :
-        (anchor == TranslateAnchorType::Viewport ? -state.getBearing() : 0);
+        (anchor == TranslateAnchorType::Map ? static_cast<float>(state.getBearing()) : 0.0f) :
+        (anchor == TranslateAnchorType::Viewport ? static_cast<float>(-state.getBearing()) : 0.0f);
 
     Point<float> translate = util::rotate(Point<float>{ translation[0], translation[1] }, angle);
 
@@ -41,8 +41,8 @@ mat4 RenderTile::translateVtxMatrix(const mat4& tileMatrix,
         matrix::translate(vtxMatrix, tileMatrix, translate.x, translate.y, 0);
     } else {
         matrix::translate(vtxMatrix, tileMatrix,
-                          id.pixelsToTileUnits(translate.x, state.getZoom()),
-                          id.pixelsToTileUnits(translate.y, state.getZoom()),
+                          id.pixelsToTileUnits(translate.x, static_cast<float>(state.getZoom())),
+                          id.pixelsToTileUnits(translate.y, static_cast<float>(state.getZoom())),
                           0);
     }
 
@@ -156,7 +156,7 @@ void RenderTile::finishRender(PaintParameters& parameters) const {
                                                            uniforms::overlay_scale::Value(1.0f)},
                          paintAttributeData,
                          properties,
-                         parameters.state.getZoom()),
+                         static_cast<float>(parameters.state.getZoom())),
                      allAttributeBindings,
                      DebugProgram::TextureBindings{textures::image::Value{debugBucket->texture->getResource()}},
                      "text-outline");
@@ -176,7 +176,7 @@ void RenderTile::finishRender(PaintParameters& parameters) const {
                                                            uniforms::overlay_scale::Value(1.0f)},
                          paintAttributeData,
                          properties,
-                         parameters.state.getZoom()),
+                         static_cast<float>(parameters.state.getZoom())),
                      allAttributeBindings,
                      DebugProgram::TextureBindings{textures::image::Value{debugBucket->texture->getResource()}},
                      "text");
@@ -203,7 +203,7 @@ void RenderTile::finishRender(PaintParameters& parameters) const {
                                                   uniforms::overlay_scale::Value(1.0f)},
                 paintAttributeData,
                 properties,
-                parameters.state.getZoom()),
+                static_cast<float>(parameters.state.getZoom())),
             DebugProgram::computeAllAttributeBindings(
                 *parameters.staticData.tileVertexBuffer, paintAttributeData, properties),
             DebugProgram::TextureBindings{textures::image::Value{debugBucket->texture->getResource()}},

--- a/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
+++ b/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
@@ -45,7 +45,7 @@ void RenderCustomGeometrySource::update(Immutable<style::Source::Impl> baseImpl_
                        needsRelayout,
                        parameters,
                        *baseImpl,
-                       util::tileSize,
+                       util::tileSize_I,
                        impl().getZoomRange(),
                        {},
                        [&](const OverscaledTileID& tileID) {

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -111,7 +111,7 @@ void RenderGeoJSONSource::update(Immutable<style::Source::Impl> baseImpl_,
                        needsRelayout,
                        parameters,
                        *baseImpl,
-                       util::tileSize,
+                       util::tileSize_I,
                        impl().getZoomRange(),
                        optional<LatLngBounds>{},
                        [&, data_](const OverscaledTileID& tileID) {

--- a/src/mbgl/renderer/sources/render_image_source.cpp
+++ b/src/mbgl/renderer/sources/render_image_source.cpp
@@ -57,7 +57,7 @@ void ImageSourceRenderData::render(PaintParameters& parameters) const {
                                                                    uniforms::overlay_scale::Value(1.0f)},
                                  paintAttributeData,
                                  properties,
-                                 parameters.state.getZoom()),
+                                 static_cast<float>(parameters.state.getZoom())),
                              DebugProgram::computeAllAttributeBindings(
                                  *parameters.staticData.tileVertexBuffer, paintAttributeData, properties),
                              DebugProgram::TextureBindings{textures::image::Value{debugTexture->getResource()}},
@@ -150,17 +150,17 @@ void RenderImageSource::update(Immutable<style::Source::Impl> baseImpl_,
    }
 
     // Calculate the optimum zoom level to determine the tile ids to use for transforms
-    auto dx = nePoint.x - swPoint.x;
-    auto dy = nePoint.y - swPoint.y;
-    auto dMax = std::max(dx, dy);
-    double zoom = std::max(0.0, std::floor(-util::log2(dMax)));
+    const auto dx = nePoint.x - swPoint.x;
+    const auto dy = nePoint.y - swPoint.y;
+    const auto dMax = std::max(dx, dy);
+    const auto zoom = static_cast<uint8_t>(std::max(0.0, std::floor(-util::log2(dMax))));
 
     // Only enable if the long side of the image is > 2 pixels. Resulting in a
     // display of at least 2 x 1 px image
     // A tile coordinate unit represents the length of one tile (tileSize) at a given zoom.
     // To convert a tile coordinate to pixels, multiply by tileSize.
     // Here dMax is in z0 tile units, so we also scale by 2^z to match current zoom.
-    enabled = dMax * std::pow(2.0, transformState.getZoom()) * util::tileSize > 2.0;
+    enabled = dMax * std::pow(2.0, transformState.getZoom()) * util::tileSize_D > 2.0;
     if (!enabled) {
         return;
     }
@@ -174,7 +174,7 @@ void RenderImageSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     bool hasVisibleTile = false;
     // Add additional wrapped tile ids if neccessary
-    auto idealTiles = util::tileCover(transformState, transformState.getZoom());
+    auto idealTiles = util::tileCover(transformState, static_cast<uint8_t>(transformState.getZoom()));
     for (auto tile : idealTiles) {
         if (tile.wrap != 0 && tileCover[0].canonical.isChildOf(tile.canonical)) {
             tileIds.emplace_back(tile.wrap, tileCover[0].canonical);

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -56,7 +56,7 @@ void RenderRasterDEMSource::onTileChanged(Tile& tile){
 
     if (tile.isRenderable() && demtile.neighboringTiles != DEMTileNeighbors::Complete) {
         const CanonicalTileID canonical = tile.id.canonical;
-        const uint32_t dim = std::pow(2, canonical.z);
+        const auto dim = static_cast<uint32_t>(std::pow(2, canonical.z));
         const uint32_t px = (canonical.x - 1 + dim) % dim;
         const int pxw = canonical.x == 0 ? tile.id.wrap - 1 : tile.id.wrap;
         const uint32_t nx = (canonical.x + 1 + dim) % dim;

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -59,7 +59,7 @@ std::unique_ptr<RenderItem> RenderTileSource::createRenderItem() {
 }
 
 void RenderTileSource::prepare(const SourcePrepareParameters& parameters) {
-    bearing = parameters.transform.state.getBearing();
+    bearing = static_cast<float>(parameters.transform.state.getBearing());
     filteredRenderTiles = nullptr;
     renderTilesSortedByY = nullptr;
     auto tiles = makeMutable<std::vector<RenderTile>>();
@@ -97,8 +97,8 @@ RenderTiles RenderTileSource::getRenderTiles() const {
 RenderTiles RenderTileSource::getRenderTilesSortedByYPosition() const {
     if (!renderTilesSortedByY) {
         const auto comp = [bearing = this->bearing](const RenderTile& a, const RenderTile& b) {
-            Point<float> pa(a.id.canonical.x, a.id.canonical.y);
-            Point<float> pb(b.id.canonical.x, b.id.canonical.y);
+            Point<float> pa(static_cast<float>(a.id.canonical.x), static_cast<float>(a.id.canonical.y));
+            Point<float> pb(static_cast<float>(b.id.canonical.x), static_cast<float>(b.id.canonical.y));
 
             auto par = util::rotate(pa, bearing);
             auto pbr = util::rotate(pb, bearing);

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -26,7 +26,7 @@ void RenderVectorSource::updateInternal(const Tileset& tileset,
                        needsRelayout,
                        parameters,
                        *baseImpl,
-                       util::tileSize,
+                       util::tileSize_I,
                        tileset.zoomRange,
                        tileset.bounds,
                        [&](const OverscaledTileID& tileID) {

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -82,7 +82,7 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
         return;
     }
 
-    handleWrapJump(parameters.transformState.getLatLng().longitude());
+    handleWrapJump(static_cast<float>(parameters.transformState.getLatLng().longitude()));
 
     const auto type = sourceImpl.type;
     // Determine the overzooming/underzooming amounts and required tiles.
@@ -213,10 +213,11 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
     }
 
     if (type != SourceType::Annotations) {
-        size_t conservativeCacheSize =
-            std::max(static_cast<float>(parameters.transformState.getSize().width) / tileSize, 1.0f) *
-            std::max(static_cast<float>(parameters.transformState.getSize().height) / tileSize, 1.0f) *
-            (parameters.transformState.getMaxZoom() - parameters.transformState.getMinZoom() + 1) * 0.5;
+        auto conservativeCacheSize = static_cast<size_t>(
+            std::max(static_cast<double>(parameters.transformState.getSize().width) / tileSize, 1.0) *
+            std::max(static_cast<double>(parameters.transformState.getSize().height) / tileSize, 1.0) *
+            (parameters.transformState.getMaxZoom() - parameters.transformState.getMinZoom() + 1) * 0.5
+        );
         cache.setSize(conservativeCacheSize);
     }
 
@@ -280,8 +281,8 @@ void TilePyramid::handleWrapJump(float lng) {
     // This enables us to reuse the tiles at more ideal locations and prevent flickering.
 
     const float lngDifference = lng - prevLng;
-    const float worldDifference = lngDifference / 360;
-    const int wrapDelta = std::round(worldDifference);
+    const float worldDifference = lngDifference / 360.f;
+    const auto wrapDelta = static_cast<int16_t>(std::round(worldDifference));
     prevLng = lng;
 
     if (wrapDelta) {
@@ -334,8 +335,8 @@ std::unordered_map<std::string, std::vector<Feature>> TilePyramid::queryRendered
         const UnwrappedTileID& id = entry.first;
         Tile& tile = entry.second;
 
-        const float scale = transformState.getScale() / (1 << id.canonical.z); // equivalent to std::pow(2, transformState.getZoom() - id.canonical.z);
-        auto queryPadding = maxPitchScaleFactor * tile.getQueryPadding(layers) * util::EXTENT / util::tileSize / scale;
+        const auto scale = static_cast<float>(transformState.getScale() / (1 << id.canonical.z)); // equivalent to std::pow(2, transformState.getZoom() - id.canonical.z);
+        auto queryPadding = maxPitchScaleFactor * tile.getQueryPadding(layers) * util::EXTENT / util::tileSize_D / scale;
 
         GeometryCoordinate tileSpaceBoundsMin = TileCoordinate::toGeometryCoordinate(id, box.min);
         if (tileSpaceBoundsMin.x - queryPadding >= util::EXTENT || tileSpaceBoundsMin.y - queryPadding >= util::EXTENT) {

--- a/src/mbgl/sprite/sprite_parser.cpp
+++ b/src/mbgl/sprite/sprite_parser.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<style::Image> createStyleImage(const std::string& id,
 
     try {
         return std::make_unique<style::Image>(
-            id, std::move(dstImage), ratio, sdf, std::move(stretchX), std::move(stretchY), content);
+            id, std::move(dstImage), static_cast<float>(ratio), sdf, std::move(stretchX), std::move(stretchY), content);
     } catch (const util::StyleImageException& ex) {
         Log::Error(Event::Sprite, "Can't create image with invalid metadata: %s", ex.what());
         return nullptr;

--- a/src/mbgl/storage/resource.cpp
+++ b/src/mbgl/storage/resource.cpp
@@ -30,7 +30,7 @@ static mapbox::geometry::point<double> getMercCoord(int32_t x, int32_t y, int8_t
 
 static std::string getTileBBox(int32_t x, int32_t y, int8_t z) {
     // Alter the y for the Google/OSM tile scheme.
-    y = std::pow(2, z) - y - 1;
+    y = static_cast<int32_t>(std::pow(2, z)) - y - 1;
 
     auto min = getMercCoord(x * 256, y * 256, z);
     auto max = getMercCoord((x + 1) * 256, (y + 1) * 256, z);

--- a/src/mbgl/style/conversion/function.cpp
+++ b/src/mbgl/style/conversion/function.cpp
@@ -183,7 +183,7 @@ struct Converter<int64_t> {
         if (!converted) {
             return nullopt;
         }
-        return *converted;
+        return static_cast<int64_t>(*converted);
     }
 };
 
@@ -219,7 +219,7 @@ static optional<std::unique_ptr<Expression>> convertLiteral(type::Type type, con
             if (!result) {
                 return nullopt;
             }
-            return literal(double(*result));
+            return literal(static_cast<double>(*result));
         },
         [&](const type::BooleanType&) -> optional<std::unique_ptr<Expression>> {
             auto result = convert<bool>(value, error);
@@ -261,7 +261,7 @@ static optional<std::unique_ptr<Expression>> convertLiteral(type::Type type, con
                             error.message = "value must be an array of numbers";
                             return nullopt;
                         }
-                        result.emplace_back(double(*number));
+                        result.emplace_back(static_cast<double>(*number));
                     }
                     return literal(result);
                 },

--- a/src/mbgl/style/conversion/geojson_options.cpp
+++ b/src/mbgl/style/conversion/geojson_options.cpp
@@ -75,7 +75,7 @@ optional<GeoJSONOptions> Converter<GeoJSONOptions>::operator()(const Convertible
     const auto clusterRadiusValue = objectMember(value, "clusterRadius");
     if (clusterRadiusValue) {
         if (toNumber(*clusterRadiusValue)) {
-            options.clusterRadius = static_cast<double>(*toNumber(*clusterRadiusValue));
+            options.clusterRadius = static_cast<uint16_t>(*toNumber(*clusterRadiusValue));
         } else {
             error.message = "GeoJSON source clusterRadius value must be a number";
             return nullopt;

--- a/src/mbgl/style/conversion/source.cpp
+++ b/src/mbgl/style/conversion/source.cpp
@@ -43,7 +43,7 @@ static optional<std::unique_ptr<Source>> convertRasterSource(const std::string& 
         return nullopt;
     }
 
-    uint16_t tileSize = util::tileSize;
+    uint16_t tileSize = util::tileSize_I;
     auto tileSizeValue = objectMember(value, "tileSize");
     if (tileSizeValue) {
         optional<float> size = toNumber(*tileSizeValue);
@@ -51,7 +51,7 @@ static optional<std::unique_ptr<Source>> convertRasterSource(const std::string& 
             error.message = "invalid tileSize";
             return nullopt;
         }
-        tileSize = *size;
+        tileSize = static_cast<uint16_t>(*size);
     }
 
     return { std::make_unique<RasterSource>(id, std::move(*urlOrTileset), tileSize) };
@@ -65,7 +65,7 @@ static optional<std::unique_ptr<Source>> convertRasterDEMSource(const std::strin
         return nullopt;
     }
 
-    uint16_t tileSize = util::tileSize;
+    uint16_t tileSize = util::tileSize_I;
     auto tileSizeValue = objectMember(value, "tileSize");
     if (tileSizeValue) {
         optional<float> size = toNumber(*tileSizeValue);
@@ -73,7 +73,7 @@ static optional<std::unique_ptr<Source>> convertRasterDEMSource(const std::strin
             error.message = "invalid tileSize";
             return nullopt;
         }
-        tileSize = *size;
+        tileSize = static_cast<uint16_t>(*size);
     }
 
     return { std::make_unique<RasterDEMSource>(id, std::move(*urlOrTileset), tileSize) };

--- a/src/mbgl/style/conversion/tileset.cpp
+++ b/src/mbgl/style/conversion/tileset.cpp
@@ -55,7 +55,7 @@ optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error
             error.message = "invalid minzoom";
             return nullopt;
         }
-        result.zoomRange.min = *minzoom;
+        result.zoomRange.min = static_cast<uint8_t>(*minzoom);
     }
 
     auto maxzoomValue = objectMember(value, "maxzoom");
@@ -65,7 +65,7 @@ optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error
             error.message = "invalid maxzoom";
             return nullopt;
         }
-        result.zoomRange.max = *maxzoom;
+        result.zoomRange.max = static_cast<uint8_t>(*maxzoom);
     }
 
     auto attributionValue = objectMember(value, "attribution");

--- a/src/mbgl/style/expression/assertion.cpp
+++ b/src/mbgl/style/expression/assertion.cpp
@@ -64,7 +64,7 @@ ParseResult Assertion::parse(const Convertible& value, ParsingContext& ctx) {
                 return ParseResult();
             }
             if (n) {
-                N = optional<std::size_t>(*n);
+                N = static_cast<size_t>(*n);
             }
             i++;
         }

--- a/src/mbgl/style/expression/distance.cpp
+++ b/src/mbgl/style/expression/distance.cpp
@@ -1,6 +1,5 @@
 #include <mbgl/style/expression/distance.hpp>
 
-#include <mapbox/cheap_ruler.hpp>
 #include <mapbox/geojson.hpp>
 #include <mapbox/geometry.hpp>
 

--- a/src/mbgl/style/expression/interpolate.cpp
+++ b/src/mbgl/style/expression/interpolate.cpp
@@ -41,12 +41,12 @@ public:
         } else if (it == stops.begin()) {
             return stops.begin()->second->evaluate(params);
         } else {
-            float t = interpolationFactor({ std::prev(it)->first, it->first }, x);
+            double t = interpolationFactor({ std::prev(it)->first, it->first }, x);
 
-            if (t == 0.0f) {
+            if (t == 0.0) {
                 return std::prev(it)->second->evaluate(params);
             }
-            if (t == 1.0f) {
+            if (t == 1.0) {
                 return it->second->evaluate(params);
             }
 

--- a/src/mbgl/style/expression/length.cpp
+++ b/src/mbgl/style/expression/length.cpp
@@ -16,10 +16,10 @@ EvaluationResult Length::evaluate(const EvaluationContext& params) const {
     if (!value) return value;
     return value->match(
         [] (const std::string& s) {
-            return EvaluationResult { double(s.size()) };
+            return EvaluationResult { static_cast<double>(s.size()) };
         },
         [] (const std::vector<Value>& v) {
-            return EvaluationResult { double(v.size()) };
+            return EvaluationResult { static_cast<double>(v.size()) };
         },
         [&] (const auto&) -> EvaluationResult {
             return EvaluationError { "Expected value to be of type string or array, but found " + toString(typeOf(*value)) + " instead." };

--- a/src/mbgl/style/expression/match.cpp
+++ b/src/mbgl/style/expression/match.cpp
@@ -108,7 +108,7 @@ template<> EvaluationResult Match<int64_t>::evaluate(const EvaluationContext& pa
     }
 
     const auto numeric = inputValue->get<double>();
-    int64_t rounded = std::floor(numeric);
+    const auto rounded = static_cast<int64_t>(std::floor(numeric));
     if (numeric == rounded) {
         auto it = branches.find(rounded);
         if (it != branches.end()) {

--- a/src/mbgl/style/expression/number_format.cpp
+++ b/src/mbgl/style/expression/number_format.cpp
@@ -57,7 +57,7 @@ EvaluationResult NumberFormat::evaluate(const EvaluationContext& params) const {
         if (!minDigitsResult) {
             return minDigitsResult.error();
         }
-        evaluatedMinFractionDigits = minDigitsResult->get<double>();
+        evaluatedMinFractionDigits = static_cast<uint8_t>(minDigitsResult->get<double>());
     }
 
     uint8_t evaluatedMaxFractionDigits = 3;
@@ -66,7 +66,7 @@ EvaluationResult NumberFormat::evaluate(const EvaluationContext& params) const {
         if (!maxDigitsResult) {
             return maxDigitsResult.error();
         }
-        evaluatedMaxFractionDigits = maxDigitsResult->get<double>();
+        evaluatedMaxFractionDigits = static_cast<uint8_t>(maxDigitsResult->get<double>());
     }
 
     std::string output;

--- a/src/mbgl/style/expression/util.cpp
+++ b/src/mbgl/style/expression/util.cpp
@@ -29,7 +29,7 @@ Result<Color> rgba(double r, double g, double b, double a) {
             "]: 'a' must be between 0 and 1."
         };
     }
-    return Color(r / 255 * a, g / 255 * a, b / 255 * a, a);
+    return Color(static_cast<float>(r / 255 * a), static_cast<float>(g / 255 * a), static_cast<float>(b / 255 * a), static_cast<float>(a));
 }
 
 } // namespace expression

--- a/src/mbgl/style/expression/value.cpp
+++ b/src/mbgl/style/expression/value.cpp
@@ -49,7 +49,7 @@ void writeJSON(rapidjson::Writer<rapidjson::StringBuffer>& writer, const Value& 
                 [&](bool b) { writer.Bool(b); },
                 [&](double f) {
                     // make sure integer values are stringified without trailing ".0".
-                    f == std::floor(f) ? writer.Int(f) : writer.Double(f);
+                    f == std::floor(f) ? writer.Int(static_cast<int>(f)) : writer.Double(f);
                 },
                 [&](const std::string& s) { writer.String(s); },
                 [&](const Color& c) { writer.String(c.stringify()); },
@@ -270,7 +270,7 @@ optional<Position> ValueConverter<Position>::fromExpressionValue(const Value& v)
 }
 
 Value ValueConverter<Rotation>::toExpressionValue(const mbgl::style::Rotation& value) {
-    return ValueConverter<float>::toExpressionValue(value.getAngle());
+    return ValueConverter<float>::toExpressionValue(static_cast<float>(value.getAngle()));
 }
 
 optional<Rotation> ValueConverter<Rotation>::fromExpressionValue(const Value& v) {

--- a/src/mbgl/style/expression/within.cpp
+++ b/src/mbgl/style/expression/within.cpp
@@ -20,12 +20,12 @@ Point<int64_t> latLonToTileCoodinates(const Point<double>& point, const mbgl::Ca
 
     auto x = (point.x + util::LONGITUDE_MAX) * size / util::DEGREES_MAX;
     auto y =
-        (util::LONGITUDE_MAX - (std::log(std::tan(point.y * M_PI / util::DEGREES_MAX + M_PI / 4.0)) * util::RAD2DEG)) *
+        (util::LONGITUDE_MAX - (std::log(std::tan(point.y * M_PI / util::DEGREES_MAX + M_PI / 4.0)) * util::RAD2DEG_D)) *
         size / util::DEGREES_MAX;
 
     Point<int64_t> p;
-    p.x = (util::clamp<int64_t>(x, std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max()));
-    p.y = (util::clamp<int64_t>(y, std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max()));
+    p.x = (util::clamp<int64_t>(static_cast<int64_t>(x), std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max()));
+    p.y = (util::clamp<int64_t>(static_cast<int64_t>(y), std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max()));
 
     return p;
 };
@@ -94,7 +94,7 @@ MultiPoint<int64_t> getTilePoints(const GeometryCoordinates& points,
                                   const WithinBBox& polyBBox) {
     const int64_t xShift = util::EXTENT * canonical.x;
     const int64_t yShift = util::EXTENT * canonical.y;
-    const auto worldSize = util::EXTENT * std::pow(2, canonical.z);
+    const auto worldSize = static_cast<int64_t>(util::EXTENT * std::pow(2, canonical.z));
     MultiPoint<int64_t> results;
     results.reserve(points.size());
     for (const auto& p : points) {
@@ -125,7 +125,7 @@ MultiLineString<int64_t> getTileLines(const GeometryCollection& lines,
         results.push_back(std::move(lineString));
     }
 
-    const auto worldSize = util::EXTENT * std::pow(2, canonical.z);
+    const auto worldSize = static_cast<int64_t>(util::EXTENT * std::pow(2, canonical.z));
     if (bbox[2] - bbox[0] <= worldSize / 2) {
         bbox = DefaultWithinBBox;
         for (auto& line : results) {

--- a/src/mbgl/style/image_impl.cpp
+++ b/src/mbgl/style/image_impl.cpp
@@ -50,9 +50,9 @@ Image::Impl::Impl(std::string id_,
         throw util::StyleImageException("dimensions may not be zero");
     } else if (pixelRatio <= 0) {
         throw util::StyleImageException("pixelRatio may not be <= 0");
-    } else if (!validateStretch(stretchX, image.size.width)) {
+    } else if (!validateStretch(stretchX, static_cast<float>(image.size.width))) {
         throw util::StyleImageException("stretchX is out of bounds or overlapping");
-    } else if (!validateStretch(stretchY, image.size.height)) {
+    } else if (!validateStretch(stretchY, static_cast<float>(image.size.height))) {
         throw util::StyleImageException("stretchY is out of bounds or overlapping");
     } else if (content && !validateContent(*content, image.size)) {
         throw util::StyleImageException("content area is invalid");

--- a/src/mbgl/style/properties.hpp
+++ b/src/mbgl/style/properties.hpp
@@ -58,7 +58,7 @@ public:
             // Interpolate between recursively-calculated prior value and final.
             float t = std::chrono::duration<float>(now - begin) / (end - begin);
             return util::interpolate(prior->get().evaluate(evaluator, now), finalValue,
-                                     util::DEFAULT_TRANSITION_EASE.solve(t, 0.001));
+                                     static_cast<float>(util::DEFAULT_TRANSITION_EASE.solve(t, 0.001)));
         }
     }
 

--- a/src/mbgl/style/rapidjson_conversion.hpp
+++ b/src/mbgl/style/rapidjson_conversion.hpp
@@ -65,7 +65,7 @@ public:
         if (!value->IsNumber()) {
             return {};
         }
-        return value->GetDouble();
+        return static_cast<float>(value->GetDouble());
     }
 
     static optional<double> toDouble(const JSValue* value) {

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -5,8 +5,17 @@
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/thread_pool.hpp>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#endif
+
 #include <mapbox/geojsonvt.hpp>
 #include <supercluster.hpp>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include <cmath>
 
@@ -82,12 +91,12 @@ T evaluateFeature(const mapbox::feature::feature<double>& f,
 std::shared_ptr<GeoJSONData> GeoJSONData::create(const GeoJSON& geoJSON,
                                                  const Immutable<GeoJSONOptions>& options,
                                                  std::shared_ptr<Scheduler> scheduler) {
-    constexpr double scale = util::EXTENT / util::tileSize;
+    constexpr double scale = util::EXTENT / util::tileSize_D;
     if (options->cluster && geoJSON.is<Features>() && !geoJSON.get<Features>().empty()) {
         mapbox::supercluster::Options clusterOptions;
         clusterOptions.maxZoom = options->clusterMaxZoom;
         clusterOptions.extent = util::EXTENT;
-        clusterOptions.radius = ::round(scale * options->clusterRadius);
+        clusterOptions.radius = static_cast<uint16_t>(::round(scale * options->clusterRadius));
         auto feature = std::make_shared<Feature>();
         clusterOptions.map = [feature, options](const PropertyMap& properties) -> PropertyMap {
             PropertyMap ret{};
@@ -114,7 +123,7 @@ std::shared_ptr<GeoJSONData> GeoJSONData::create(const GeoJSON& geoJSON,
     mapbox::geojsonvt::Options vtOptions;
     vtOptions.maxZoom = options->maxzoom;
     vtOptions.extent = util::EXTENT;
-    vtOptions.buffer = ::round(scale * options->buffer);
+    vtOptions.buffer = static_cast<uint16_t>(::round(scale * options->buffer));
     vtOptions.tolerance = scale * options->tolerance;
     vtOptions.lineMetrics = options->lineMetrics;
     if (!scheduler) scheduler = Scheduler::GetSequenced();

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -69,13 +69,13 @@ void VectorSource::loadDescription(FileSource& fileSource) {
                 return;
             }
             if (maxZoom) {
-                tileset->zoomRange.max = *maxZoom;
+                tileset->zoomRange.max = static_cast<uint8_t>(*maxZoom);
             }
             if (minZoom) {
-                tileset->zoomRange.min = *minZoom;
+                tileset->zoomRange.min = static_cast<uint8_t>(*minZoom);
             }
             const TileServerOptions& tileServerOptions = fileSource.getResourceOptions().tileServerOptions();
-            util::mapbox::canonicalizeTileset(tileServerOptions, *tileset, url, getType(), util::tileSize);
+            util::mapbox::canonicalizeTileset(tileServerOptions, *tileset, url, getType(), util::tileSize_I);
             bool changed = impl().tileset != *tileset;
 
             baseImpl = makeMutable<Impl>(impl(), *tileset);

--- a/src/mbgl/text/check_max_angle.cpp
+++ b/src/mbgl/text/check_max_angle.cpp
@@ -53,12 +53,12 @@ bool checkMaxAngle(const GeometryCoordinates& line,
         auto& current = line[index];
         auto& next = line[index + 1];
 
-        float angleDelta = util::angle_to(prev, current) - util::angle_to(current, next);
+        double angleDelta = util::angle_to(prev, current) - util::angle_to(current, next);
         // restrict angle to -pi..pi range
         angleDelta = std::fabs(std::fmod(angleDelta + 3 * M_PI, M_PI * 2) - M_PI);
 
-        recentCorners.emplace(anchorDistance, angleDelta);
-        recentAngleDelta += angleDelta;
+        recentCorners.emplace(anchorDistance, static_cast<float>(angleDelta));
+        recentAngleDelta +=  static_cast<float>(angleDelta);
 
         // remove corners that are far enough away from the list of recent anchors
         while (anchorDistance - recentCorners.front().distance > windowSize) {

--- a/src/mbgl/text/collision_feature.cpp
+++ b/src/mbgl/text/collision_feature.cpp
@@ -34,7 +34,7 @@ CollisionFeature::CollisionFeature(const GeometryCoordinates& line,
 
     if (alongLine) {
         float height = y2 - y1;
-        const double length = x2 - x1;
+        const float length = x2 - x1;
 
         if (height <= 0.0f) return;
 
@@ -46,7 +46,7 @@ CollisionFeature::CollisionFeature(const GeometryCoordinates& line,
         if (rotate) {
             // Account for *-rotate in point collision boxes
             // Doesn't account for icon-text-fit
-            const float rotateRadians = rotate * M_PI / 180.0;
+            const float rotateRadians = rotate * util::DEG2RAD_F;
 
             const Point<float> tl = util::rotate(Point<float>(x1, y1), rotateRadians);
             const Point<float> tr = util::rotate(Point<float>(x2, y1), rotateRadians);
@@ -85,8 +85,8 @@ void CollisionFeature::bboxifyLabel(const GeometryCoordinates& line,
     // symbol spacing will put labels very close together in a pitched map.
     // To reduce the cost of adding extra collision circles, we slowly increase
     // them for overscaled tiles.
-    const float overscalingPaddingFactor = 1 + .4 * util::log2(static_cast<double>(overscaling));
-    const int nPitchPaddingBoxes = std::floor(nBoxes * overscalingPaddingFactor / 2);
+    const double overscalingPaddingFactor = 1 + .4 * util::log2(static_cast<double>(overscaling));
+    const int nPitchPaddingBoxes = static_cast<int>(std::floor(nBoxes * overscalingPaddingFactor / 2));
 
     // offset the center of the first box by half a box so that the edge of the
     // box is at the edge of the label.
@@ -162,8 +162,8 @@ void CollisionFeature::bboxifyLabel(const GeometryCoordinates& line,
         // Otherwise, the .8 multiplication gives us a little bit of conservative
         // padding in choosing which boxes to use (see CollisionIndex#placedCollisionCircles)
         const float paddedAnchorDistance = std::abs(boxDistanceToAnchor - firstBoxOffset) < step ?
-            0 :
-            (boxDistanceToAnchor - firstBoxOffset) * 0.8;
+            0.0f :
+            (boxDistanceToAnchor - firstBoxOffset) * 0.8f;
 
         boxes.emplace_back(boxAnchor, -boxSize / 2, -boxSize / 2, boxSize / 2, boxSize / 2, paddedAnchorDistance);
     }

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -33,7 +33,7 @@ void TileLayerIndex::findMatches(SymbolBucket& bucket,
                                  const OverscaledTileID& newCoord,
                                  std::set<uint32_t>& zoomCrossTileIDs) const {
     auto& symbolInstances = bucket.symbolInstances;
-    float tolerance = coord.canonical.z < newCoord.canonical.z ? 1 : std::pow(2, coord.canonical.z - newCoord.canonical.z);
+    float tolerance = coord.canonical.z < newCoord.canonical.z ? 1.0f : static_cast<float>(std::pow(2, coord.canonical.z - newCoord.canonical.z));
 
     if (bucket.bucketLeaderID != bucketLeaderId) return;
 
@@ -76,7 +76,7 @@ CrossTileSymbolLayerIndex::CrossTileSymbolLayerIndex(uint32_t& maxCrossTileID_) 
  * so that they match the new wrapped version of the map.
  */
 void CrossTileSymbolLayerIndex::handleWrapJump(float newLng) {
-    const int wrapDelta = std::round((newLng - lng) / 360);
+    const auto wrapDelta = static_cast<int>(std::round((newLng - lng) / 360.0f));
     if (wrapDelta != 0) {
         std::map<uint8_t, std::map<OverscaledTileID,TileLayerIndex>> newIndexes;
         for (auto& zoomIndex : indexes) {
@@ -102,10 +102,10 @@ bool isInVewport(const mat4& posMatrix, const Point<float>& point) {
     matrix::transformMat4(p, p, posMatrix);
 
     // buffer covers area of the next zoom level (current zoom - 1 covered area).
-    constexpr float buffer = 1.0f;
-    constexpr float edge = 1.0f + buffer;
-    float x = p[0] / p[3];
-    float y = p[1] / p[3];
+    constexpr double buffer = 1.0;
+    constexpr double edge = 1.0 + buffer;
+    const double x = p[0] / p[3];
+    const double y = p[1] / p[3];
     return (x > -edge && y > -edge && x < edge && y < edge);
 }
 

--- a/src/mbgl/text/get_anchors.cpp
+++ b/src/mbgl/text/get_anchors.cpp
@@ -46,14 +46,14 @@ static Anchors resample(const GeometryCoordinates& line,
         const GeometryCoordinate& b = *(it + 1);
 
         const auto segmentDist = util::dist<float>(a, b);
-        const float angle = util::angle_to(b, a);
+        const auto angle = static_cast<float>(util::angle_to(b, a));
 
         while (markedDistance + spacing < distance + segmentDist) {
             markedDistance += spacing;
 
             float t = (markedDistance - distance) / segmentDist;
-            float x = util::interpolate(float(a.x), float(b.x), t);
-            float y = util::interpolate(float(a.y), float(b.y), t);
+            float x = util::interpolate(static_cast<float>(a.x), static_cast<float>(b.x), t);
+            float y = util::interpolate(static_cast<float>(a.y), static_cast<float>(b.y), t);
 
             // Check that the point is within the tile boundaries and that
             // the label would fit before the beginning and end of the line
@@ -158,10 +158,10 @@ optional<Anchor> getCenterAnchor(const GeometryCoordinates& line,
         if (prevDistance + segmentDistance > centerDistance) {
             // The center is on this segment
             float t = (centerDistance - prevDistance) / segmentDistance;
-            float x = util::interpolate(float(a.x), float(b.x), t);
-            float y = util::interpolate(float(a.y), float(b.y), t);
+            float x = util::interpolate(static_cast<float>(a.x), static_cast<float>(b.x), t);
+            float y = util::interpolate(static_cast<float>(a.y), static_cast<float>(b.y), t);
 
-            Anchor anchor(std::round(x), std::round(y), util::angle_to(b, a), i);
+            Anchor anchor(std::round(x), std::round(y), static_cast<float>(util::angle_to(b, a)), i);
 
             if (!angleWindowSize || checkMaxAngle(line, anchor, labelLength, angleWindowSize, maxAngle)) {
                 return anchor;

--- a/src/mbgl/text/language_tag.cpp
+++ b/src/mbgl/text/language_tag.cpp
@@ -1,8 +1,17 @@
 #include <mbgl/text/language_tag.hpp>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4828)
+#endif
+
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix_core.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include <sstream>
 

--- a/src/mbgl/text/quads.cpp
+++ b/src/mbgl/text/quads.cpp
@@ -76,8 +76,8 @@ SymbolQuads getIconQuads(const PositionedIcon& shapedIcon,
     const float iconWidth = shapedIcon.right() - shapedIcon.left();
     const float iconHeight = shapedIcon.bottom() - shapedIcon.top();
 
-    const ImageStretches stretchXFull{{0, imageWidth}};
-    const ImageStretches stretchYFull{{0, imageHeight}};
+    const ImageStretches stretchXFull{{0.0f, imageWidth}};
+    const ImageStretches stretchYFull{{0.0f, imageHeight}};
     const ImageStretches& stretchX = !image.stretchX.empty() ? image.stretchX : stretchXFull;
     const ImageStretches& stretchY = !image.stretchY.empty() ? image.stretchY : stretchYFull;
 
@@ -109,7 +109,7 @@ SymbolQuads getIconQuads(const PositionedIcon& shapedIcon,
 
     optional<std::array<float, 4>> matrix{nullopt};
     if (iconRotate) {
-        const float angle = iconRotate * util::DEG2RAD;
+        const float angle = iconRotate * util::DEG2RAD_F;
         const float angle_sin = std::sin(angle);
         const float angle_cos = std::cos(angle);
         matrix = std::array<float, 4>{{angle_cos, -angle_sin, angle_sin, angle_cos}};
@@ -201,7 +201,7 @@ SymbolQuads getGlyphQuads(const Shaping& shapedText,
                           const style::SymbolPlacementType placement,
                           const ImageMap& imageMap,
                           bool allowVerticalPlacement) {
-    const float textRotate = layout.get<TextRotate>() * util::DEG2RAD;
+    const float textRotate = layout.get<TextRotate>() * util::DEG2RAD_F;
     const bool alongLine = layout.get<TextRotationAlignment>() == AlignmentType::Map && placement != SymbolPlacementType::Point;
 
     SymbolQuads quads;
@@ -216,7 +216,7 @@ SymbolQuads getGlyphQuads(const Shaping& shapedText,
             float pixelRatio = 1.0f;
             float lineOffset = 0.0f;
             const bool rotateVerticalGlyph = (alongLine || allowVerticalPlacement) && positionedGlyph.vertical;
-            const float halfAdvance = positionedGlyph.metrics.advance * positionedGlyph.scale / 2.0;
+            const float halfAdvance = positionedGlyph.metrics.advance * positionedGlyph.scale / 2.0f;
             const Rect<uint16_t>& rect = positionedGlyph.rect;
             bool isSDF = true;
 

--- a/src/mbgl/text/tagged_string.cpp
+++ b/src/mbgl/text/tagged_string.cpp
@@ -16,7 +16,7 @@ void TaggedString::addTextSection(const std::u16string& sectionText,
                                   optional<Color> textColor) {
     styledText.first += sectionText;
     sections.emplace_back(scale, fontStack, std::move(textColor));
-    styledText.second.resize(styledText.first.size(), sections.size() - 1);
+    styledText.second.resize(styledText.first.size(), static_cast<uint8_t>(sections.size() - 1));
     supportsVerticalWritingMode = nullopt;
 }
 

--- a/src/mbgl/tile/custom_geometry_tile.cpp
+++ b/src/mbgl/tile/custom_geometry_tile.cpp
@@ -39,7 +39,7 @@ void CustomGeometryTile::setTileData(const GeoJSON& geoJSON) {
 
         mapbox::geojsonvt::TileOptions vtOptions;
         vtOptions.extent = util::EXTENT;
-        vtOptions.buffer = ::round(scale * options->buffer);
+        vtOptions.buffer = static_cast<uint16_t>(::round(scale * options->buffer));
         vtOptions.tolerance = scale * options->tolerance;
         featureData =
             mapbox::geojsonvt::geoJSONToTile(

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -333,7 +333,7 @@ void GeometryTile::queryRenderedFeatures(std::unordered_map<std::string, std::ve
     matrix::multiply(posMatrix, projMatrix, posMatrix);
 
     layoutResult->featureIndex->query(result, queryGeometry, transformState, posMatrix,
-                                      util::tileSize * id.overscaleFactor(),
+                                      util::tileSize_D * id.overscaleFactor(),
                                       std::pow(2, transformState.getZoom() - id.overscaledZ), options, id.toUnwrapped(),
                                       layers, queryPadding * transformState.maxPitchScaleFactor(), featureState);
 }

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -1,8 +1,17 @@
 #include <mbgl/tile/geometry_tile_data.hpp>
 #include <mbgl/tile/tile_id.hpp>
+#include <mbgl/math/clamp.hpp>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4005)
+#endif
 
 #include <mapbox/geometry/wagyu/wagyu.hpp>
-#include <mbgl/math/clamp.hpp>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 namespace mbgl {
 
@@ -184,11 +193,11 @@ GeometryCollection convertGeometry(const Feature::geometry_type& geometryTileFea
 
         auto x = (c.x + 180.0) * size / 360.0 - x0;
         p.x =
-            int16_t(util::clamp<int64_t>(x, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
+            int16_t(util::clamp<int64_t>(static_cast<int16_t>(x), std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
 
         auto y = (180 - (std::log(std::tan((c.y + 90) * M_PI / 360.0)) * 180 / M_PI)) * size / 360 - y0;
         p.y =
-            int16_t(util::clamp<int64_t>(y, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
+            int16_t(util::clamp<int64_t>(static_cast<int16_t>(y), std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
 
         return p;
     };

--- a/src/mbgl/tile/raster_dem_tile.cpp
+++ b/src/mbgl/tile/raster_dem_tile.cpp
@@ -87,7 +87,7 @@ void RasterDEMTile::backfillBorder(const RasterDEMTile& borderTile, const DEMTil
     int32_t dx = static_cast<int32_t>(borderTile.id.canonical.x) - static_cast<int32_t>(id.canonical.x);
     const auto dy =
         static_cast<int8_t>(static_cast<int32_t>(borderTile.id.canonical.y) - static_cast<int32_t>(id.canonical.y));
-    const uint32_t dim = pow(2, id.canonical.z);
+    const auto dim = static_cast<uint32_t>(pow(2, id.canonical.z));
     if (dx == 0 && dy == 0) return;
     if (std::abs(dy) > 1) return;
     // neighbor is in another world wrap

--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -39,7 +39,7 @@ FeatureIdentifier VectorTileFeature::getID() const {
 
 const GeometryCollection& VectorTileFeature::getGeometries() const {
     if (!lines) {
-        const float scale = float(util::EXTENT) / feature.getExtent();
+        const auto scale = static_cast<float>(util::EXTENT) / feature.getExtent();
         lines = feature.getGeometries<GeometryCollection>(scale);
         if (feature.getVersion() < 2 && feature.getType() == mapbox::vector_tile::GeomType::POLYGON) {
             lines = fixupPolygons(*lines);

--- a/src/mbgl/tile/vector_tile_data.hpp
+++ b/src/mbgl/tile/vector_tile_data.hpp
@@ -1,6 +1,16 @@
 #include <mbgl/tile/geometry_tile_data.hpp>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#endif
+
 #include <mapbox/vector_tile.hpp>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #include <protozero/pbf_reader.hpp>
 
 #include <unordered_map>

--- a/src/mbgl/util/camera.cpp
+++ b/src/mbgl/util/camera.cpp
@@ -34,7 +34,7 @@ static double mercatorYfromLat(double lat) {
 }
 
 static double latFromMercatorY(double y) {
-    return util::RAD2DEG * (2.0 * std::atan(std::exp(M_PI - y * util::M2PI)) - M_PI_2);
+    return util::RAD2DEG_D * (2.0 * std::atan(std::exp(M_PI - y * util::M2PI)) - M_PI_2);
 }
 
 static double lngFromMercatorX(double x) {
@@ -113,7 +113,7 @@ mat4 Camera::getWorldToCamera(double scale, bool flippedY) const {
     // cameraToWorld: (flip * cam^-1 * zScale)^-1 => (zScale^-1 * cam * flip^-1)
     const double worldSize = Projection::worldSize(scale);
     const double latitude = latFromMercatorY(getColumn(transform, 3)[1]);
-    const double pixelsPerMeter = worldSize / (std::cos(latitude * util::DEG2RAD) * util::M2PI * util::EARTH_RADIUS_M);
+    const double pixelsPerMeter = worldSize / (std::cos(latitude * util::DEG2RAD_D) * util::M2PI * util::EARTH_RADIUS_M);
 
     // Compute inverse of the camera matrix
     mat4 result = orientation.conjugate().toRotationMatrix();
@@ -256,7 +256,7 @@ void FreeCameraOptions::lookAtPoint(const LatLng& location, const optional<vec3>
 }
 
 void FreeCameraOptions::setPitchBearing(double pitch, double bearing) {
-    orientation = util::orientationFromPitchBearing(pitch * util::DEG2RAD, bearing * util::DEG2RAD).m;
+    orientation = util::orientationFromPitchBearing(pitch * util::DEG2RAD_D, bearing * util::DEG2RAD_D).m;
 }
 
 } // namespace mbgl

--- a/src/mbgl/util/color.cpp
+++ b/src/mbgl/util/color.cpp
@@ -45,7 +45,7 @@ std::array<double, 4> Color::toArray() const {
 }
 
 mbgl::Value Color::toObject() const {
-    return mapbox::base::ValueObject{{"r", double(r)}, {"g", double(g)}, {"b", double(b)}, {"a", double(a)}};
+    return mapbox::base::ValueObject{{"r", static_cast<double>(r)}, {"g", static_cast<double>(g)}, {"b", static_cast<double>(b)}, {"a", static_cast<double>(a)}};
 }
 
 mbgl::Value Color::serialize() const {

--- a/src/mbgl/util/convert.cpp
+++ b/src/mbgl/util/convert.cpp
@@ -1,3 +1,8 @@
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#endif
+
 #include <cstdint>
 #include <mbgl/util/convert.hpp>
 
@@ -8,3 +13,7 @@ template std::array<float, 2> convert(const std::array<int32_t, 2>&);
 
 } // namespace util
 } // namespace mbgl
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/src/mbgl/util/geo.cpp
+++ b/src/mbgl/util/geo.cpp
@@ -12,7 +12,7 @@ namespace {
 
 double lat_(const uint8_t z, const int64_t y) {
     const double n = M_PI - 2.0 * M_PI * y / std::pow(2.0, z);
-    return util::RAD2DEG * std::atan(0.5 * (std::exp(n) - std::exp(-n)));
+    return util::RAD2DEG_D * std::atan(0.5 * (std::exp(n) - std::exp(-n)));
 }
 
 double lon_(const uint8_t z, const int64_t x) {

--- a/src/mbgl/util/grid_index.cpp
+++ b/src/mbgl/util/grid_index.cpp
@@ -12,8 +12,8 @@ template <class T>
 GridIndex<T>::GridIndex(const float width_, const float height_, const uint32_t cellSize_) :
     width(width_),
     height(height_),
-    xCellCount(std::ceil(width / cellSize_)),
-    yCellCount(std::ceil(height / cellSize_)),
+    xCellCount(static_cast<size_t>(std::ceil(width / cellSize_))),
+    yCellCount(static_cast<size_t>(std::ceil(height / cellSize_))),
     xScale(xCellCount / width),
     yScale(yCellCount / height)
     {
@@ -263,12 +263,12 @@ void GridIndex<T>::query(const BCircle& queryBCircle, std::function<bool (const 
 
 template <class T>
 std::size_t GridIndex<T>::convertToXCellCoord(const float x) const {
-    return util::max(0.0, util::min(xCellCount - 1.0, std::floor(x * xScale)));
+    return util::max(size_t(0), util::min(xCellCount - 1, static_cast<size_t>(std::floor(x * xScale))));
 }
 
 template <class T>
 std::size_t GridIndex<T>::convertToYCellCoord(const float y) const {
-    return util::max(0.0, util::min(yCellCount - 1.0, std::floor(y * yScale)));
+    return util::max(size_t(0), util::min(yCellCount - 1, static_cast<size_t>(std::floor(y * yScale))));
 }
 
 template <class T>

--- a/src/mbgl/util/http_header.cpp
+++ b/src/mbgl/util/http_header.cpp
@@ -3,9 +3,18 @@
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/string.hpp>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4828)
+#endif
+
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix_core.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 namespace mbgl {
 namespace http {

--- a/src/mbgl/util/i18n.cpp
+++ b/src/mbgl/util/i18n.cpp
@@ -420,7 +420,7 @@ bool allowsFixedWidthGlyphGeneration(char16_t chr) {
 }
 
 bool allowsVerticalWritingMode(const std::u16string& string) {
-    for (char32_t chr : string) {
+    for (char16_t chr : string) {
         if (hasUprightVerticalOrientation(chr)) {
             return true;
         }

--- a/src/mbgl/util/interpolate.cpp
+++ b/src/mbgl/util/interpolate.cpp
@@ -13,8 +13,10 @@ float interpolationFactor(float base, Range<float> range, float z) {
     } else if (base == 1.0f) {
         return zoomProgress / zoomDiff;
     } else {
-        return (std::pow(static_cast<double>(base), zoomProgress) - 1) /
-               (std::pow(static_cast<double>(base), zoomDiff) - 1);
+        return static_cast<float>(
+            (std::pow(static_cast<double>(base), zoomProgress) - 1) /
+            (std::pow(static_cast<double>(base), zoomDiff) - 1)
+        );
     }
 }
 

--- a/src/mbgl/util/intersection_tests.cpp
+++ b/src/mbgl/util/intersection_tests.cpp
@@ -9,7 +9,7 @@ bool polygonContainsPoint(const GeometryCoordinates& ring, const GeometryCoordin
     for (auto i = ring.begin(), j = ring.end() - 1; i != ring.end(); j = i++) {
         auto& p1 = *i;
         auto& p2 = *j;
-        if (((p1.y > p.y) != (p2.y > p.y)) && (p.x < float(p2.x - p1.x) * float(p.y - p1.y) / float(p2.y - p1.y) + p1.x)) {
+        if (((p1.y > p.y) != (p2.y > p.y)) && (p.x < static_cast<float>(p2.x - p1.x) * static_cast<float>(p.y - p1.y) / static_cast<float>(p2.y - p1.y) + p1.x)) {
             c = !c;
         }
     }
@@ -20,7 +20,7 @@ bool polygonContainsPoint(const GeometryCoordinates& ring, const GeometryCoordin
 float distToSegmentSquared(const GeometryCoordinate& p, const GeometryCoordinate& v, const GeometryCoordinate& w) {
     if (v == w) return util::distSqr<float>(p, v);
     const auto l2 = util::distSqr<float>(v, w);
-    const float t = float((p.x - v.x) * (w.x - v.x) + (p.y - v.y) * (w.y - v.y)) / l2;
+    const float t = static_cast<float>((p.x - v.x) * (w.x - v.x) + (p.y - v.y) * (w.y - v.y)) / l2;
     if (t < 0) return util::distSqr<float>(p, v);
     if (t > 1) return util::distSqr<float>(p, w);
     return util::distSqr<float>(p, convertPoint<float>(w - v) * t + convertPoint<float>(v));

--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -282,7 +282,7 @@ canonicalizeTileURL(const TileServerOptions& tileServerOptions, const std::strin
     result.append(str, path.directory.first + versionPrefixLen, path.directory.second - versionPrefixLen);
     result.append(str, path.filename.first, path.filename.second);
     if (type == style::SourceType::Raster || type == style::SourceType::RasterDEM) {
-        result += tileSize == util::tileSize ? "@2x" : "{ratio}";
+        result += tileSize == util::tileSize_I ? "@2x" : "{ratio}";
     }
     result.append(str, path.extension.first, path.extension.second);
 

--- a/src/mbgl/util/mat3.cpp
+++ b/src/mbgl/util/mat3.cpp
@@ -102,9 +102,9 @@ void scale(mat3& out, const mat3& a, double x, double y) {
 }
 
 void transformMat3f(vec3f& out, const vec3f& a, const mat3& m) {
-    out[0] = m[0] * a[0] + m[3] * a[1] + m[6] * a[2];
-    out[1] = m[1] * a[0] + m[4] * a[1] + m[7] * a[2];
-    out[2] = m[2] * a[0] + m[5] * a[1] + m[8] * a[2];
+    out[0] = static_cast<float>(m[0]) * a[0] + static_cast<float>(m[3]) * a[1] + static_cast<float>(m[6]) * a[2];
+    out[1] = static_cast<float>(m[1]) * a[0] + static_cast<float>(m[4]) * a[1] + static_cast<float>(m[7]) * a[2];
+    out[2] = static_cast<float>(m[2]) * a[0] + static_cast<float>(m[5]) * a[1] + static_cast<float>(m[8]) * a[2];
 }
 
 } // namespace matrix

--- a/src/mbgl/util/math.hpp
+++ b/src/mbgl/util/math.hpp
@@ -47,18 +47,16 @@ T perp(const T& a) {
 
 template <typename T, typename S1, typename S2>
 T dist(const S1& a, const S2& b) {
-    T dx = b.x - a.x;
-    T dy = b.y - a.y;
-    T c = std::sqrt(dx * dx + dy * dy);
-    return c;
+    auto dx = b.x - a.x;
+    auto dy = b.y - a.y;
+    return static_cast<T>(std::sqrt(dx * dx + dy * dy));
 }
 
 template <typename T, typename S1, typename S2>
 T distSqr(const S1& a, const S2& b) {
-    T dx = b.x - a.x;
-    T dy = b.y - a.y;
-    T c = dx * dx + dy * dy;
-    return c;
+    auto dx = b.x - a.x;
+    auto dy = b.y - a.y;
+    return static_cast<T>(dx * dx + dy * dy);
 }
 
 template <typename T>
@@ -87,12 +85,12 @@ S unit(const S& a) {
 }
 
 template <typename T, typename S = double>
-T rotate(const T& a, S angle) {
+Point<T> rotate(const Point<T>& a, S angle) {
     S cos = std::cos(angle);
     S sin = std::sin(angle);
     S x = cos * a.x - sin * a.y;
     S y = sin * a.x + cos * a.y;
-    return T(x, y);
+    return Point<T>(static_cast<T>(x), static_cast<T>(y));
 }
 
 template <typename T>

--- a/src/mbgl/util/tile_coordinate.hpp
+++ b/src/mbgl/util/tile_coordinate.hpp
@@ -21,7 +21,7 @@ public:
 
     static TileCoordinate fromLatLng(double zoom, const LatLng& latLng) {
         const double scale = std::pow(2.0, zoom);
-        return { Projection::project(latLng, scale) / util::tileSize, zoom };
+        return { Projection::project(latLng, scale) / util::tileSize_D, zoom };
     }
 
     static TileCoordinate fromScreenCoordinate(const TransformState& state, uint8_t zoom, const ScreenCoordinate& screenCoordinate) {

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -51,10 +51,10 @@ void scanSpans(edge e0, edge e1, int32_t ymin, int32_t ymax, ScanLine& scanLine)
     double m1 = e1.dx / e1.dy;
     double d0 = e0.dx > 0; // use y + 1 to compute x0
     double d1 = e1.dx < 0; // use y + 1 to compute x1
-    for (int32_t y = y0; y < y1; y++) {
+    for (double y = y0; y < y1; y++) {
         double x0 = m0 * ::fmax(0, ::fmin(e0.dy, y + d0 - e0.y0)) + e0.x0;
         double x1 = m1 * ::fmax(0, ::fmin(e1.dy, y + d1 - e1.y0)) + e1.x0;
-        scanLine(std::floor(x1), std::ceil(x0), y);
+        scanLine(static_cast<int32_t>(std::floor(x1)), static_cast<int32_t>(std::ceil(x0)), static_cast<int32_t>(y));
     }
 }
 
@@ -139,11 +139,11 @@ std::vector<UnwrappedTileID> tileCover(const Point<double>& tl,
 } // namespace
 
 int32_t coveringZoomLevel(double zoom, style::SourceType type, uint16_t size) {
-    zoom += util::log2(util::tileSize / size);
+    zoom += util::log2(util::tileSize_D / size);
     if (type == style::SourceType::Raster || type == style::SourceType::Video) {
-        return ::round(zoom);
+        return static_cast<int32_t>(std::round(zoom));
     } else {
-        return std::floor(zoom);
+        return static_cast<int32_t>(std::floor(zoom));
     }
 }
 
@@ -316,7 +316,7 @@ uint64_t tileCount(const LatLngBounds& bounds, uint8_t zoom){
 
     auto dx = x1 > x2 ? (maxTile - x1) + x2 : x2 - x1;
     auto dy = y1 - y2;
-    return (dx + 1) * (dy + 1);
+    return static_cast<uint64_t>((dx + 1) * (dy + 1));
 }
 
 uint64_t tileCount(const Geometry<double>& geometry, uint8_t z) {

--- a/src/mbgl/util/tiny_sdf.cpp
+++ b/src/mbgl/util/tiny_sdf.cpp
@@ -85,7 +85,7 @@ AlphaImage transformRasterToSDF(const AlphaImage& rasterInput, double radius, do
     std::vector<int16_t> v(maxDimension);
     
     for (uint32_t i = 0; i < size; i++) {
-        double a = double(rasterInput.data[i]) / 255; // alpha value
+        double a = static_cast<double>(rasterInput.data[i]) / 255; // alpha value
         gridOuter[i] = a == 1.0 ? 0.0 : a == 0.0 ? tinysdf::INF : std::pow(std::max(0.0, 0.5 - a), 2.0);
         gridInner[i] = a == 1.0 ? tinysdf::INF : a == 0.0 ? 0.0 : std::pow(std::max(0.0, a - 0.5), 2.0);
     }
@@ -95,7 +95,7 @@ AlphaImage transformRasterToSDF(const AlphaImage& rasterInput, double radius, do
 
     for (uint32_t i = 0; i < size; i++) {
         double distance = gridOuter[i] - gridInner[i];
-        sdf.data[i] = std::max(0l, std::min(255l, ::lround(255.0 - 255.0 * (distance / radius + cutoff))));
+        sdf.data[i] = static_cast<uint8_t>(std::max(0l, std::min(255l, ::lround(255.0 - 255.0 * (distance / radius + cutoff)))));
     }
 
     return sdf;

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -68,7 +68,7 @@ TEST(Transform, InvalidBearing) {
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(1, transform.getZoom());
-    ASSERT_DOUBLE_EQ(-2.0 * util::DEG2RAD, transform.getBearing());
+    ASSERT_DOUBLE_EQ(-2.0 * util::DEG2RAD_D, transform.getBearing());
 
     const double invalid = NAN;
 
@@ -76,7 +76,7 @@ TEST(Transform, InvalidBearing) {
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(1, transform.getZoom());
-    ASSERT_DOUBLE_EQ(-2.0 * util::DEG2RAD, transform.getBearing());
+    ASSERT_DOUBLE_EQ(-2.0 * util::DEG2RAD_D, transform.getBearing());
 }
 
 TEST(Transform, IntegerZoom) {
@@ -272,24 +272,24 @@ TEST(Transform, Anchor) {
     ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
     transform.jumpTo(CameraOptions().withBearing(45.0).withAnchor(anchorPoint));
-    ASSERT_DOUBLE_EQ(-45.0 * util::DEG2RAD, transform.getBearing());
+    ASSERT_DOUBLE_EQ(-45.0 * util::DEG2RAD_D, transform.getBearing());
 
     // Anchor coordinates are imprecise because we are converting from an integer pixel.
     ASSERT_NEAR(anchorLatLng.latitude(), transform.getLatLng().latitude(), 0.5);
     ASSERT_NEAR(anchorLatLng.longitude(), transform.getLatLng().longitude(), 0.5);
 
     transform.jumpTo(CameraOptions().withCenter(latLng).withZoom(10.0).withPitch(10.0));
-    ASSERT_DOUBLE_EQ(10.0 * util::DEG2RAD, transform.getPitch());
+    ASSERT_DOUBLE_EQ(10.0 * util::DEG2RAD_D, transform.getPitch());
     ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
     transform.jumpTo(CameraOptions().withPitch(15.0));
-    ASSERT_DOUBLE_EQ(15.0 * util::DEG2RAD, transform.getPitch());
+    ASSERT_DOUBLE_EQ(15.0 * util::DEG2RAD_D, transform.getPitch());
     ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
     transform.jumpTo(CameraOptions().withPitch(20.0).withAnchor(anchorPoint));
-    ASSERT_DOUBLE_EQ(20.0 * util::DEG2RAD, transform.getPitch());
+    ASSERT_DOUBLE_EQ(20.0 * util::DEG2RAD_D, transform.getPitch());
 
     // Anchor coordinates are imprecise because we are converting from an integer pixel.
     ASSERT_NEAR(anchorLatLng.latitude(), transform.getLatLng().latitude(), 0.5);
@@ -811,15 +811,15 @@ TEST(Transform, InvalidPitch) {
 
     transform.jumpTo(CameraOptions().withZoom(1.0).withPitch(45));
     ASSERT_DOUBLE_EQ(1, transform.getZoom());
-    ASSERT_DOUBLE_EQ(45 * util::DEG2RAD, transform.getPitch());
+    ASSERT_DOUBLE_EQ(45 * util::DEG2RAD_D, transform.getPitch());
 
     const double invalid = NAN;
 
     transform.jumpTo(CameraOptions().withPitch(invalid));
-    ASSERT_DOUBLE_EQ(45 * util::DEG2RAD, transform.getPitch());
+    ASSERT_DOUBLE_EQ(45 * util::DEG2RAD_D, transform.getPitch());
 
     transform.jumpTo(CameraOptions().withPitch(60));
-    ASSERT_DOUBLE_EQ(60 * util::DEG2RAD, transform.getPitch());
+    ASSERT_DOUBLE_EQ(60 * util::DEG2RAD_D, transform.getPitch());
 }
 
 TEST(Transform, MinMaxPitch) {
@@ -834,17 +834,17 @@ TEST(Transform, MinMaxPitch) {
     transform.jumpTo(CameraOptions().withZoom(1.0).withPitch(60));
     ASSERT_DOUBLE_EQ(1, transform.getZoom());
     ASSERT_DOUBLE_EQ(transform.getState().getMaxPitch(), transform.getPitch());
-    ASSERT_DOUBLE_EQ(60 * util::DEG2RAD, transform.getPitch());
+    ASSERT_DOUBLE_EQ(60 * util::DEG2RAD_D, transform.getPitch());
 
     transform.setMaxPitch(70);
     transform.jumpTo(CameraOptions().withPitch(70));
     ASSERT_DOUBLE_EQ(transform.getState().getMaxPitch(), transform.getPitch());
-    ASSERT_DOUBLE_EQ(60 * util::DEG2RAD, transform.getPitch());
+    ASSERT_DOUBLE_EQ(60 * util::DEG2RAD_D, transform.getPitch());
 
     transform.setMaxPitch(45);
     transform.jumpTo(CameraOptions().withPitch(60));
     ASSERT_DOUBLE_EQ(transform.getState().getMaxPitch(), transform.getPitch());
-    ASSERT_DOUBLE_EQ(45 * util::DEG2RAD, transform.getPitch());
+    ASSERT_DOUBLE_EQ(45 * util::DEG2RAD_D, transform.getPitch());
 
     transform.jumpTo(CameraOptions().withPitch(0));
     ASSERT_DOUBLE_EQ(transform.getState().getMinPitch(), transform.getPitch());
@@ -858,18 +858,18 @@ TEST(Transform, MinMaxPitch) {
     transform.setMinPitch(15);
     transform.jumpTo(CameraOptions().withPitch(0));
     ASSERT_DOUBLE_EQ(transform.getState().getMinPitch(), transform.getPitch());
-    ASSERT_DOUBLE_EQ(15 * util::DEG2RAD, transform.getPitch());
+    ASSERT_DOUBLE_EQ(15 * util::DEG2RAD_D, transform.getPitch());
 
     transform.setMinPitch(45);
-    ASSERT_DOUBLE_EQ(45 * util::DEG2RAD, transform.getState().getMinPitch());
+    ASSERT_DOUBLE_EQ(45 * util::DEG2RAD_D, transform.getState().getMinPitch());
     transform.setMaxPitch(45);
-    ASSERT_DOUBLE_EQ(45 * util::DEG2RAD, transform.getState().getMaxPitch());
+    ASSERT_DOUBLE_EQ(45 * util::DEG2RAD_D, transform.getState().getMaxPitch());
 
     transform.setMaxPitch(10);
-    ASSERT_DOUBLE_EQ(45 * util::DEG2RAD, transform.getState().getMaxPitch());
+    ASSERT_DOUBLE_EQ(45 * util::DEG2RAD_D, transform.getState().getMaxPitch());
 
     transform.setMinPitch(60);
-    ASSERT_DOUBLE_EQ(45 * util::DEG2RAD, transform.getState().getMinPitch());
+    ASSERT_DOUBLE_EQ(45 * util::DEG2RAD_D, transform.getState().getMinPitch());
 }
 
 static const double abs_double_error = 1e-5;
@@ -968,26 +968,26 @@ TEST(Transform, FreeCameraOptionsSetOrientation) {
     EXPECT_DOUBLE_EQ(0.0, transform.getState().getX());
     EXPECT_DOUBLE_EQ(0.0, transform.getState().getY());
 
-    options.orientation = Quaternion::fromAxisAngle(vec3{{1.0, 0.0, 0.0}}, -60.0 * util::DEG2RAD).m;
+    options.orientation = Quaternion::fromAxisAngle(vec3{{1.0, 0.0, 0.0}}, -60.0 * util::DEG2RAD_D).m;
     transform.setFreeCameraOptions(options);
     EXPECT_DOUBLE_EQ(0.0, transform.getState().getBearing());
-    EXPECT_DOUBLE_EQ(60.0 * util::DEG2RAD, transform.getState().getPitch());
+    EXPECT_DOUBLE_EQ(60.0 * util::DEG2RAD_D, transform.getState().getPitch());
     EXPECT_DOUBLE_EQ(0.0, transform.getState().getX());
     EXPECT_DOUBLE_EQ(206.0, transform.getState().getY());
 
-    options.orientation = Quaternion::fromAxisAngle(vec3{{0.0, 0.0, 1.0}}, 56.0 * util::DEG2RAD).m;
+    options.orientation = Quaternion::fromAxisAngle(vec3{{0.0, 0.0, 1.0}}, 56.0 * util::DEG2RAD_D).m;
     transform.setFreeCameraOptions(options);
-    EXPECT_DOUBLE_EQ(-56.0 * util::DEG2RAD, transform.getState().getBearing());
+    EXPECT_DOUBLE_EQ(-56.0 * util::DEG2RAD_D, transform.getState().getBearing());
     EXPECT_DOUBLE_EQ(0.0, transform.getState().getPitch());
     EXPECT_DOUBLE_EQ(0.0, transform.getState().getX());
     EXPECT_NEAR(152.192378, transform.getState().getY(), 1e-6);
 
-    options.orientation = Quaternion::fromEulerAngles(0.0, 0.0, -179.0 * util::DEG2RAD)
-                              .multiply(Quaternion::fromEulerAngles(-30.0 * util::DEG2RAD, 0.0, 0.0))
+    options.orientation = Quaternion::fromEulerAngles(0.0, 0.0, -179.0 * util::DEG2RAD_D)
+                              .multiply(Quaternion::fromEulerAngles(-30.0 * util::DEG2RAD_D, 0.0, 0.0))
                               .m;
     transform.setFreeCameraOptions(options);
-    EXPECT_DOUBLE_EQ(179.0 * util::DEG2RAD, transform.getState().getBearing());
-    EXPECT_DOUBLE_EQ(30.0 * util::DEG2RAD, transform.getState().getPitch());
+    EXPECT_DOUBLE_EQ(179.0 * util::DEG2RAD_D, transform.getState().getBearing());
+    EXPECT_DOUBLE_EQ(30.0 * util::DEG2RAD_D, transform.getState().getPitch());
     EXPECT_NEAR(1.308930, transform.getState().getX(), 1e-6);
     EXPECT_NEAR(56.813889, transform.getState().getY(), 1e-6);
 }
@@ -1004,7 +1004,7 @@ TEST(Transform, FreeCameraOptionsClampPitch) {
     FreeCameraOptions options;
     vec3 right, up, forward;
 
-    options.orientation = Quaternion::fromAxisAngle(vec3{{1.0, 0.0, 0.0}}, -85.0 * util::DEG2RAD).m;
+    options.orientation = Quaternion::fromAxisAngle(vec3{{1.0, 0.0, 0.0}}, -85.0 * util::DEG2RAD_D).m;
     transform.setFreeCameraOptions(options);
     EXPECT_DOUBLE_EQ(util::PITCH_MAX, transform.getState().getPitch());
     std::tie(right, up, forward) = rotatedFrame(transform.getFreeCameraOptions().orientation.value());
@@ -1022,14 +1022,14 @@ TEST(Transform, FreeCameraOptionsClampToBounds) {
 
     // Place camera to an arbitrary position looking away from the map
     options.position = vec3{{-100.0, -10000.0, 1000.0}};
-    options.orientation = Quaternion::fromEulerAngles(-45.0 * util::DEG2RAD, 0.0, 0.0).m;
+    options.orientation = Quaternion::fromEulerAngles(-45.0 * util::DEG2RAD_D, 0.0, 0.0).m;
     transform.setFreeCameraOptions(options);
 
     // Map center should be clamped to width/2 pixels away from map borders
     EXPECT_DOUBLE_EQ(206.0, transform.getState().getX());
     EXPECT_DOUBLE_EQ(206.0, transform.getState().getY());
     EXPECT_DOUBLE_EQ(0.0, transform.getState().getBearing());
-    EXPECT_DOUBLE_EQ(45.0 * util::DEG2RAD, transform.getState().getPitch());
+    EXPECT_DOUBLE_EQ(45.0 * util::DEG2RAD_D, transform.getState().getPitch());
 
     vec3 right, up, forward;
     std::tie(right, up, forward) = rotatedFrame(transform.getFreeCameraOptions().orientation.value());
@@ -1070,7 +1070,7 @@ TEST(Transform, FreeCameraOptionsOrientationRoll) {
     EXPECT_NEAR(options.orientation.value()[2], orientationWithoutRoll.z, 1e-9);
     EXPECT_NEAR(options.orientation.value()[3], orientationWithoutRoll.w, 1e-9);
 
-    EXPECT_NEAR(45.0 * util::DEG2RAD, transform.getState().getPitch(), 1e-9);
+    EXPECT_NEAR(45.0 * util::DEG2RAD_D, transform.getState().getPitch(), 1e-9);
     EXPECT_NEAR(0.0, transform.getState().getBearing(), 1e-9);
     EXPECT_NEAR(0.0, transform.getState().getX(), 1e-9);
     EXPECT_NEAR(150.0, transform.getState().getY(), 1e-9);

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -774,7 +774,7 @@ public:
                            needsRelayout,
                            parameters,
                            *baseImpl,
-                           util::tileSize,
+                           util::tileSize_I,
                            tileset.zoomRange,
                            tileset.bounds,
                            [&](const OverscaledTileID& tileID) { return std::make_unique<FakeTile>(*this, tileID); });

--- a/test/tile/tile_coordinate.test.cpp
+++ b/test/tile/tile_coordinate.test.cpp
@@ -42,7 +42,7 @@ TEST(TileCoordinate, FromLatLng) {
 
     Transform transform(observer);
 
-    const double max = util::tileSize;
+    const double max = util::tileSize_D;
     transform.resize({ static_cast<uint32_t>(max), static_cast<uint32_t>(max) });
 
     // Center, top-left, bottom-left, bottom-right, top-right edges.

--- a/test/util/camera.test.cpp
+++ b/test/util/camera.test.cpp
@@ -27,12 +27,12 @@ TEST(FreeCameraOptions, SetLocation) {
     ASSERT_THAT(options.position.value(), Vec3NearEquals1E7(vec3{{0.0, 0.4282409625, 0.000027532812465}}));
 
     options.setLocation(
-        {{util::LATITUDE_MAX, 0.0}, util::EARTH_RADIUS_M * M_PI * std::cos(util::LATITUDE_MAX * util::DEG2RAD)});
+        {{util::LATITUDE_MAX, 0.0}, util::EARTH_RADIUS_M * M_PI * std::cos(util::LATITUDE_MAX * util::DEG2RAD_D)});
     ASSERT_TRUE(options.position);
     ASSERT_THAT(options.position.value(), Vec3NearEquals1E7(vec3{{0.5, 0.0, 0.5}}));
 
     options.setLocation(
-        {{-util::LATITUDE_MAX, 0.0}, util::EARTH_RADIUS_M * M_PI * std::cos(-util::LATITUDE_MAX * util::DEG2RAD)});
+        {{-util::LATITUDE_MAX, 0.0}, util::EARTH_RADIUS_M * M_PI * std::cos(-util::LATITUDE_MAX * util::DEG2RAD_D)});
     ASSERT_TRUE(options.position);
     ASSERT_THAT(options.position.value(), Vec3NearEquals1E7(vec3{{0.5, 1.0, 0.5}}));
 }
@@ -240,8 +240,8 @@ TEST(FreeCameraOptions, SetPitchBearing) {
     ASSERT_THAT(up, Vec3NearEquals1E7(vec3{{0.0, 1.0, 0.0}}));
     ASSERT_THAT(forward, Vec3NearEquals1E7(vec3{{0.0, 0.0, -1.0}}));
 
-    const double cos60 = std::cos(60.0 * util::DEG2RAD);
-    const double sin60 = std::sin(60.0 * util::DEG2RAD);
+    const double cos60 = std::cos(60.0 * util::DEG2RAD_D);
+    const double sin60 = std::sin(60.0 * util::DEG2RAD_D);
 
     options.setPitchBearing(60.0, 0.0);
     ASSERT_TRUE(options.orientation);

--- a/test/util/projection.test.cpp
+++ b/test/util/projection.test.cpp
@@ -19,7 +19,7 @@ TEST(Projection, Boundaries) {
 
     projected = Projection::project(sw, minScale);
     EXPECT_DOUBLE_EQ(projected.x, 0.0);
-    EXPECT_DOUBLE_EQ(projected.y, util::tileSize);
+    EXPECT_DOUBLE_EQ(projected.y, util::tileSize_D);
 
     unprojected = Projection::unproject(projected, minScale);
     EXPECT_DOUBLE_EQ(unprojected.latitude(), -util::LATITUDE_MAX);
@@ -27,14 +27,14 @@ TEST(Projection, Boundaries) {
 
     projected = Projection::project(sw, maxScale);
     EXPECT_DOUBLE_EQ(projected.x, 0.0);
-    EXPECT_DOUBLE_EQ(projected.y, util::tileSize * maxScale);
+    EXPECT_DOUBLE_EQ(projected.y, util::tileSize_D * maxScale);
 
     unprojected = Projection::unproject(projected, maxScale);
     EXPECT_DOUBLE_EQ(unprojected.latitude(), -util::LATITUDE_MAX);
     EXPECT_DOUBLE_EQ(unprojected.longitude(), sw.longitude());
 
     projected = Projection::project(ne, minScale);
-    EXPECT_DOUBLE_EQ(projected.x, util::tileSize);
+    EXPECT_DOUBLE_EQ(projected.x, util::tileSize_D);
     ASSERT_NEAR(projected.y, 0.0, 1e-10);
 
     unprojected = Projection::unproject(projected, minScale);
@@ -42,7 +42,7 @@ TEST(Projection, Boundaries) {
     EXPECT_DOUBLE_EQ(unprojected.longitude(), ne.longitude());
 
     projected = Projection::project(ne, maxScale);
-    EXPECT_DOUBLE_EQ(projected.x, util::tileSize * maxScale);
+    EXPECT_DOUBLE_EQ(projected.x, util::tileSize_D * maxScale);
     ASSERT_NEAR(projected.y, 0.0, 1e-6);
 
     unprojected = Projection::unproject(projected, maxScale);

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -46,8 +46,8 @@ TEST(TileCover, PitchIssue15442) {
     transform.resize({ 412, 691 });
 
     transform.jumpTo(CameraOptions().withCenter(LatLng { 59.116898740996106, 91.565660781803615, })
-        .withZoom(2.0551126748417214).withBearing(0.74963938256567264 * util::RAD2DEG)
-        .withPitch(1.0471975511965976 * util::RAD2DEG));
+        .withZoom(2.0551126748417214).withBearing(0.74963938256567264 * util::RAD2DEG_D)
+        .withPitch(1.0471975511965976 * util::RAD2DEG_D));
 
     EXPECT_EQ((std::vector<OverscaledTileID>{
                   {2, 3, 1}, {2, 2, 1}, {2, 3, 0}, {2, 2, 0}, {2, 1, {2, 0, 0}}, {2, 1, {2, 1, 0}}}),
@@ -61,7 +61,7 @@ TEST(TileCover, PitchOverAllowedByContentInsets) {
     transform.jumpTo(CameraOptions().withCenter(LatLng { 0.1, -0.1 }).withPadding(EdgeInsets { 376, 0, 0, 0 })
                                     .withZoom(8.0).withBearing(45.0).withPitch(60.0));
     // Top padding of 376 leads to capped pitch. See Transform::getMaxPitchForEdgeInsets.
-    EXPECT_LE(transform.getPitch() + 0.001, util::DEG2RAD * 60);
+    EXPECT_LE(transform.getPitch() + 0.001, util::DEG2RAD_D * 60);
 
     EXPECT_EQ(
         (std::vector<OverscaledTileID>{{3, 4, 3}, {3, 3, 3}, {3, 4, 4}, {3, 3, 4}, {3, 4, 2}, {3, 5, 3}, {3, 5, 2}}),


### PR DESCRIPTION
MSVC is quite eager with warnings (which is good in my opinion). This MR cleans most of the core codebase of MSVC warnings:
 - implicit casting to smaller types (e.g. `double` to `float`)
 - some encoding stuff
 - warnings from dependencies

Note that this is mostly silencing warnings (e.g. using `static_cast`) but I also tried to fix some trivial cases and add some template specialisations. This should be purely technical, but let's see what also CI says.