### PR TITLE
Replace Mapbox with MapLibre in README titles

### DIFF
--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -1,11 +1,6 @@
-# [Mapbox Maps SDK for Android](https://www.mapbox.com/android-sdk/)
+# MapLibre Maps SDK for Android
 
-[![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native-android/tree/master.svg?style=shield)](https://circleci.com/gh/mapbox/mapbox-gl-native-android/tree/master)
-
-
-[![](https://www.mapbox.com/android-docs/assets/overview-map-sdk-322-9abe118316efb5910b6101e222a2e57c.png)](https://docs.mapbox.com/android/maps/overview/)
-
-The Mapbox Maps SDK for Android is a library based on [Mapbox GL Native](https://github.com/mapbox/mapbox-gl-native/) for embedding interactive map views with scalable, customizable vector maps onto Android devices.
+The MapLibre Maps SDK for Android is a library based on MapLibre GL Native for embedding interactive map views with scalable, customizable vector maps onto Android devices.
 
 ## Getting Started
 

--- a/platform/darwin/README.md
+++ b/platform/darwin/README.md
@@ -2,9 +2,9 @@
 
 The code in the Darwin platform targets Apple platforms but is not specific
 to iOS or macOS. This code is not distributed as an SDK in itself, but is required
-by iOS and macOS builds of Mapbox GL Native and ultimately by the
-[Mapbox Maps SDK for iOS](https://github.com/mapbox/mapbox-gl-native-ios/tree/master/platform/ios)
-and [Mapbox Maps SDK for macOS](https://github.com/mapbox/mapbox-gl-native-ios/tree/master/platform/macos).
+by iOS and macOS builds of MapLibre GL Native and ultimately by the
+[MapLibre Maps SDK for iOS](https://github.com/maplibre/maplibre-gl-native/tree/main/platform/ios)
+and [MapLibre Maps SDK for macOS](https://github.com/maplibre/maplibre-gl-native/tree/main/platform/macos).
 
 These files depend on the Foundation and Core Foundation frameworks but do not
 depend on iOS- or macOS–specific frameworks, such as UIKit or AppKit. Any

--- a/platform/ios/README.md
+++ b/platform/ios/README.md
@@ -1,14 +1,9 @@
-# Mapbox Maps SDKs for iOS and macOS
+# MapLibre Maps SDKs for iOS and macOS
 
-The Mapbox Maps SDK for iOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 9.0 and above using Objective-C, Swift, or Interface Builder. It takes stylesheets that conform to the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://www.mapbox.com/developers/vector-tiles/), and renders them using OpenGL. It is based on the [Mapbox GL Native](https://github.com/mapbox/mapbox-gl-native) library.
-
-| SDK                                     | Languages                          | Build status                             |
-| --------------------------------------- | ---------------------------------- | ---------------------------------------- |
-| [Mapbox Maps SDK for iOS](platform/ios/)         | Objective-C or Swift               | [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native-ios.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native-ios/tree/master) |
-| [Mapbox Maps SDK for macOS](platform/macos/)     | Objective-C, Swift, or AppleScript | [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native-ios.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native-ios/tree/master) |
+The MapLibre Maps SDK for iOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 9.0 and above using Objective-C, Swift, or Interface Builder. It takes stylesheets that conform to the [MapLibre GL Style Specification](https://maplibre.org/maplibre-gl-js-docs/style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://www.mapbox.com/developers/vector-tiles/), and renders them using OpenGL. It is based on the MapLibre GL Native library.
 
 ## License
 
-Mapbox GL Native is licensed under the [2-Clause BSD license](LICENSE.md). The licenses of its dependencies are tracked via [FOSSA](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmapbox%2Fmapbox-gl-native):
+MapLibre GL Native is licensed under the [2-Clause BSD license](LICENSE.md). The licenses of its dependencies are tracked via [FOSSA](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmapbox%2Fmapbox-gl-native):
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmapbox%2Fmapbox-gl-native.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmapbox%2Fmapbox-gl-native)

--- a/platform/linux/README.md
+++ b/platform/linux/README.md
@@ -1,6 +1,6 @@
 # Linux
 
-A simple map application and test suite for Linux based on [Mapbox GL Native](../../README.md) and [GLFW](https://github.com/glfw/glfw).
+A simple map application and test suite for Linux based on MapLibre GL Native and [GLFW](https://github.com/glfw/glfw).
 
 We are using Ubuntu for development. While the software should work on other distributions as well, we are not providing explicit build instructions here.
 

--- a/platform/macos/README.md
+++ b/platform/macos/README.md
@@ -1,3 +1,3 @@
 # macOS
 
-This folder contains build configuration files for the macOS distribution of Mapbox GL Native, which ultimately targets Cocoa applications written in Objective-C, Swift, Interface Builder, or AppleScript via the [Mapbox Maps SDK for macOS](https://mapbox.github.io/mapbox-gl-native/macos/). The SDK was previously developed here in this repository but is now developed [in the separate mapbox-gl-native-ios repository](https://github.com/mapbox/mapbox-gl-native-ios/tree/master/platform/macos/) ([details](https://github.com/mapbox/mapbox-gl-native/issues/15971)).
+This folder contains build configuration files for the macOS distribution of MapLibre GL Native, which ultimately targets Cocoa applications written in Objective-C, Swift, Interface Builder, or AppleScript via the MapLibre Maps SDK for macOS.

--- a/platform/qt/README.md
+++ b/platform/qt/README.md
@@ -1,17 +1,13 @@
-# Mapbox Maps SDK for Qt
-
-[![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native/tree/master) [![AppVeyor CI build status](https://ci.appveyor.com/api/projects/status/3q12kbcooc6df8uc?svg=true)](https://ci.appveyor.com/project/Mapbox/mapbox-gl-native)
+# MapLibre Maps SDK for Qt
 
 ## Developing
 
 This is the foundation for the [Mapbox GL plugin](https://doc.qt.io/qt-5/location-plugin-mapboxgl.html)
 available in the Qt SDK since Qt 5.9. Use the [Qt bugtracker](https://bugreports.qt.io) for bugs related
-to the plugin and this GitHub repository for bugs related to Mapbox GL Native and the Qt bindings.
+to the plugin and this GitHub repository for bugs related to MapLibre GL Native and the Qt bindings.
 
 You should build this repository if you want to develop/contribute using the low level Qt C++ bindings or
-want to contribute to the Mapbox GL Native project using the Qt port for debugging.
-
-See the Mapbox Qt landing page for more details: https://www.mapbox.com/qt/
+want to contribute to the MapLibre GL Native project using the Qt port for debugging.
 
 ### Build dependencies
 


### PR DESCRIPTION
Replaces `Mapbox` with `MapLibre in some README titles
