### PR TITLE
Only override CMAKE_OSX_ARCHITECTURES for XCode

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -154,8 +154,6 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} -DMBGL_WITH_COVERAGE=ON
-          sed -i -e 's/$(ARCHS_STANDARD)/x86_64/g' build/build.ninja
-          sed -i -e 's/-arch arm64e/-arch x86_64/g' build/build.ninja
 
       - name: CMake
         if: runner.os == 'Linux'

--- a/platform/ios/ios.cmake
+++ b/platform/ios/ios.cmake
@@ -7,7 +7,9 @@ endif()
 # Override default CMake NATIVE_ARCH_ACTUAL
 # https://gitlab.kitware.com/cmake/cmake/-/issues/20893
 # https://stackoverflow.com/a/22689917/5531400
-set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)")
+if(CMAKE_GENERATOR STREQUAL Xcode)
+    set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)")
+endif()
 set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH[variant=Debug] "YES")
 
 macro(initialize_ios_target target)

--- a/platform/macos/macos.cmake
+++ b/platform/macos/macos.cmake
@@ -4,7 +4,9 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11")
 # Override default CMake NATIVE_ARCH_ACTUAL
 # https://gitlab.kitware.com/cmake/cmake/-/issues/20893
 # https://stackoverflow.com/a/22689917/5531400
-set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)")
+if(CMAKE_GENERATOR STREQUAL Xcode)
+    set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)")
+endif()
 set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH[variant=Debug] "YES")
 
 set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)

--- a/platform/node/DEVELOPING.md
+++ b/platform/node/DEVELOPING.md
@@ -51,12 +51,6 @@ To compile the Node.js bindings and install module dependencies, from the reposi
 cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DMBGL_WITH_COVERAGE=ON
 ```
 
-Then, as a temporary step until build system is changed, run:
-```bash
-sed -i -e 's/$(ARCHS_STANDARD)/x86_64/g' build/build.ninja
-sed -i -e 's/-arch arm64e/-arch x86_64/g' build/build.ninja
-```
-
 #### Linux
 
 ```bash


### PR DESCRIPTION
Only override `CMAKE_OSX_ARCHITECTURES` for `XCode`. This simplifies/fixes node build on macOS.

Looking at `platform/ios/Makefile` we only ever use XCode for building iOS and macOS bindings so this should be a safe change.