### PR TITLE
Remove `changelog_staging` files

### DIFF
--- a/scripts/changelog_staging/idle-event.json
+++ b/scripts/changelog_staging/idle-event.json
@@ -1,6 +1,0 @@
-{
-  "core": "Add onDidEnterIdle to MapObserver, which fires whenever render completes and no repaint is scheduled.",
-  "darwin": "Add mapViewDidEnterIdle to MGLMapViewDelegate, which fires whenever render completes and no repaint is scheduled.",
-  "android": "Add onDidEnterIdle listener to MapView, which fires whenever render completes and no repaint is scheduled.",
-  "issue": 13469
-}

--- a/scripts/changelog_staging/no-offline-cjk.json
+++ b/scripts/changelog_staging/no-offline-cjk.json
@@ -1,6 +1,0 @@
-{
-  "core": "Add `--includeIdeographs` option to mbgl-offline tool to include CJK glyphs in offline region, at the cost of increased size requirements.",
-  "darwin": "Added the `MGLOfflineRegion.includesIdeographicGlyphs` property, which you can set to NO to exclude CJK glyphs and save space.",
-  "android": "Added the `includeIdeographs` property to `OfflineRegionDefinition`, which you can set to false to exclude CJK glyphs and save space.",
-  "issue": 11561
-}

--- a/scripts/changelog_staging/tile-is-child.json
+++ b/scripts/changelog_staging/tile-is-child.json
@@ -1,4 +1,0 @@
-{
-  "core": "Fix OverscaledTileID::isChildOf to exclude tiles with different wrap. Incorrect child detection could cause flickering for symbols displaying in two wrapped world copies at the same time.",
-  "issue": 13478
-}


### PR DESCRIPTION
The changelog staging files seem to be left overs from the Mapbox repo and can be removed.
