### PR TITLE
Qt build improvements and documentation

### DIFF
--- a/.github/actions/qt5-build/Dockerfile
+++ b/.github/actions/qt5-build/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/maplibre/linux-builder:centos7
+
+# Copy and set the entry point
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/qt5-build/action.yml
+++ b/.github/actions/qt5-build/action.yml
@@ -1,0 +1,6 @@
+# action.yml
+name: 'Qt5 Linux Builder'
+description: 'Helper action to build in a specific Docker container'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/qt5-build/entrypoint.sh
+++ b/.github/actions/qt5-build/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -l
+
+source scl_source enable devtoolset-8 rh-git218
+
+set -e
+set -x
+
+export CCACHE_DIR="$GITHUB_WORKSPACE/.ccache"
+export PATH="$Qt5_Dir/bin:$PATH"
+
+mkdir build && cd build
+cmake ../source/ \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DMBGL_WITH_QT=ON \
+  -DMBGL_QT_LIBRARY_ONLY=ON \
+  -DCMAKE_INSTALL_PREFIX="../install/"
+ninja
+ninja install

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - name: Linux
+            os: ubuntu-latest
+            static: OFF
+            qt: 5.15.2
+            qt_target: desktop
           - name: macOS
             os: macos-latest
             static: OFF
@@ -38,11 +43,11 @@ jobs:
             static: ON
             qt: 5.15.2
             qt_target: desktop
-#          - name: iOS_static
-#            os: macos-latest
-#            static: ON
-#            qt: 5.15.2
-#            qt_target: ios
+          - name: iOS_static
+            os: macos-latest
+            static: ON
+            qt: 5.15.2
+            qt_target: ios
           - name: macOS
             os: macos-latest
             static: ON
@@ -55,7 +60,7 @@ jobs:
             qt_target: desktop
     runs-on: ${{ matrix.os }}
     env:
-      BUILD_TYPE: Debug
+      BUILD_TYPE: RelWithDebInfo
       BUILD_MODE: ${{ matrix.static }}
       QT_VERSION: ${{ matrix.qt }}
 
@@ -67,7 +72,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Install dependencies
+      - name: Install macOS dependencies
         if: runner.os == 'macOS'
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
@@ -78,6 +83,7 @@ jobs:
           brew list ninja || brew install ninja
 
       - name: Setup Xcode
+        if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
@@ -86,9 +92,11 @@ jobs:
         uses: jurplel/install-qt-action@v2
         with:
           version: ${{ env.QT_VERSION }}
+          dir: ${{ github.workspace }}
           target: ${{ matrix.qt_target }}
 
       - name: Prepare ccache
+        if: runner.os == 'macOS'
         run: |
           ccache --clear
           ccache --set-config cache_dir=~/.ccache
@@ -106,6 +114,7 @@ jobs:
             ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.name }}-${{ matrix.qt }}-${{ github.job }}
 
       - name: Clear ccache statistics
+        if: runner.os == 'macOS'
         run: |
           ccache --zero-stats
           ccache --max-size=2G
@@ -119,7 +128,6 @@ jobs:
             -G Ninja \
             -DMBGL_WITH_QT=ON \
             -DMBGL_QT_STATIC=${BUILD_MODE} \
-            -DMBGL_QT_WITH_INTERNAL_SQLITE=OFF \
             -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
@@ -132,21 +140,24 @@ jobs:
         run: |
           mkdir build && cd build
           cmake ../source/ \
-            -DCMAKE_TOOLCHAIN_FILE=../source/platform/ios/platform/ios/toolchain.cmake \
-            -G XCode \
-            -DPLATFORM=OS64COMBINED \
-            -DDEPLOYMENT_TARGET=12.0 \
-            -DENABLE_BITCODE=ON \
+            -G"Ninja Multi-Config" \
+            -DCMAKE_SYSTEM_NAME=iOS \
+            -DCMAKE_CONFIGURATION_TYPES="Release;Debug" \
+            -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
             -DMBGL_WITH_QT=ON \
-            -DMBGL_WITH_WERROR=OFF \
-            -DMBGL_QT_LIBRARY_ONLY=ON \
             -DMBGL_QT_STATIC=${BUILD_MODE} \
-            -DMBGL_QT_WITH_INTERNAL_SQLITE=OFF \
+            -DMBGL_QT_LIBRARY_ONLY=ON \
             -DMBGL_QT_WITH_IOS_CCACHE=ON \
-            -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-            -DCMAKE_INSTALL_PREFIX=../install
+            -DCMAKE_INSTALL_PREFIX=../install \
+            -DCMAKE_FIND_ROOT_PATH="$Qt5_Dir" \
+            -DCMAKE_PREFIX_PATH="$Qt5_Dir"
           cmake --build . --config Release
           cmake --install . --config Release
+
+      - name: Build maplibre-gl-native (Linux)
+        if: runner.os == 'Linux'
+        uses: ./source/.github/actions/qt5-build
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
@@ -155,5 +166,6 @@ jobs:
           path: install
 
       - name: Show ccache statistics
+        if: runner.os == 'macOS'
         run: |
           ccache --show-stats -v

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 option(MBGL_WITH_CORE_ONLY "Build only the core bits, no platform code" OFF)
 option(MBGL_WITH_COVERAGE "Enable code coverage collection" OFF)
 option(MBGL_WITH_QT "Build Mapbox GL Qt bindings" OFF)
-option(MBGL_QT_STATIC "Build Mapbox GL Qt bindings staticly" OFF)
 option(MBGL_WITH_SANITIZER "Use [address|thread|undefined] here" OFF)
 option(MBGL_WITH_RTTI "Compile with runtime type information" OFF)
 option(MBGL_WITH_OPENGL "Build with OpenGL renderer" ON)
@@ -55,6 +54,7 @@ target_compile_options(
         -fsanitize-blacklist=${UBSAN_BLACKLIST}>
         $<$<STREQUAL:${MBGL_WITH_SANITIZER},undefined>:-fsanitize=float-divide-by-zero,
         -fsanitize-blacklist=${UBSAN_BLACKLIST}>
+        $<$<PLATFORM_ID:iOS>:-fembed-bitcode>
         $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<OR:$<BOOL:${MBGL_WITH_RTTI}>,$<CXX_COMPILER_ID:MSVC>>>>:-fno-rtti>
         $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<PLATFORM_ID:Windows>>>:-Wall>
         $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<PLATFORM_ID:Windows>>>:-Wshadow>
@@ -68,10 +68,10 @@ target_compile_options(
         $<$<AND:$<CXX_COMPILER_ID:AppleClang>,$<NOT:$<BOOL:${MBGL_WITH_QT}>>>:-Wno-error=unused-parameter>
         $<$<AND:$<CXX_COMPILER_ID:AppleClang>,$<NOT:$<BOOL:${MBGL_WITH_QT}>>>:-Wno-error=unused-property-ivar>
         $<$<CXX_COMPILER_ID:MSVC>:/utf-8>
-        # $<$<CXX_COMPILER_ID:MSVC>:/WX>    # all warnings as errors
+        $<$<CXX_COMPILER_ID:MSVC>:/WX>      # all warnings as errors
+        $<$<CXX_COMPILER_ID:MSVC>:/EHsc>    # exceptions
         $<$<CXX_COMPILER_ID:MSVC>:/wd4068>  # pragma
-        $<$<CXX_COMPILER_ID:MSVC>:/wd4244>  # types
-        $<$<CXX_COMPILER_ID:MSVC>:/wd4828>  # encoding
+        $<$<CXX_COMPILER_ID:MSVC>:/D_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS>
         $<$<CXX_COMPILER_ID:MSVC>:/D_CRT_SECURE_NO_WARNINGS>
 )
 
@@ -93,12 +93,16 @@ set(CMAKE_C_EXTENSIONS OFF)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
+if (CMAKE_GENERATOR STREQUAL "Ninja Multi-Config")
+    set(CMAKE_CROSS_CONFIGS "all")
+    set(CMAKE_DEFAULT_CONFIGS "all")
+endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
-if(MBGL_QT_STATIC)
+if(MBGL_WITH_QT AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
     add_library(mbgl-core OBJECT)
 else()
     add_library(mbgl-core STATIC)
@@ -1018,6 +1022,38 @@ target_link_libraries(
         Mapbox::Base::geometry.hpp
         Mapbox::Base::optional
         Mapbox::Base::variant
+)
+
+export(TARGETS
+    mbgl-core
+
+    mapbox-base
+    mapbox-base-cheap-ruler-cpp
+    mapbox-base-extras-expected-lite
+    mapbox-base-extras-kdbush.hpp
+    mapbox-base-extras-rapidjson
+    mapbox-base-geojson-vt-cpp
+    mapbox-base-geojson.hpp
+    mapbox-base-geometry.hpp
+    mapbox-base-jni.hpp
+    mapbox-base-optional
+    mapbox-base-pixelmatch-cpp
+    mapbox-base-shelf-pack-cpp
+    mapbox-base-supercluster.hpp
+    mapbox-base-variant
+    mbgl-compiler-options
+    mbgl-vendor-boost
+    mbgl-vendor-csscolorparser
+    mbgl-vendor-earcut.hpp
+    mbgl-vendor-eternal
+    mbgl-vendor-parsedate
+    mbgl-vendor-polylabel
+    mbgl-vendor-protozero
+    mbgl-vendor-unique_resource
+    mbgl-vendor-vector-tile
+    mbgl-vendor-wagyu
+
+    FILE MapboxCoreTargets.cmake
 )
 
 set_target_properties(

--- a/include/mbgl/actor/actor_ref.hpp
+++ b/include/mbgl/actor/actor_ref.hpp
@@ -38,7 +38,11 @@ public:
     template <typename Fn, class... Args>
     auto ask(Fn fn, Args&&... args) const {
         // Result type is deduced from the function's return type
+#if __cplusplus >= 201703L  // TODO: remove this once fully migrated to C++17
+        using ResultType = std::invoke_result_t<decltype(fn), Object, Args...>;
+#else
         using ResultType = typename std::result_of<decltype(fn)(Object, Args...)>::type;
+#endif
 
         std::promise<ResultType> promise;
         auto future = promise.get_future();

--- a/include/mbgl/actor/actor_ref.hpp
+++ b/include/mbgl/actor/actor_ref.hpp
@@ -38,7 +38,7 @@ public:
     template <typename Fn, class... Args>
     auto ask(Fn fn, Args&&... args) const {
         // Result type is deduced from the function's return type
-#if __cplusplus >= 201703L  // TODO: remove this once fully migrated to C++17
+#if __cplusplus >= 201703L
         using ResultType = std::invoke_result_t<decltype(fn), Object, Args...>;
 #else
         using ResultType = typename std::result_of<decltype(fn)(Object, Args...)>::type;

--- a/platform/qt/README.md
+++ b/platform/qt/README.md
@@ -1,108 +1,44 @@
 # MapLibre Maps SDK for Qt
 
-## Developing
+This is a community maintained MapLibre SDK for usage in Qt apps.
+Both Qt5 (minimal 5.6) and Qt6 are supported.
+Note that only OpenGL rendering is supported at the moment.
 
-This is the foundation for the [Mapbox GL plugin](https://doc.qt.io/qt-5/location-plugin-mapboxgl.html)
-available in the Qt SDK since Qt 5.9. Use the [Qt bugtracker](https://bugreports.qt.io) for bugs related
-to the plugin and this GitHub repository for bugs related to MapLibre GL Native and the Qt bindings.
+## Supported platforms
 
-You should build this repository if you want to develop/contribute using the low level Qt C++ bindings or
-want to contribute to the MapLibre GL Native project using the Qt port for debugging.
+- macOS
+- iOS
+- Android
+- Linux
+- Windows
 
-### Build dependencies
+## Building
 
-#### Linux
+This project uses out of source build. CMake 3.10 or later is used to generate
+make files. Ninja is recommended.
 
-For Linux (tested on Ubuntu) desktop, together with these [build instructions](../linux/README.md), you also need:
+Before the project can be built Qt installation needs to be added to the `PATH`:
 
-```
-$ sudo apt-get install qt5-default
-```
-
-#### macOS
-
-For macOS desktop, you can install Qt 5 via [Homebrew](https://brew.sh):
-
-```
-$ brew install qt5
+```shell
+export PATH=<path_to_Qt>/Qt/<Qt_version>/<Qt_platform>/bin:$PATH
 ```
 
-Since Homebrew doesn't add Qt to the path, you'll have to do that manually before running any Make target:
+A minimal set of commands to build and install is
 
-```
-export PATH=/usr/local/opt/qt5/bin:$PATH
-```
-
-### Windows
-
-The Windows build will assume you have installed and on the default path:
-
-- Microsoft Visual Studio 2019
-- [CMake 3.10.1+](https://cmake.org/download/)
-- [Ninja](https://github.com/ninja-build/ninja/releases)
-- [Qt 5.4+](https://www.qt.io/download) with "msvc2019" (or later) support.
-
-At runtime, you will also need installed:
-
-- [OpenSSL 1.0.2+](https://slproweb.com/products/Win32OpenSSL.html)
-- DirectX
-
-#### QNX 7.0
-
-To build for QNX 7.0, you need to install the QNX Software Development Platform (SDP) on a Linux host.
-
-http://www.qnx.com/developers/docs/7.0.0/#com.qnx.doc.qnxsdp.nav/topic/bookset.html
-
-After installing the SDP, you need to source the QNX environment script:
-
-```
-source <SDP_DIRECTORY>/qnxsdp-env.sh
+```shell
+mkdir build && cd build
+cmake ../maplibre-gl-native/ \
+  -GNinja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=<installation_prefix> \
+  -DMBGL_WITH_QT=ON
+ninja
+ninja install
 ```
 
-You also need to Build Qt for QNX.
+`<installation_prefix>` above should be replaced with a wished installation path.
+Files installed there can later be used as the dependency for your app.
 
-http://wiki.qt.io/Building_Qt_for_QNX_Neutrino_OS
-
-After building Qt for QNX, you need to add Qt installation's bin directory to the path.
-
-```
-export PATH=<INSTALLFOLDER>/bin:$PATH
-```
-
-### Build instructions
-
-Public API headers can be found in the [platform/qt/include](include) directory.
-
-#### Linux and macOS
-
-#### QMapboxGL example application
-
-```
-$ make qt-lib      # Will build libqmapboxgl.so
-$ make qt-app      # Will build the test app and libqmapboxgl.so if not built yet
-$ make run-qt-app  # Will build and run the test app
-```
-
-#### Windows
-
-```
-$ mkdir build
-$ cd build
-$ cmake -G Ninja -DMBGL_WITH_QT=ON -DCMAKE_BUILD_TYPE=Release ..
-$ ninja
-```
-
-You may need to specify the path to Qt:
-
-```
-$ cmake -G Ninja -DMBGL_WITH_QT=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake ..
-```
-
-
-#### QNX 7.0
-
-Building the repository for QNX 7.0 is very similar to other platforms (e.g. Linux and macOS).
-
-```
-$ make qnx-qt-lib      # Will build libqmapboxgl.so
-```
+For platform-specific details look at build scripts provided
+in the [scripts](scripts) folder. Each script requires (at least) paths
+to source and installation locations.

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -9,10 +9,14 @@
 
 // This header follows the Qt coding style: https://wiki.qt.io/Qt_Coding_Style
 
-#if defined(QT_BUILD_MAPBOXGL_LIB)
-#  define Q_MAPBOXGL_EXPORT Q_DECL_EXPORT
+#if !defined(QT_MAPBOXGL_STATIC)
+#  if defined(QT_BUILD_MAPBOXGL_LIB)
+#    define Q_MAPBOXGL_EXPORT Q_DECL_EXPORT
+#  else
+#    define Q_MAPBOXGL_EXPORT Q_DECL_IMPORT
+#  endif
 #else
-#  define Q_MAPBOXGL_EXPORT Q_DECL_IMPORT
+#  define Q_MAPBOXGL_EXPORT
 #endif
 
 namespace QMapbox {

--- a/platform/qt/scripts/configure_Qt5_Android_static.sh
+++ b/platform/qt/scripts/configure_Qt5_Android_static.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+if [[ -z ${1+x} ]]; then
+  echo "Error: Pass the path to maplibre-gl-native as first argument" 1>&2
+  exit 1
+fi
+
+if [[ -z ${2+x} ]]; then
+  echo "Error: Pass the install prefix as the second argument" 1>&2
+  exit 2
+fi
+
+if [[ -z ${3+x} ]]; then
+  echo "Error: Pass Qt installation path as the third argument" 1>&2
+  exit 3
+fi
+
+if [[ -z ${4+x} ]]; then
+  echo "Error: Pass Android ABI as the fourth argument" 1>&2
+  exit 3
+fi
+
+cmake "$1" \
+-DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake" \
+-DANDROID_ABI="$4" \
+-DANDROID_NATIVE_API_LEVEL=21 \
+-G Ninja \
+-DMBGL_WITH_QT=ON \
+-DMBGL_QT_STATIC=ON \
+-DMBGL_QT_LIBRARY_ONLY=ON \
+-DCMAKE_CXX_FLAGS_RELEASE=-g0 \
+-DCMAKE_INSTALL_PREFIX="$2" \
+-DCMAKE_FIND_ROOT_PATH="$3/android" \
+-DCMAKE_PREFIX_PATH="$3/android"

--- a/platform/qt/scripts/configure_Qt5_Linux.sh
+++ b/platform/qt/scripts/configure_Qt5_Linux.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [[ -z ${1+x} ]]; then
+  echo "Error: Pass the path to maplibre-gl-native as first argument" 1>&2
+  exit 1
+fi
+
+if [[ -z ${2+x} ]]; then
+  echo "Error: Pass the install prefix as the second argument" 1>&2
+  exit 2
+fi
+
+cmake "$1" \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DMBGL_WITH_QT=ON \
+  -DCMAKE_INSTALL_PREFIX="$2"

--- a/platform/qt/scripts/configure_Qt5_Windows.ps1
+++ b/platform/qt/scripts/configure_Qt5_Windows.ps1
@@ -1,0 +1,8 @@
+$path = $args[0]
+$install = $args[1]
+
+cmake -S "$path" `
+  -GNinja `
+  -DCMAKE_BUILD_TYPE="Release" `
+  -DCMAKE_INSTALL_PREFIX="$install" `
+  -DMBGL_WITH_QT=ON

--- a/platform/qt/scripts/configure_Qt5_Windows_static.ps1
+++ b/platform/qt/scripts/configure_Qt5_Windows_static.ps1
@@ -1,0 +1,10 @@
+$path = $args[0]
+$install = $args[1]
+
+cmake -S "$path" `
+  -GNinja `
+  -DCMAKE_BUILD_TYPE="Release" `
+  -DCMAKE_INSTALL_PREFIX="$install" `
+  -DMBGL_WITH_QT=ON `
+  -DMBGL_QT_STATIC=ON `
+  -DMBGL_QT_LIBRARY_ONLY=ON

--- a/platform/qt/scripts/configure_Qt5_iOS_static.sh
+++ b/platform/qt/scripts/configure_Qt5_iOS_static.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [[ -z ${1+x} ]]; then
+  echo "Error: Pass the path to maplibre-gl-native as first argument" 1>&2
+  exit 1
+fi
+
+if [[ -z ${2+x} ]]; then
+  echo "Error: Pass the install prefix as the second argument" 1>&2
+  exit 2
+fi
+
+if [[ -z ${3+x} ]]; then
+  echo "Error: Pass Qt installation path as the third argument" 1>&2
+  exit 3
+fi
+
+cmake "$1" \
+  -G"Ninja Multi-Config" \
+  -DCMAKE_SYSTEM_NAME=iOS \
+  -DCMAKE_CONFIGURATION_TYPES="Release;Debug" \
+  -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
+  -DMBGL_WITH_QT=ON \
+  -DMBGL_QT_STATIC=ON \
+  -DMBGL_QT_LIBRARY_ONLY=ON \
+  -DCMAKE_INSTALL_PREFIX="$2" \
+  -DCMAKE_FIND_ROOT_PATH="$3/ios" \
+  -DCMAKE_PREFIX_PATH="$3/ios"

--- a/platform/qt/scripts/configure_Qt5_macOS.sh
+++ b/platform/qt/scripts/configure_Qt5_macOS.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [[ -z ${1+x} ]]; then
+  echo "Error: Pass the path to maplibre-gl-native as first argument" 1>&2
+  exit 1
+fi
+
+if [[ -z ${2+x} ]]; then
+  echo "Error: Pass the install prefix as the second argument" 1>&2
+  exit 2
+fi
+
+cmake "$1" \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 \
+  -DMBGL_WITH_QT=ON \
+  -DCMAKE_INSTALL_PREFIX="$2"

--- a/platform/qt/scripts/configure_Qt5_macOS_static.sh
+++ b/platform/qt/scripts/configure_Qt5_macOS_static.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [[ -z ${1+x} ]]; then
+  echo "Error: Pass the path to maplibre-gl-native as first argument" 1>&2
+  exit 1
+fi
+
+if [[ -z ${2+x} ]]; then
+  echo "Error: Pass the install prefix as the second argument" 1>&2
+  exit 2
+fi
+
+cmake "$1" \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 \
+  -DMBGL_WITH_QT=ON \
+  -DMBGL_QT_STATIC=ON \
+  -DMBGL_QT_LIBRARY_ONLY=ON \
+  -DCMAKE_INSTALL_PREFIX="$2"

--- a/platform/qt/scripts/configure_Qt6_Windows.ps1
+++ b/platform/qt/scripts/configure_Qt6_Windows.ps1
@@ -1,0 +1,8 @@
+$path = $args[0]
+$install = $args[1]
+
+qt-cmake -S "$path" `
+  -GNinja `
+  -DCMAKE_BUILD_TYPE="Release" `
+  -DCMAKE_INSTALL_PREFIX="$install" `
+  -DMBGL_WITH_QT=ON

--- a/platform/qt/scripts/configure_Qt6_macOS.sh
+++ b/platform/qt/scripts/configure_Qt6_macOS.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [[ -z ${1+x} ]]; then
+  echo "Error: Pass the path to maplibre-gl-native as first argument" 1>&2
+  exit 1
+fi
+
+if [[ -z ${2+x} ]]; then
+  echo "Error: Pass the install prefix as the second argument" 1>&2
+  exit 2
+fi
+
+qt-cmake "$1" \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 \
+  -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+  -DMBGL_WITH_QT=ON \
+  -DCMAKE_INSTALL_PREFIX="$2"

--- a/platform/qt/scripts/configure_Qt6_macOS_static.sh
+++ b/platform/qt/scripts/configure_Qt6_macOS_static.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [[ -z ${1+x} ]]; then
+  echo "Error: Pass the path to maplibre-gl-native as first argument" 1>&2
+  exit 1
+fi
+
+if [[ -z ${2+x} ]]; then
+  echo "Error: Pass the install prefix as the second argument" 1>&2
+  exit 2
+fi
+
+qt-cmake "$1" \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 \
+  -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+  -DMBGL_WITH_QT=ON \
+  -DMBGL_QT_STATIC=ON \
+  -DMBGL_QT_LIBRARY_ONLY=ON \
+  -DCMAKE_INSTALL_PREFIX="$2"

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -68,6 +68,11 @@
 
 using namespace QMapbox;
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4805)
+#endif
+
 // mbgl::GLContextMode
 static_assert(mbgl::underlying_type(QMapboxGLSettings::UniqueGLContext) == mbgl::underlying_type(mbgl::gfx::ContextMode::Unique), "error");
 static_assert(mbgl::underlying_type(QMapboxGLSettings::SharedGLContext) == mbgl::underlying_type(mbgl::gfx::ContextMode::Shared), "error");
@@ -90,6 +95,11 @@ static_assert(mbgl::underlying_type(QMapboxGL::NorthUpwards) == mbgl::underlying
 static_assert(mbgl::underlying_type(QMapboxGL::NorthRightwards) == mbgl::underlying_type(mbgl::NorthOrientation::Rightwards), "error");
 static_assert(mbgl::underlying_type(QMapboxGL::NorthDownwards) == mbgl::underlying_type(mbgl::NorthOrientation::Downwards), "error");
 static_assert(mbgl::underlying_type(QMapboxGL::NorthLeftwards) == mbgl::underlying_type(mbgl::NorthOrientation::Leftwards), "error");
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 
 namespace {
 
@@ -984,7 +994,7 @@ mbgl::optional<mbgl::Annotation> asMapboxGLAnnotation(const QMapbox::Annotation 
 */
 QMapbox::AnnotationID QMapboxGL::addAnnotation(const QMapbox::Annotation &annotation)
 {
-    return d_ptr->mapObj->addAnnotation(*asMapboxGLAnnotation(annotation));
+    return static_cast<QMapbox::AnnotationID>(d_ptr->mapObj->addAnnotation(*asMapboxGLAnnotation(annotation)));
 }
 
 /*!

--- a/platform/qt/src/qt_geojson.cpp
+++ b/platform/qt/src/qt_geojson.cpp
@@ -1,7 +1,4 @@
 #include "qt_geojson.hpp"
-#include <mapbox/geojson.hpp>
-#include <mbgl/util/geometry.hpp>
-#include <mbgl/util/feature.hpp>
 
 #pragma clang diagnostic ignored "-Wenum-compare-switch"
 

--- a/platform/qt/src/timer.cpp
+++ b/platform/qt/src/timer.cpp
@@ -18,7 +18,11 @@ void Timer::Impl::start(uint64_t timeout, uint64_t repeat_, std::function<void (
     callback = std::move(cb);
 
     timer.setSingleShot(true);
-    timer.start(timeout);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+    timer.start(static_cast<std::chrono::milliseconds>(timeout));
+#else
+    timer.start(static_cast<int>(timeout));
+#endif
 }
 
 void Timer::Impl::stop() {
@@ -28,7 +32,11 @@ void Timer::Impl::stop() {
 void Timer::Impl::timerFired() {
     if (repeat) {
         timer.setSingleShot(false);
-        timer.start(repeat);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+        timer.start(static_cast<std::chrono::milliseconds>(repeat));
+#else
+        timer.start(static_cast<int>(repeat));
+#endif
     }
 
     callback();

--- a/platform/qt/test/main.cpp
+++ b/platform/qt/test/main.cpp
@@ -18,7 +18,11 @@ int main(int argc, char *argv[]) {
     QApplication app(argc, argv);
 
 #ifdef WORK_DIRECTORY
+#ifdef _MSC_VER
+    const int result = _chdir(xstr(WORK_DIRECTORY));
+#else
     const int result = chdir(xstr(WORK_DIRECTORY));
+#endif
     if (result != 0) {
         fprintf(stderr, "failed to change directory: %s\n", strerror(errno));
         return errno;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -229,4 +229,11 @@ target_link_libraries(
     $<$<AND:$<PLATFORM_ID:Windows>,$<BOOL:MINGW>>:psapi>
 )
 
+if(MSVC)
+    target_compile_definitions(
+        mbgl-test
+        PRIVATE MBGL_BUILDING_LIB
+    )
+endif()
+
 set_property(TARGET mbgl-test PROPERTY FOLDER Core)

--- a/vendor/csscolorparser.cmake
+++ b/vendor/csscolorparser.cmake
@@ -2,7 +2,7 @@ if(TARGET mbgl-vendor-csscolorparser)
     return()
 endif()
 
-if(MBGL_QT_STATIC)
+if(MBGL_WITH_QT AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
     add_library(mbgl-vendor-csscolorparser OBJECT)
 else()
     add_library(mbgl-vendor-csscolorparser STATIC)
@@ -22,6 +22,10 @@ target_include_directories(
     mbgl-vendor-csscolorparser SYSTEM
     PUBLIC ${CMAKE_CURRENT_LIST_DIR}/csscolorparser
 )
+
+if(MSVC)
+    target_compile_options(mbgl-vendor-csscolorparser PRIVATE /wd4244)
+endif()
 
 set_target_properties(
     mbgl-vendor-csscolorparser

--- a/vendor/icu.cmake
+++ b/vendor/icu.cmake
@@ -43,3 +43,8 @@ target_include_directories(
 )
 
 set_property(TARGET mbgl-vendor-icu PROPERTY FOLDER Core)
+
+export(TARGETS
+    mbgl-vendor-icu
+    APPEND FILE MapboxCoreTargets.cmake
+)

--- a/vendor/nunicode.cmake
+++ b/vendor/nunicode.cmake
@@ -2,7 +2,7 @@ if(TARGET mbgl-vendor-nunicode)
     return()
 endif()
 
-if(MBGL_QT_STATIC)
+if(MBGL_WITH_QT AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
     add_library(mbgl-vendor-nunicode OBJECT)
 else()
     add_library(mbgl-vendor-nunicode STATIC)
@@ -24,11 +24,18 @@ target_compile_definitions(
     PRIVATE NU_BUILD_STATIC
 )
 
-if(NOT MSVC)
+if(MSVC)
+    target_compile_options(mbgl-vendor-nunicode PRIVATE /wd4146)
+else()
     target_compile_options(mbgl-vendor-nunicode PRIVATE -Wno-error)
 endif()
 
 target_include_directories(
     mbgl-vendor-nunicode SYSTEM
     PUBLIC ${CMAKE_CURRENT_LIST_DIR}/nunicode/include
+)
+
+export(TARGETS
+    mbgl-vendor-nunicode
+    APPEND FILE MapboxCoreTargets.cmake
 )

--- a/vendor/parsedate.cmake
+++ b/vendor/parsedate.cmake
@@ -2,7 +2,7 @@ if(TARGET mbgl-vendor-parsedate)
     return()
 endif()
 
-if(MBGL_QT_STATIC)
+if(MBGL_WITH_QT AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
     add_library(mbgl-vendor-parsedate OBJECT)
 else()
     add_library(mbgl-vendor-parsedate STATIC)

--- a/vendor/sqlite.cmake
+++ b/vendor/sqlite.cmake
@@ -27,3 +27,8 @@ target_include_directories(
     mbgl-vendor-sqlite SYSTEM
     INTERFACE ${CMAKE_CURRENT_LIST_DIR}/sqlite/include
 )
+
+export(TARGETS
+    mbgl-vendor-sqlite
+    APPEND FILE MapboxCoreTargets.cmake
+)


### PR DESCRIPTION
Various improvements to the Qt build:
 - always build core libraries as object libraries when building with Qt
 - build on Windows warningless
 - embed bitcode on iOS
 - fix windows symbol exports
 - add helper scripts (eventually to be used in the CI)

/cc @kiibimees @rinigus