### PR TITLE
[waiting] don't pack attributes in coordinates of line programm

### DIFF
--- a/src/mbgl/programs/attributes.hpp
+++ b/src/mbgl/programs/attributes.hpp
@@ -10,7 +10,7 @@ namespace attributes {
 MBGL_DEFINE_ATTRIBUTE(int16_t, 2, pos);
 MBGL_DEFINE_ATTRIBUTE(int16_t, 2, extrude);
 MBGL_DEFINE_ATTRIBUTE(int16_t, 4, pos_offset);
-MBGL_DEFINE_ATTRIBUTE(int16_t, 2, pos_normal);
+MBGL_DEFINE_ATTRIBUTE(int16_t, 4, pos_normal);
 MBGL_DEFINE_ATTRIBUTE(float, 3, projected_pos);
 MBGL_DEFINE_ATTRIBUTE(int16_t, 4, pixeloffset);
 MBGL_DEFINE_ATTRIBUTE(int16_t, 2, label_pos);

--- a/src/mbgl/programs/line_program.cpp
+++ b/src/mbgl/programs/line_program.cpp
@@ -10,7 +10,7 @@ namespace mbgl {
 
 using namespace style;
 
-static_assert(sizeof(LineLayoutVertex) == 8, "expected LineLayoutVertex size");
+static_assert(sizeof(LineLayoutVertex) == 12, "expected LineLayoutVertex size");
 
 template <class Values, class...Args>
 Values makeValues(const style::LinePaintProperties::PossiblyEvaluated& properties,

--- a/src/mbgl/programs/line_program.hpp
+++ b/src/mbgl/programs/line_program.hpp
@@ -55,8 +55,10 @@ public:
     static LayoutVertex layoutVertex(Point<int16_t> p, Point<double> e, bool round, bool up, int8_t dir, int32_t linesofar = 0) {
         return LayoutVertex {
             {{
-                static_cast<int16_t>((p.x * 2) | (round ? 1 : 0)),
-                static_cast<int16_t>((p.y * 2) | (up ? 1 : 0))
+                p.x,
+                p.y,
+                static_cast<int16_t>(round ? 1 : 0),
+                static_cast<int16_t>(up ? 1 : -1)
             }},
             {{
                 // add 128 to store a byte in an unsigned byte


### PR DESCRIPTION
pass round and up as own attributes.

This change goes along with https://github.com/maplibre/maplibre-gl-js/pull/1244

This PR can only be merged when the maplibre-gl-js submodule in this repo is updated to keep the shaders in sync.

# ToDo
- [ ] wait until maplibre-gl-js submodule is updated
- [ ] run scripts/generate-shaders.js
- [ ] run tests
