### PR TITLE
Remove android api docs from installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,6 @@ git checkout tags/$TAG -b $TAG
 
 ### Android
 
-The Android API documentation is available at https://maplibre.org/maplibre-gl-native/android/api/
-
 ---
 
 <details open><summary>macOS Build Environment:  Android Studio + NDK</summary>


### PR DESCRIPTION
The docs link is already a bit higher up in the readme and does not belong to the install section. I think I put it there by mistake...