### PR TITLE
Remove redundant working directory

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -70,7 +70,6 @@ jobs:
 
       - name: npm install
         run: npm install --ignore-scripts
-        working-directory: platform/android
 
       - name: Prepare ccache
         run: ccache --clear


### PR DESCRIPTION
The working directory is set to `platform/android` for the entire action. The npm step does not need to set it.