### PR TITLE
Contrib docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,11 @@ If you want to contribute code:
 
 1. Please familiarize yourself with the [install process](INSTALL.md).
 
-1. Ensure that existing [pull requests](https://github.com/mapbox/mapbox-gl-native-ios/pulls) and [issues](https://github.com/mapbox/mapbox-gl-native-ios/issues) don’t already cover your contribution or question.
+1. Ensure that existing [pull requests](https://github.com/maplibre/maplibre-gl-native/pulls) and [issues](https://github.com/maplibre/maplibre-gl-native/issues) don’t already cover your contribution or question.
 
 1. Pull requests are gladly accepted. If there are any changes that developers using one of the GL SDKs should be aware of, please update the **master** section of the relevant changelog(s):
-  * [Mapbox Maps SDK for iOS](platform/ios/CHANGELOG.md)
-  * [Mapbox Maps SDK for macOS](platform/macos/CHANGELOG.md)
+  * [Maplibre Maps SDK for iOS](platform/ios/CHANGELOG.md)
+  * [Maplibre Maps SDK for macOS](platform/macos/CHANGELOG.md)
 
 1. Prefix your commit messages with the platform(s) your changes affect: `[ios]` or `[macos]`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ If you have a usage question for a product built on MapLibre GL (such as our iOS
 
 If you want to contribute code:
 
-1. Please familiarize yourself with the [install process](INSTALL.md).
+1. Please familiarize yourself with the [install process](README.md#installation).
 
 1. Ensure that existing [pull requests](https://github.com/maplibre/maplibre-gl-native/pulls) and [issues](https://github.com/maplibre/maplibre-gl-native/issues) don’t already cover your contribution or question.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,4 +14,4 @@ If you want to contribute code:
 
 1. Prefix your commit messages with the platform(s) your changes affect: `[ios]` or `[macos]`.
 
-Please note the special instructions for contributing new source code files, asset files, or user-facing strings to the [iOS SDK](platform/ios/DEVELOPING.md#contributing) or [macOS SDK](platform/macos/DEVELOPING.md#contributing).
+Please note the special instructions for contributing new source code files, asset files, or user-facing strings to the [iOS SDK](platform/ios/DEVELOPING.md) or [macOS SDK](platform/macos/DEVELOPING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ If you want to contribute code:
 1. Ensure that existing [pull requests](https://github.com/maplibre/maplibre-gl-native/pulls) and [issues](https://github.com/maplibre/maplibre-gl-native/issues) don’t already cover your contribution or question.
 
 1. Pull requests are gladly accepted. If there are any changes that developers using one of the GL SDKs should be aware of, please update the **master** section of the relevant changelog(s):
-  * [Maplibre Maps SDK for iOS](platform/ios/CHANGELOG.md)
-  * [Maplibre Maps SDK for macOS](platform/macos/CHANGELOG.md)
+  * [MapLibre Maps SDK for iOS](platform/ios/CHANGELOG.md)
+  * [MapLibre Maps SDK for macOS](platform/macos/CHANGELOG.md)
 
 1. Prefix your commit messages with the platform(s) your changes affect: `[ios]` or `[macos]`.
 


### PR DESCRIPTION
Actually fix #134.

Mapbox links and anchors still exist in files linked from CONTRIBUTING.md though.