### PR TITLE
Fix shiftY calculation typo

### DIFF
--- a/src/mbgl/text/shaping.cpp
+++ b/src/mbgl/text/shaping.cpp
@@ -145,7 +145,7 @@ void align(Shaping& shaping,
     if (maxLineHeight != lineHeight) {
         shiftY = -blockHeight * verticalAlign - Shaping::yOffset;
     } else {
-        shiftY = (-verticalAlign * static_cast<float>(lineCount + 0.5)) * lineHeight;
+        shiftY = (-verticalAlign * static_cast<float>(lineCount) + 0.5f) * lineHeight;
     }
 
     for (auto& line : shaping.positionedLines) {


### PR DESCRIPTION
In [this PR](https://github.com/maplibre/maplibre-gl-native/pull/270/files#diff-d57cd3143ace69af2f7ae79a917ac1328acc7543ae8a2a15f58b4635b86f1b91R148) during refactoring a typo error was introduced and because of it the calculation of `shiftY` is broken right now. This PR fixes it.
Also, there is [an issue](https://github.com/maplibre/maplibre-gl-native/issues/279) with it.

| Before | After |
| - | - |
| <img width="390" alt="image" src="https://user-images.githubusercontent.com/8909650/168667685-587d1ca4-54a2-435c-99ed-0be575304b68.png"> |  <img width="388" alt="image" src="https://user-images.githubusercontent.com/8909650/168667701-85940ff2-66a5-4e47-828e-573279ea5620.png"> |