### PR TITLE
Suppress unused-but-set-variable in benchmark/

### DIFF
--- a/benchmark/parse/vector_tile.benchmark.cpp
+++ b/benchmark/parse/vector_tile.benchmark.cpp
@@ -22,6 +22,7 @@ static void Parse_VectorTile(benchmark::State& state) {
                 }
             }
         }
+        (void)length;
     }
 }
 

--- a/benchmark/util/tilecover.benchmark.cpp
+++ b/benchmark/util/tilecover.benchmark.cpp
@@ -16,6 +16,7 @@ static void TileCountBounds(benchmark::State& state) {
         auto count = util::tileCount(sanFrancisco, 10);
         length += count;
     }
+    (void)length;
 }
 
 static void TileCoverPitchedViewport(benchmark::State& state) {
@@ -29,6 +30,7 @@ static void TileCoverPitchedViewport(benchmark::State& state) {
         auto tiles = util::tileCover(transform.getState(), 8);
         length += tiles.size();
     }
+    (void)length;
 }
 
 static void TileCoverBounds(benchmark::State& state) {
@@ -37,6 +39,7 @@ static void TileCoverBounds(benchmark::State& state) {
         auto tiles = util::tileCover(sanFrancisco, 8);
         length += tiles.size();
     }
+    (void)length;
 }
 
 static const auto geomPolygon = Polygon<double>{
@@ -74,6 +77,7 @@ static void TileCoverPolygon(benchmark::State& state) {
         auto tiles = util::tileCover(geomPolygon, 8);
         length += tiles.size();
     }
+    (void)length;
 }
 
 static void TileCountPolygon(benchmark::State& state) {
@@ -83,6 +87,7 @@ static void TileCountPolygon(benchmark::State& state) {
         auto tiles = util::tileCount(geomPolygon, 16);
         length += tiles;
     }
+    (void)length;
 }
 
 BENCHMARK(TileCountBounds);


### PR DESCRIPTION
In recent versions of `clang`, the code in `benchmark/` will fail to
build, due to the `unused-but-set-variable` warning.

Tested the patch fixes the build for me with:

```
Apple clang version 13.1.6 (clang-1316.0.21.2.3)
Target: x86_64-apple-darwin21.4.0
```