### PR TITLE
Add gh-pages-android-api workflow

### DIFF
--- a/.github/workflows/gh-pages-android-api.yml
+++ b/.github/workflows/gh-pages-android-api.yml
@@ -1,0 +1,31 @@
+name: gh-pages-android-api
+
+on: 
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'     
+        required: true
+        default: '9.5.2'
+
+jobs:
+  gh-pages-android-api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Download javadoc from Maven
+        run: |
+          wget https://repo1.maven.org/maven2/org/maplibre/gl/android-sdk/${{ github.event.inputs.version }}/android-sdk-${{ github.event.inputs.version }}-javadoc.jar -O javadoc.zip
+      
+      - name: Unzip
+        run: |
+          mkdir -p unzipped/android/api/
+          unzip javadoc.zip -d unzipped/android/api/
+      
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.3.0
+        with:
+          branch: gh-pages
+          folder: unzipped


### PR DESCRIPTION
Adds a workflow which downloads the android javadocs from maven and deploys them to the GitHub Pages branch.

The url would be something like https://maplibre.org/maplibre-gl-native/android/api/

You can see a live demo of the Android API at:

https://wipfli.github.io/maplibre-gl-native/android/api/
