### PR TITLE
ENH: MaptilerFileSource::request_tile(): do not return error when tile is not found in mbtiles file

### DIFF
--- a/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
@@ -204,8 +204,6 @@ public:
 
         Response response;
         response.noContent = true;
-        response.error = std::make_unique<Response::Error>(Response::Error::Reason::Connection,
-                                                           "Not found in mbtile database");
 
         for (mapbox::sqlite::Query q(stmt); q.run();) {
 
@@ -215,7 +213,6 @@ public:
                 response.noContent = false;
                 response.expires = Timestamp::max();
                 response.etag = resource.url;
-                response.error.release();
 
                 if (is_compressed(*response.data)) {
                     response.data = std::make_shared<std::string>(util::decompress(*response.data));


### PR DESCRIPTION
Resolves #271 

The error is not useful in this case and breaks rendering against local mbtiles files for out-of-bounds tiles.  These are properly returned with no content and no error.