### PR TITLE
Add iOS API docs workflow

### DIFF
--- a/.github/workflows/gh-pages-ios-api.yml
+++ b/.github/workflows/gh-pages-ios-api.yml
@@ -1,0 +1,76 @@
+name: gh-pages-ios-api
+
+on:
+  workflow_dispatch
+
+jobs:
+  build-api:
+    runs-on: macos-10.15
+    env:
+      BUILDTYPE: Debug
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+
+    defaults:
+      run:
+        working-directory: platform/ios
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install macos dependencies
+        run: |
+          brew list cmake || brew install cmake
+          brew list ccache || brew install ccache
+          brew list pkg-config || brew install pkg-config
+          brew list glfw3 || brew install glfw3
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: /user/local/lib/node_modules
+          key: ${{ runner.macos }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.macos }}-build-${{ env.cache-name }}-
+            ${{ runner.macos }}-build-
+            ${{ runner.macos }}-
+
+      - name: npm install
+        run: npm install --ignore-scripts
+
+      - name: Prepare ccache
+        run: ccache --clear
+
+      - name: Cache ccache
+        uses: actions/cache@v2
+        env:
+          cache-name: ccache-v1
+        with:
+          path: ~/.ccache'
+          key: ${{ env.cache-name }}-${{ runner.macos }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}-${{ github.head_ref }}
+          restore-keys: |
+            ${{ env.cache-name }}-${{ runner.macos }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}
+            ${{ env.cache-name }}-${{ runner.macos }}-${{ github.job }}-${{ github.ref }}
+            ${{ env.cache-name }}-${{ runner.macos }}-${{ github.job }}
+
+      - name: Clear ccache statistics
+        run: |
+          ccache --zero-stats
+          ccache --max-size=2G
+          ccache --show-stats
+
+      - name: Build docs
+        run: make idocument
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.3.0
+        with:
+          branch: gh-pages
+          folder: platform/ios/documentation/
+          target-folder: ios/api/

--- a/platform/ios/platform/darwin/docs/theme/templates/header.mustache
+++ b/platform/ios/platform/darwin/docs/theme/templates/header.mustache
@@ -3,7 +3,7 @@
     <div class="header">
     <p class="header-col header-col--primary">
       <a class="header-link" href="{{path_to_root}}index.html">
-        <img style="height: 25px;"  class="header-icon" src="{{path_to_root}}img/mapbox.svg" alt="{{module_name}} Docs"/>
+        <img style="height: 25px;"  class="header-icon" src="https://maplibre.org/img/maplibre-logo.svg" alt="{{module_name}} Docs"/>
         <span class='header-tag'>{{docs_title}} Reference ({{module_version}})</span>
       </a>
       {{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}

--- a/platform/ios/platform/ios/jazzy.yml
+++ b/platform/ios/platform/ios/jazzy.yml
@@ -1,12 +1,12 @@
 module: Mapbox
 author: Mapbox
-author_url: https://www.mapbox.com/
-github_url: https://github.com/mapbox/mapbox-gl-native-ios
+author_url: https://maplibre.org/
+github_url: https://github.com/maplibre/maplibre-gl-native
 dash_url: https://docs.mapbox.com/ios/docsets/Mapbox.xml
-copyright: '© 2014–2019 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/mapbox-gl-native-ios/blob/master/LICENSE.md) for more details.'
+copyright: '[License](https://github.com/maplibre/maplibre-gl-native/blob/main/platform/ios/LICENSE.md)'
 
 head: |
-  <link rel='shortcut icon' href='https://www.mapbox.com/img/favicon.ico' type='image/x-icon' />
+  <link rel='shortcut icon' href='https://maplibre.org/favicon.ico' type='image/x-icon' />
 
 objc: Yes
 skip_undocumented: Yes


### PR DESCRIPTION
Adds a workflow which builds the iOS API docs website and publishes it to the GitHub pages branch. The URL would be https://maplibre.org/maplibre-gl-native/ios/api/

For a live demo of how that would look like, see https://wipfli.github.io/maplibre-gl-native/ios/api/