### PR TITLE
Replace master with main in node changelog

### DIFF
--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-# master
+# main
 * Add support for [image expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-types-image). ([#15877](https://github.com/mapbox/mapbox-gl-native/pull/15877))
 
 # 5.0.0


### PR DESCRIPTION
Replaces master with main in the node changelog.
