### PR TITLE
Cancel previous CI run on new pull request push

### DIFF
--- a/.github/workflows/android-ci-pull.yml
+++ b/.github/workflows/android-ci-pull.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    concurrency: 
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     defaults:
       run:
         working-directory: platform/android

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    concurrency: 
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     defaults:
       run:
         working-directory: platform/android

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -24,6 +24,9 @@ on:
 jobs:
   build:
     runs-on: macos-10.15
+    concurrency: 
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     env:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -26,6 +26,9 @@ on:
 jobs:
   build:
     runs-on: macos-10.15
+    concurrency: 
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     env:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -30,6 +30,9 @@ jobs:
           - ubuntu-20.04
           - ubuntu-18.04
     runs-on: ${{ matrix.os }}
+    concurrency: 
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     env:
       BUILDTYPE: ${{github.ref == 'refs/heads/main' && 'Release' || 'Debug'}}
 

--- a/.github/workflows/qt-ci-windows.yml
+++ b/.github/workflows/qt-ci-windows.yml
@@ -28,6 +28,9 @@ on:
 jobs:
   build-core:
     runs-on: windows-latest
+    concurrency: 
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     strategy:
       matrix:
         include:

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -54,6 +54,9 @@ jobs:
             qt: 6.2.2
             qt_target: desktop
     runs-on: ${{ matrix.os }}
+    concurrency: 
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     env:
       BUILD_TYPE: Debug
       BUILD_MODE: ${{ matrix.static }}


### PR DESCRIPTION
Cancels old ci runs.

See https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre

and https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
