### PR TITLE
Deploy to `android/api` GitHub Pages folder

### DIFF
--- a/.github/workflows/gh-pages-android-api.yml
+++ b/.github/workflows/gh-pages-android-api.yml
@@ -21,11 +21,12 @@ jobs:
       
       - name: Unzip
         run: |
-          mkdir -p unzipped/android/api/
-          unzip javadoc.zip -d unzipped/android/api/
+          mkdir unzipped/
+          unzip javadoc.zip -d unzipped/
       
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.3.0
         with:
           branch: gh-pages
           folder: unzipped
+          target-folder: android/api/


### PR DESCRIPTION
By default, the github pages deploy action takes a folder and pushes the contents of this folder to the github pages branch.

This deletes all previous files on the github pages branch. This would mean that an existing ios/api folder would be deleted if we push the android/api folder.

With this pull request, we only push the android docs to the android/api folder and not to the root folder.
