### PR TITLE
Add ClientOptions to be able to pass around client name and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### ✨ New features
 
-- *...Add new stuff here...*
+- [core] Add `ClientOptions` to configure client information.
+- [qt] Build user agent based on `ClientOptions`, if available.
 
 ### 🐞 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### ✨ New features
 
-- [core] Add `ClientOptions` to configure client information.
-- [qt] Build user agent based on `ClientOptions`, if available.
+- [core] Add `ClientOptions` to configure client information [#365](https://github.com/maplibre/maplibre-gl-native/pull/365).
+- [qt] Build user agent based on `ClientOptions`, if available [#365](https://github.com/maplibre/maplibre-gl-native/pull/365).
 
 ### 🐞 Bug fixes
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ target_sources(
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/async_task.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/char_array_buffer.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/chrono.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/util/client_options.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/color.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/compression.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/constants.hpp
@@ -774,6 +775,7 @@ target_sources(
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/bounding_volumes.hpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/bounding_volumes.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/chrono.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/util/client_options.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/color.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/constants.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/convert.cpp

--- a/bin/offline.cpp
+++ b/bin/offline.cpp
@@ -5,6 +5,7 @@
 #include <mbgl/storage/database_file_source.hpp>
 #include <mbgl/storage/file_source_manager.hpp>
 #include <mbgl/storage/resource_options.hpp>
+#include <mbgl/util/client_options.hpp>
 #include <mbgl/util/tile_server_options.hpp>
 
 #include <args.hxx>
@@ -172,12 +173,13 @@ int main(int argc, char *argv[]) {
             FileSourceType::Database,
             ResourceOptions().withApiKey(apiKey)
               .withTileServerOptions(mapTilerConfiguration)
-              .withCachePath(output))));
+              .withCachePath(output),
+            ClientOptions())));
 
     std::unique_ptr<OfflineRegion> region;
 
     if (inputDb && mergePath) {
-        DatabaseFileSource inputSource(ResourceOptions().withCachePath(*inputDb));
+        DatabaseFileSource inputSource(ResourceOptions().withCachePath(*inputDb), ClientOptions());
 
         int retCode = 0;
         std::cout << "Start Merge" << std::endl;

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -13,6 +13,7 @@
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/map/projection_mode.hpp>
 #include <mbgl/storage/resource_options.hpp>
+#include <mbgl/util/client_options.hpp>
 
 #include <cstdint>
 #include <string>
@@ -35,7 +36,8 @@ public:
     explicit Map(RendererFrontend&,
                  MapObserver&,
                  const MapOptions&,
-                 const ResourceOptions&);
+                 const ResourceOptions&,
+                 const ClientOptions& = ClientOptions());
     ~Map();
 
     // Register a callback that will get called (on the render thread) when all resources have

--- a/include/mbgl/storage/database_file_source.hpp
+++ b/include/mbgl/storage/database_file_source.hpp
@@ -4,16 +4,16 @@
 #include <mbgl/storage/offline.hpp>
 #include <mbgl/util/expected.hpp>
 #include <mbgl/util/optional.hpp>
-#include <mbgl/storage/resource_options.hpp>
 
 namespace mbgl {
 
+class ClientOptions;
 class ResourceOptions;
 
 // TODO: Split DatabaseFileSource into Ambient cache and Database interfaces.
 class DatabaseFileSource : public FileSource {
 public:
-    explicit DatabaseFileSource(const ResourceOptions& options);
+    explicit DatabaseFileSource(const ResourceOptions& resourceOptions, const ClientOptions& clientOptions);
     ~DatabaseFileSource() override;
 
     // FileSource overrides
@@ -235,6 +235,9 @@ public:
 
     void setResourceOptions(ResourceOptions) override;
     ResourceOptions getResourceOptions() override;
+
+    void setClientOptions(ClientOptions) override;
+    ClientOptions getClientOptions() override;
 
 private:
     class Impl;

--- a/include/mbgl/storage/file_source.hpp
+++ b/include/mbgl/storage/file_source.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/storage/resource_transform.hpp>
 #include <mbgl/storage/response.hpp>
 #include <mbgl/storage/resource_options.hpp>
+#include <mbgl/util/client_options.hpp>
 
 #include <mapbox/compatibility/value.hpp>
 
@@ -91,6 +92,11 @@ public:
     virtual void setResourceOptions(ResourceOptions) = 0;
     // gets the resource options
     virtual ResourceOptions getResourceOptions() = 0;
+
+    // sets the client options
+    virtual void setClientOptions(ClientOptions) = 0;
+    // gets the client options
+    virtual ClientOptions getClientOptions() = 0;
 
 protected:
     FileSource() = default;

--- a/include/mbgl/storage/file_source_manager.hpp
+++ b/include/mbgl/storage/file_source_manager.hpp
@@ -5,6 +5,7 @@
 
 namespace mbgl {
 
+class ClientOptions;
 class ResourceOptions;
 
 /**
@@ -18,7 +19,7 @@ class ResourceOptions;
  */
 class FileSourceManager {
 public:
-    using FileSourceFactory = std::function<std::unique_ptr<FileSource>(const ResourceOptions&)>;
+    using FileSourceFactory = std::function<std::unique_ptr<FileSource>(const ResourceOptions&, const ClientOptions&)>;
 
     /**
      * @brief A singleton getter.
@@ -30,7 +31,7 @@ public:
     // Returns shared instance of a file source for (type, options) tuple.
     // Creates new instance via registered factory if needed. If new instance cannot be
     // created, nullptr would be returned.
-    PassRefPtr<FileSource> getFileSource(FileSourceType, const ResourceOptions&) noexcept;
+    PassRefPtr<FileSource> getFileSource(FileSourceType, const ResourceOptions&, const ClientOptions& = ClientOptions()) noexcept;
 
     // Registers file source factory for a provided FileSourceType type. If factory for the
     // same type was already registered, will unregister previously registered factory.

--- a/include/mbgl/storage/online_file_source.hpp
+++ b/include/mbgl/storage/online_file_source.hpp
@@ -2,16 +2,19 @@
 
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/storage/resource_options.hpp>
+#include <mbgl/util/client_options.hpp>
 #include <mbgl/util/optional.hpp>
 
 namespace mbgl {
 
 class OnlineFileSource : public FileSource {
 public:
-    OnlineFileSource(const ResourceOptions& options);
+    OnlineFileSource(const ResourceOptions& resourceOptions, const ClientOptions& clientOptions);
     ~OnlineFileSource() override;
     void setResourceOptions(ResourceOptions) override;
-    ResourceOptions getResourceOptions() override;    
+    ResourceOptions getResourceOptions() override;
+    void setClientOptions(ClientOptions) override;
+    ClientOptions getClientOptions() override;
 
 private:
     // FileSource overrides

--- a/include/mbgl/util/client_options.hpp
+++ b/include/mbgl/util/client_options.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace mbgl {
+
+/**
+ * @brief Holds values for client options.
+ */
+class ClientOptions final {
+public:
+    /**
+     * @brief Constructs a ClientOptions object with default values.
+     */
+    ClientOptions();
+    ~ClientOptions();
+
+    ClientOptions(ClientOptions&&) noexcept;
+    ClientOptions& operator=(const ClientOptions& options);
+    ClientOptions& operator=(ClientOptions&& options);
+
+    ClientOptions clone() const;
+
+    /**
+     * @brief Sets the client name.
+     *
+     * @param name Client name.
+     * @return ClientOptions for chaining options together.
+     */
+    ClientOptions& withName(std::string name);
+
+    /**
+     * @brief Gets the previously set (or default) client name.
+     *
+     * @return client name
+     */
+    const std::string& name() const;
+
+    /**
+     * @brief Sets the client version.
+     *
+     * @param version Client version.
+     * @return ClientOptions for chaining options together.
+     */
+    ClientOptions& withVersion(std::string version);
+
+    /**
+     * @brief Gets the previously set (or default) client version.
+     *
+     * @return client version
+     */
+    const std::string& version() const;
+
+private:
+    ClientOptions(const ClientOptions&);
+
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace mbgl

--- a/platform/android/MapboxGLAndroidSDK/src/cpp/asset_manager_file_source.hpp
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/asset_manager_file_source.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/storage/resource_options.hpp>
+#include <mbgl/util/client_options.hpp>
 
 #include "asset_manager.hpp"
 
@@ -15,7 +16,7 @@ template <typename T> class Thread;
 
 class AssetManagerFileSource : public FileSource {
 public:
-    AssetManagerFileSource(jni::JNIEnv&, const jni::Object<android::AssetManager>&, const ResourceOptions);
+    AssetManagerFileSource(jni::JNIEnv&, const jni::Object<android::AssetManager>&, const ResourceOptions, const ClientOptions);
     ~AssetManagerFileSource() override;
 
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
@@ -23,6 +24,9 @@ public:
 
     void setResourceOptions(ResourceOptions options) override;
     ResourceOptions getResourceOptions() override;
+
+    void setClientOptions(ClientOptions options) override;
+    ClientOptions getClientOptions() override;
 
 private:
     class Impl;

--- a/platform/android/MapboxGLAndroidSDK/src/cpp/file_source.hpp
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/file_source.hpp
@@ -72,12 +72,15 @@ public:
 
     static mbgl::ResourceOptions getSharedResourceOptions(jni::JNIEnv&, const jni::Object<FileSource>&);
 
+    static mbgl::ClientOptions getSharedClientOptions(jni::JNIEnv&, const jni::Object<FileSource>&);
+
     static void registerNative(jni::JNIEnv&);
 
 private:
     const std::string DATABASE_FILE = "/mbgl-offline.db";
     optional<int> activationCounter;
     mbgl::ResourceOptions resourceOptions;
+    mbgl::ClientOptions clientOptions;
     std::unique_ptr<Actor<ResourceTransform::TransformCallback>> resourceTransform;
     std::function<void()> pathChangeCallback;
     std::shared_ptr<mbgl::DatabaseFileSource> databaseSource;

--- a/platform/android/MapboxGLAndroidSDK/src/cpp/http_file_source.cpp
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/http_file_source.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/storage/response.hpp>
+#include <mbgl/util/client_options.hpp>
 #include <mbgl/util/logging.hpp>
 
 #include <mbgl/util/async_request.hpp>
@@ -17,15 +18,20 @@ namespace mbgl {
 
 class HTTPFileSource::Impl {
 public:
-    Impl(const ResourceOptions options): resourceOptions(options.clone()){};
+    Impl(const ResourceOptions resourceOptions_, const ClientOptions clientOptions_)
+        : resourceOptions(resourceOptions_.clone()), clientOptions(clientOptions_.clone()) {};
 
     android::UniqueEnv env { android::AttachEnv() };
 
     void setResourceOptions(ResourceOptions options) {resourceOptions = options;};
     ResourceOptions getResourceOptions() {return resourceOptions.clone(); };
 
+    void setClientOptions(ClientOptions options) {clientOptions = options;};
+    ClientOptions getClientOptions() {return clientOptions.clone();};
+
 private:
     ResourceOptions resourceOptions;
+    ClientOptions clientOptions;
 };
 
 class HTTPRequest : public AsyncRequest {
@@ -191,8 +197,8 @@ void HTTPRequest::onFailure(jni::JNIEnv& env, int type, const jni::String& messa
     async.send();
 }
 
-HTTPFileSource::HTTPFileSource(const ResourceOptions& options)
-    : impl(std::make_unique<Impl>(options.clone())) {
+HTTPFileSource::HTTPFileSource(const ResourceOptions& resourceOptions, const ClientOptions& clientOptions)
+    : impl(std::make_unique<Impl>(resourceOptions.clone(), clientOptions.clone())) {
 }
 
 HTTPFileSource::~HTTPFileSource() = default;
@@ -207,6 +213,14 @@ void HTTPFileSource::setResourceOptions(ResourceOptions options) {
 
 ResourceOptions HTTPFileSource::getResourceOptions() {
     return impl->getResourceOptions();
+}
+
+void HTTPFileSource::setClientOptions(ClientOptions options) {
+    impl->setClientOptions(options.clone());
+}
+
+ClientOptions HTTPFileSource::getClientOptions() {
+    return impl->getClientOptions();
 }
 
 } // namespace mbgl

--- a/platform/android/MapboxGLAndroidSDK/src/cpp/native_map_view.cpp
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/native_map_view.cpp
@@ -85,7 +85,8 @@ NativeMapView::NativeMapView(jni::JNIEnv& _env,
     // Create the core map
     map = std::make_unique<mbgl::Map>(
         *rendererFrontend, *this, options,
-        mbgl::android::FileSource::getSharedResourceOptions(_env, jFileSource));
+        mbgl::android::FileSource::getSharedResourceOptions(_env, jFileSource),
+        mbgl::android::FileSource::getSharedClientOptions(_env, jFileSource));
 }
 
 /**

--- a/platform/android/MapboxGLAndroidSDK/src/cpp/offline/offline_manager.cpp
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/offline/offline_manager.cpp
@@ -27,7 +27,9 @@ void handleException(std::exception_ptr exception,
 OfflineManager::OfflineManager(jni::JNIEnv& env, const jni::Object<FileSource>& jFileSource)
     : fileSource(std::static_pointer_cast<mbgl::DatabaseFileSource>(
           std::shared_ptr<mbgl::FileSource>(mbgl::FileSourceManager::get()->getFileSource(
-              mbgl::FileSourceType::Database, FileSource::getSharedResourceOptions(env, jFileSource))))) {
+              mbgl::FileSourceType::Database,
+              FileSource::getSharedResourceOptions(env, jFileSource),
+              FileSource::getSharedClientOptions(env, jFileSource))))) {
     if (!fileSource) {
         ThrowNew(env, jni::FindClass(env, "java/lang/IllegalStateException"), "Offline functionality is disabled.");
     }

--- a/platform/android/MapboxGLAndroidSDK/src/cpp/offline/offline_region.cpp
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/offline/offline_region.cpp
@@ -18,7 +18,9 @@ OfflineRegion::OfflineRegion(jni::JNIEnv& env, jni::jlong offlineRegionPtr, cons
     : region(reinterpret_cast<mbgl::OfflineRegion*>(offlineRegionPtr)),
       fileSource(std::static_pointer_cast<mbgl::DatabaseFileSource>(
           std::shared_ptr<mbgl::FileSource>(mbgl::FileSourceManager::get()->getFileSource(
-              mbgl::FileSourceType::Database, FileSource::getSharedResourceOptions(env, jFileSource))))) {
+              mbgl::FileSourceType::Database,
+              FileSource::getSharedResourceOptions(env, jFileSource),
+              FileSource::getSharedClientOptions(env, jFileSource))))) {
     if (!fileSource) {
         ThrowNew(env, jni::FindClass(env, "java/lang/IllegalStateException"), "Offline functionality is disabled.");
     }

--- a/platform/android/MapboxGLAndroidSDK/src/cpp/snapshotter/map_snapshotter.cpp
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/snapshotter/map_snapshotter.cpp
@@ -46,6 +46,7 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
         size,
         pixelRatio,
         mbgl::android::FileSource::getSharedResourceOptions(_env, _jFileSource),
+        mbgl::android::FileSource::getSharedClientOptions(_env, _jFileSource),
         *this,
         _localIdeographFontFamily ? jni::Make<std::string>(_env, _localIdeographFontFamily) : optional<std::string>{});
 

--- a/platform/android/src/test/http_file_source_test_stub.cpp
+++ b/platform/android/src/test/http_file_source_test_stub.cpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class HTTPFileSource::Impl {};
 
-HTTPFileSource::HTTPFileSource(const ResourceOptions& /*options*/)
+HTTPFileSource::HTTPFileSource(const ResourceOptions& /*resourceOptions*/, const ClientOptions& /*clientOptions*/)
     : impl(std::make_unique<Impl>()) {
 }
 
@@ -18,6 +18,13 @@ void HTTPFileSource::setResourceOptions(ResourceOptions /*options*/) {
 
 ResourceOptions HTTPFileSource::getResourceOptions() {
     return ResourceOptions::Default();
+}
+
+void HTTPFileSource::setClientOptions(ClientOptions /*options*/) {
+}
+
+ClientOptions HTTPFileSource::getClientOptions() {
+    return ClientOptions();
 }
 
 std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource&, Callback) {

--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -3,6 +3,7 @@
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/storage/response.hpp>
 
+#include <mbgl/util/client_options.hpp>
 #include <mbgl/util/http_header.hpp>
 #include <mbgl/util/async_task.hpp>
 #include <mbgl/util/async_request.hpp>
@@ -83,7 +84,8 @@ private:
 
 class HTTPFileSource::Impl {
 public:
-    Impl(const ResourceOptions& options): resourceOptions(options.clone()) {
+    Impl(const ResourceOptions& resourceOptions_, const ClientOptions& clientOptions_)
+        : resourceOptions(resourceOptions_.clone()), clientOptions(clientOptions_.clone()) {
         @autoreleasepool {
             NSURLSessionConfiguration *sessionConfig = MGLNativeNetworkManager.sharedManager.sessionConfiguration;
             session = [NSURLSession sessionWithConfiguration:sessionConfig];
@@ -95,6 +97,9 @@ public:
     void setResourceOptions(ResourceOptions options);
     ResourceOptions getResourceOptions();
 
+    void setClientOptions(ClientOptions options);
+    ClientOptions getClientOptions();
+
     NSURLSession* session = nil;
     NSString* userAgent = nil;
 
@@ -102,6 +107,7 @@ private:
     NSString* getUserAgent() const;
     NSBundle* getSDKBundle() const;
     ResourceOptions resourceOptions;
+    ClientOptions clientOptions;
 };
 
 void HTTPFileSource::Impl::setResourceOptions(ResourceOptions options) {
@@ -110,6 +116,14 @@ void HTTPFileSource::Impl::setResourceOptions(ResourceOptions options) {
 
 ResourceOptions HTTPFileSource::Impl::getResourceOptions() {
     return resourceOptions.clone();
+}
+
+void HTTPFileSource::Impl::setClientOptions(ClientOptions options) {
+    clientOptions = options;
+}
+
+ClientOptions HTTPFileSource::Impl::getClientOptions() {
+    return clientOptions.clone();
 }
 
 NSString *HTTPFileSource::Impl::getUserAgent() const {
@@ -193,8 +207,8 @@ NSBundle *HTTPFileSource::Impl::getSDKBundle() const {
     return bundle;
 }
 
-HTTPFileSource::HTTPFileSource(const ResourceOptions& options)
-    : impl(std::make_unique<Impl>(options)) {
+HTTPFileSource::HTTPFileSource(const ResourceOptions& resourceOptions, const ClientOptions& clientOptions)
+    : impl(std::make_unique<Impl>(resourceOptions, clientOptions)) {
 }
 
 HTTPFileSource::~HTTPFileSource() = default;
@@ -403,5 +417,12 @@ ResourceOptions HTTPFileSource::getResourceOptions() {
     return impl->getResourceOptions();
 }
 
+void HTTPFileSource::setClientOptions(ClientOptions options) {
+    impl->setClientOptions(options.clone());
+}
+
+ClientOptions HTTPFileSource::getClientOptions() {
+    return impl->getClientOptions();
+}
 
 }

--- a/platform/default/include/mbgl/map/map_snapshotter.hpp
+++ b/platform/default/include/mbgl/map/map_snapshotter.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/util/client_options.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/geo.hpp>
@@ -12,6 +13,7 @@
 namespace mbgl {
 
 struct CameraOptions;
+class ClientOptions;
 class LatLngBounds;
 class ResourceOptions;
 
@@ -34,10 +36,11 @@ public:
     MapSnapshotter(Size size,
                    float pixelRatio,
                    const ResourceOptions&,
+                   const ClientOptions&,
                    MapSnapshotterObserver&,
                    optional<std::string> localFontFamily = nullopt);
 
-    MapSnapshotter(Size size, float pixelRatio, const ResourceOptions&);
+    MapSnapshotter(Size size, float pixelRatio, const ResourceOptions&, const ClientOptions& = ClientOptions());
 
     ~MapSnapshotter();
 

--- a/platform/default/src/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/src/mbgl/map/map_snapshotter.cpp
@@ -151,6 +151,7 @@ public:
     Impl(Size size,
          float pixelRatio,
          const ResourceOptions& resourceOptions,
+         const ClientOptions& clientOptions,
          MapSnapshotterObserver& observer_,
          optional<std::string> localFontFamily)
         : observer(observer_),
@@ -158,7 +159,8 @@ public:
           map(frontend,
               *this,
               MapOptions().withMapMode(MapMode::Static).withSize(size).withPixelRatio(pixelRatio),
-              resourceOptions) {}
+              resourceOptions,
+              clientOptions) {}
 
     void setRegion(const LatLngBounds& region) {
         mbgl::EdgeInsets insets{0, 0, 0, 0};
@@ -252,13 +254,14 @@ private:
 MapSnapshotter::MapSnapshotter(Size size,
                                float pixelRatio,
                                const ResourceOptions& resourceOptions,
+                               const ClientOptions& clientOptions,
                                MapSnapshotterObserver& observer,
                                optional<std::string> localFontFamily)
     : impl(std::make_unique<MapSnapshotter::Impl>(
-          size, pixelRatio, resourceOptions, observer, std::move(localFontFamily))) {}
+          size, pixelRatio, resourceOptions, clientOptions, observer, std::move(localFontFamily))) {}
 
-MapSnapshotter::MapSnapshotter(Size size, float pixelRatio, const ResourceOptions& resourceOptions)
-    : MapSnapshotter(size, pixelRatio, resourceOptions, MapSnapshotterObserver::nullObserver()) {}
+MapSnapshotter::MapSnapshotter(Size size, float pixelRatio, const ResourceOptions& resourceOptions, const ClientOptions& clientOptions)
+    : MapSnapshotter(size, pixelRatio, resourceOptions, clientOptions, MapSnapshotterObserver::nullObserver()) {}
 
 MapSnapshotter::~MapSnapshotter() = default;
 

--- a/platform/default/src/mbgl/storage/file_source_manager.cpp
+++ b/platform/default/src/mbgl/storage/file_source_manager.cpp
@@ -12,27 +12,28 @@ namespace mbgl {
 class DefaultFileSourceManagerImpl final : public FileSourceManager {
 public:
     DefaultFileSourceManagerImpl() {
-        registerFileSourceFactory(FileSourceType::ResourceLoader, [](const ResourceOptions& options) {
-            return std::make_unique<MainResourceLoader>(options);
+        registerFileSourceFactory(FileSourceType::ResourceLoader, [](const ResourceOptions& resourceOptions, const ClientOptions& clientOptions) {
+            return std::make_unique<MainResourceLoader>(resourceOptions, clientOptions);
         });
 
-        registerFileSourceFactory(FileSourceType::Asset, [](const ResourceOptions& options) {
-            return std::make_unique<AssetFileSource>(options);
+        registerFileSourceFactory(FileSourceType::Asset, [](const ResourceOptions& resourceOptions, const ClientOptions& clientOptions) {
+            return std::make_unique<AssetFileSource>(resourceOptions, clientOptions);
         });
 
-        registerFileSourceFactory(FileSourceType::Database, [](const ResourceOptions& options) {
-            return std::make_unique<DatabaseFileSource>(options);
+        registerFileSourceFactory(FileSourceType::Database, [](const ResourceOptions& resourceOptions, const ClientOptions& clientOptions) {
+            return std::make_unique<DatabaseFileSource>(resourceOptions, clientOptions);
         });
 
-        registerFileSourceFactory(FileSourceType::FileSystem,
-                                  [](const ResourceOptions& options) { return std::make_unique<LocalFileSource>(options); });
+        registerFileSourceFactory(FileSourceType::FileSystem, [](const ResourceOptions& resourceOptions, const ClientOptions& clientOptions) {
+            return std::make_unique<LocalFileSource>(resourceOptions, clientOptions);
+        });
 
-        registerFileSourceFactory(FileSourceType::Mbtiles,
-                                  [](const ResourceOptions& options) { return std::make_unique<MBTilesFileSource>(options); });
+        registerFileSourceFactory(FileSourceType::Mbtiles, [](const ResourceOptions& resourceOptions, const ClientOptions& clientOptions) {
+            return std::make_unique<MBTilesFileSource>(resourceOptions, clientOptions);
+        });
 
-        registerFileSourceFactory(FileSourceType::Network, [](const ResourceOptions& options) {
-            std::unique_ptr<FileSource> networkSource = std::make_unique<OnlineFileSource>(options);
-            return networkSource;
+        registerFileSourceFactory(FileSourceType::Network, [](const ResourceOptions& resourceOptions, const ClientOptions& clientOptions) {
+            return std::make_unique<OnlineFileSource>(resourceOptions, clientOptions);
         });
     }
 };

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -121,11 +121,12 @@ void glfwError(int error, const char *description) {
     mbgl::Log::Error(mbgl::Event::OpenGL, "GLFW error (%i): %s", error, description);
 }
 
-GLFWView::GLFWView(bool fullscreen_, bool benchmark_, const mbgl::ResourceOptions &options)
+GLFWView::GLFWView(bool fullscreen_, bool benchmark_, const mbgl::ResourceOptions &resourceOptions, const mbgl::ClientOptions &clientOptions)
     : fullscreen(fullscreen_),
       benchmark(benchmark_),
       snapshotterObserver(std::make_unique<SnapshotObserver>()),
-      mapResourceOptions(options.clone()) {
+      mapResourceOptions(resourceOptions.clone()),
+      mapClientOptions(clientOptions.clone()) {
     glfwSetErrorCallback(glfwError);
 
     std::srand(static_cast<unsigned int>(std::time(nullptr)));
@@ -726,7 +727,7 @@ void GLFWView::popAnnotation() {
 void GLFWView::makeSnapshot(bool withOverlay) {
     if (!snapshotter || snapshotter->getStyleURL() != map->getStyle().getURL()) {
         snapshotter = std::make_unique<mbgl::MapSnapshotter>(
-            map->getMapOptions().size(), map->getMapOptions().pixelRatio(), mapResourceOptions, *snapshotterObserver);
+            map->getMapOptions().size(), map->getMapOptions().pixelRatio(), mapResourceOptions, mapClientOptions, *snapshotterObserver);
         snapshotter->setStyleURL(map->getStyle().getURL());
     }
 

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -25,7 +25,7 @@ class RendererBackend;
 
 class GLFWView : public mbgl::MapObserver {
 public:
-    GLFWView(bool fullscreen, bool benchmark, const mbgl::ResourceOptions &options);
+    GLFWView(bool fullscreen, bool benchmark, const mbgl::ResourceOptions &resourceOptions, const mbgl::ClientOptions &clientOptions);
     ~GLFWView() override;
 
     float getPixelRatio() const;
@@ -152,6 +152,7 @@ private:
     std::unique_ptr<mbgl::MapSnapshotter> snapshotter;
     std::unique_ptr<SnapshotObserver> snapshotterObserver;
     mbgl::ResourceOptions mapResourceOptions;
+    mbgl::ClientOptions mapClientOptions;
 
 #if defined(MBGL_RENDER_BACKEND_OPENGL) && !defined(MBGL_LAYER_CUSTOM_DISABLE_ALL)
     bool puckFollowsCameraCenter = false;

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -102,13 +102,14 @@ int main(int argc, char *argv[]) {
     auto mapTilerConfiguration = mbgl::TileServerOptions::MapTilerConfiguration();
     mbgl::ResourceOptions resourceOptions;
     resourceOptions.withCachePath(cacheDB).withApiKey(apikey).withTileServerOptions(mapTilerConfiguration);
+    mbgl::ClientOptions clientOptions;
     auto orderedStyles = mapTilerConfiguration.defaultStyles();
 
-    GLFWView backend(fullscreen, benchmark, resourceOptions);
+    GLFWView backend(fullscreen, benchmark, resourceOptions, clientOptions);
     view = &backend;
 
     std::shared_ptr<mbgl::FileSource> onlineFileSource =
-        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, resourceOptions);
+        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, resourceOptions, clientOptions);
     if (!settings.online) {
         if (onlineFileSource) {
             onlineFileSource->setProperty("online-status", false);
@@ -122,7 +123,7 @@ int main(int argc, char *argv[]) {
     GLFWRendererFrontend rendererFrontend { std::make_unique<mbgl::Renderer>(view->getRendererBackend(), view->getPixelRatio()), *view };
 
     mbgl::Map map(rendererFrontend, *view,
-                  mbgl::MapOptions().withSize(view->getSize()).withPixelRatio(view->getPixelRatio()), resourceOptions);
+                  mbgl::MapOptions().withSize(view->getSize()).withPixelRatio(view->getPixelRatio()), resourceOptions, clientOptions);
 
     backend.setMap(&map);
 
@@ -166,7 +167,7 @@ int main(int argc, char *argv[]) {
 
     // Resource loader controls top-level request processing and can resume / pause all managed sources simultaneously.
     std::shared_ptr<mbgl::FileSource> resourceLoader =
-        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::ResourceLoader, resourceOptions);
+        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::ResourceLoader, resourceOptions, clientOptions);
     view->setPauseResumeCallback([resourceLoader]() {
         static bool isPaused = false;
 
@@ -181,7 +182,7 @@ int main(int argc, char *argv[]) {
 
     // Database file source.
     auto databaseFileSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(std::shared_ptr<mbgl::FileSource>(
-        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, resourceOptions)));
+        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, resourceOptions, clientOptions)));
     view->setResetCacheCallback([databaseFileSource]() {
         databaseFileSource->resetDatabase([](const std::exception_ptr& ex) {
             if (ex) {

--- a/platform/ios/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/ios/platform/darwin/src/MGLMapSnapshotter.mm
@@ -7,6 +7,7 @@
 #import <mbgl/map/map_snapshotter.hpp>
 #import <mbgl/map/camera.hpp>
 #import <mbgl/storage/resource_options.hpp>
+#import <mbgl/util/client_options.hpp>
 #import <mbgl/util/string.hpp>
 
 #import "MGLOfflineStorage_Private.h"
@@ -718,6 +719,8 @@ NSArray<MGLAttributionInfo *> *MGLAttributionInfosFromAttributions(mbgl::MapSnap
         .withTileServerOptions(*tileServerOptions)
         .withCachePath(MGLOfflineStorage.sharedOfflineStorage.databasePath.UTF8String)
         .withAssetPath(NSBundle.mainBundle.resourceURL.path.UTF8String);
+    mbgl::ClientOptions clientOptions;
+
     auto apiKey = [[MGLSettings sharedSettings] apiKey];
     if (apiKey) {
         resourceOptions.withApiKey([apiKey UTF8String]);
@@ -727,7 +730,7 @@ NSArray<MGLAttributionInfo *> *MGLAttributionInfosFromAttributions(mbgl::MapSnap
     auto localFontFamilyName = config.localFontFamilyName ? std::string(config.localFontFamilyName.UTF8String) : nullptr;
     _delegateHost = std::make_unique<MGLMapSnapshotterDelegateHost>(self);
     _mbglMapSnapshotter = std::make_unique<mbgl::MapSnapshotter>(
-                                                                 size, pixelRatio, resourceOptions, *_delegateHost, localFontFamilyName);
+                                                                 size, pixelRatio, resourceOptions, clientOptions, *_delegateHost, localFontFamilyName);
     
     _mbglMapSnapshotter->setStyleURL(std::string(options.styleURL.absoluteString.UTF8String));
     

--- a/platform/ios/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/ios/platform/darwin/src/MGLOfflineStorage.mm
@@ -19,6 +19,7 @@
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/storage/resource_transform.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/util/client_options.hpp>
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/string.hpp>
 
@@ -159,14 +160,14 @@ const MGLExceptionName MGLUnsupportedRegionTypeException = @"MGLUnsupportedRegio
 
     if (self = [super init]) {
         mbgl::TileServerOptions* tileServerOptions = [[MGLSettings sharedSettings] tileServerOptionsInternal];
-        mbgl::ResourceOptions options;
-        options.withCachePath(self.databasePath.UTF8String)
-               .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String)
-               .withTileServerOptions(*tileServerOptions);
-        
-        _mbglFileSource = mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::ResourceLoader, options);
-        _mbglOnlineFileSource = mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, options);
-        _mbglDatabaseFileSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(std::shared_ptr<mbgl::FileSource>(mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, options)));
+        mbgl::ResourceOptions resourceOptions;
+        resourceOptions.withCachePath(self.databasePath.UTF8String)
+                       .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String)
+                       .withTileServerOptions(*tileServerOptions);
+        mbgl::ClientOptions clientOptions;
+        _mbglFileSource = mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::ResourceLoader, resourceOptions, clientOptions);
+        _mbglOnlineFileSource = mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, resourceOptions, clientOptions);
+        _mbglDatabaseFileSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(std::shared_ptr<mbgl::FileSource>(mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, resourceOptions, clientOptions)));
         
         // Observe for changes to the tile server options (and find out the current one).
         [[MGLSettings sharedSettings] addObserver:self

--- a/platform/ios/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/platform/ios/src/MGLMapView.mm
@@ -15,6 +15,7 @@
 #include <mbgl/gl/custom_layer.hpp>
 #include <mbgl/renderer/renderer.hpp>
 #include <mbgl/math/wrap.hpp>
+#include <mbgl/util/client_options.hpp>
 #include <mbgl/util/exception.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/constants.hpp>
@@ -499,14 +500,15 @@ public:
     resourceOptions.withCachePath(MGLOfflineStorage.sharedOfflineStorage.databasePath.UTF8String)
                    .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String)
                    .withTileServerOptions(*tileServerOptions);
-    
+    mbgl::ClientOptions clientOptions;
+
     auto apiKey = [[MGLSettings sharedSettings] apiKey];
     if (apiKey) {
         resourceOptions.withApiKey([apiKey UTF8String]);
     }
 
     NSAssert(!_mbglMap, @"_mbglMap should be NULL");
-    _mbglMap = std::make_unique<mbgl::Map>(*_rendererFrontend, *_mbglView, mapOptions, resourceOptions);
+    _mbglMap = std::make_unique<mbgl::Map>(*_rendererFrontend, *_mbglView, mapOptions, resourceOptions, clientOptions);
 
     // start paused if launch into the background
     if (background) {

--- a/platform/ios/platform/macos/src/MGLMapView.mm
+++ b/platform/ios/platform/macos/src/MGLMapView.mm
@@ -34,6 +34,7 @@
 #import <mbgl/storage/network_status.hpp>
 #import <mbgl/storage/resource_options.hpp>
 #import <mbgl/math/wrap.hpp>
+#import <mbgl/util/client_options.hpp>
 #import <mbgl/util/constants.hpp>
 #import <mbgl/util/chrono.hpp>
 #import <mbgl/util/exception.hpp>
@@ -298,13 +299,14 @@ public:
     resourceOptions.withTileServerOptions(*tileServerOptions)
                    .withCachePath(MGLOfflineStorage.sharedOfflineStorage.databasePath.UTF8String)
                    .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String);
-    
+    mbgl::ClientOptions clientOptions;
+
     auto apiKey = [[MGLSettings sharedSettings] apiKey];
     if (apiKey) {
         resourceOptions.withApiKey([apiKey UTF8String]);
     }                     
 
-    _mbglMap = std::make_unique<mbgl::Map>(*_rendererFrontend, *_mbglView, mapOptions, resourceOptions);
+    _mbglMap = std::make_unique<mbgl::Map>(*_rendererFrontend, *_mbglView, mapOptions, resourceOptions, clientOptions);
 
     // Notify map object when network reachability status changes.
     _reachability = [MGLReachability reachabilityForInternetConnection];

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -194,7 +194,7 @@ void NodeMap::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     info.This()->SetInternalField(1, options);
 
     mbgl::FileSourceManager::get()->registerFileSourceFactory(
-        mbgl::FileSourceType::ResourceLoader, [](const mbgl::ResourceOptions& resourceOptions) {
+        mbgl::FileSourceType::ResourceLoader, [](const mbgl::ResourceOptions& resourceOptions, const mbgl::ClientOptions& clientOptions) {
             return std::make_unique<node_mbgl::NodeFileSource>(
                 reinterpret_cast<node_mbgl::NodeMap*>(resourceOptions.platformContext()));
         });
@@ -644,7 +644,8 @@ void NodeMap::cancel() {
                                       .withPixelRatio(pixelRatio)
                                       .withMapMode(mbgl::MapMode::Static)
                                       .withCrossSourceCollisions(crossSourceCollisions),
-                                      mbgl::ResourceOptions().withPlatformContext(reinterpret_cast<void*>(this)));
+                                      mbgl::ResourceOptions().withPlatformContext(reinterpret_cast<void*>(this)),
+                                      mbgl::ClientOptions());
 
     // FIXME: Reload the style after recreating the map. We need to find
     // a better way of canceling an ongoing rendering on the core level
@@ -1422,7 +1423,8 @@ NodeMap::NodeMap(v8::Local<v8::Object> options)
                                       .withPixelRatio(pixelRatio)
                                       .withMapMode(mbgl::MapMode::Static)
                                       .withCrossSourceCollisions(crossSourceCollisions),
-                                      mbgl::ResourceOptions().withPlatformContext(reinterpret_cast<void*>(this))))
+                                      mbgl::ResourceOptions().withPlatformContext(reinterpret_cast<void*>(this)),
+                                      mbgl::ClientOptions()))
     , async(new uv_async_t) {
     async->data = this;
     uv_async_init(uv_default_loop(), async, [](uv_async_t* h) {
@@ -1475,6 +1477,14 @@ void NodeFileSource::setResourceOptions(mbgl::ResourceOptions options) {
 
 mbgl::ResourceOptions NodeFileSource::getResourceOptions() {
     return this->_resourceOptions.clone();
+}
+
+void NodeFileSource::setClientOptions(mbgl::ClientOptions options) {
+    this->_clientOptions = std::move(options);
+}
+
+mbgl::ClientOptions NodeFileSource::getClientOptions() {
+    return this->_clientOptions.clone();
 }
 
 } // namespace node_mbgl

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/util/async_request.hpp>
+#include <mbgl/util/client_options.hpp>
 #include <mbgl/util/image.hpp>
 
 #include <exception>
@@ -103,8 +104,11 @@ struct NodeFileSource : public mbgl::FileSource {
     bool canRequest(const mbgl::Resource&) const override;
     void setResourceOptions(mbgl::ResourceOptions) override;
     mbgl::ResourceOptions getResourceOptions() override;
+    void setClientOptions(mbgl::ClientOptions) override;
+    mbgl::ClientOptions getClientOptions() override;
     NodeMap* nodeMap;
     mbgl::ResourceOptions _resourceOptions;
+    mbgl::ClientOptions _clientOptions;
 };
 
 } // namespace node_mbgl

--- a/platform/qt/app/main.cpp
+++ b/platform/qt/app/main.cpp
@@ -10,6 +10,9 @@ int main(int argc, char **argv)
     settings.setCacheDatabasePath("/tmp/mbgl-cache.db");
     settings.setCacheDatabaseMaximumSize(20 * 1024 * 1024);
 
+    settings.setClientName("TestApp");
+    settings.setClientVersion("1.0");
+
     MapWindow window(settings);
 
     window.resize(800, 600);

--- a/platform/qt/include/QMapLibreGL/settings.hpp
+++ b/platform/qt/include/QMapLibreGL/settings.hpp
@@ -82,6 +82,12 @@ public:
     QString localFontFamily() const;
     void setLocalFontFamily(const QString &);
 
+    QString clientName() const;
+    void setClientName(const QString &);
+
+    QString clientVersion() const;
+    void setClientVersion(const QString &);
+
     std::function<std::string(const std::string &)> resourceTransform() const;
     void setResourceTransform(const std::function<std::string(const std::string &)> &);
 
@@ -102,6 +108,8 @@ private:
     QString m_assetPath;
     QString m_apiKey;
     QString m_localFontFamily;
+    QString m_clientName;
+    QString m_clientVersion;
     std::function<std::string(const std::string &)> m_resourceTransform;
 
     mbgl::TileServerOptions *m_tileServerOptionsInternal{};

--- a/platform/qt/src/mbgl/http_file_source.cpp
+++ b/platform/qt/src/mbgl/http_file_source.cpp
@@ -11,9 +11,10 @@
 
 namespace mbgl {
 
-HTTPFileSource::Impl::Impl(const ResourceOptions& options)
+HTTPFileSource::Impl::Impl(const ResourceOptions& resourceOptions, const ClientOptions& clientOptions)
     : m_manager(new QNetworkAccessManager(this)),
-      m_resourceOptions(options.clone())
+      m_resourceOptions(resourceOptions.clone()),
+      m_clientOptions(clientOptions.clone())
 {
     QNetworkProxyFactory::setUseSystemConfiguration(true);
 }
@@ -110,8 +111,18 @@ ResourceOptions HTTPFileSource::Impl::getResourceOptions()
     return m_resourceOptions.clone();
 }
 
-HTTPFileSource::HTTPFileSource(const ResourceOptions& options)
-    : impl(std::make_unique<Impl>(options)) {
+void HTTPFileSource::Impl::setClientOptions(ClientOptions options)
+{
+    m_clientOptions = options;
+}
+
+ClientOptions HTTPFileSource::Impl::getClientOptions()
+{
+    return m_clientOptions.clone();
+}
+
+HTTPFileSource::HTTPFileSource(const ResourceOptions& resourceOptions, const ClientOptions& clientOptions)
+    : impl(std::make_unique<Impl>(resourceOptions, clientOptions)) {
 }
 
 HTTPFileSource::~HTTPFileSource() = default;
@@ -128,5 +139,14 @@ void HTTPFileSource::setResourceOptions(ResourceOptions options) {
 ResourceOptions HTTPFileSource::getResourceOptions() {
     return impl->getResourceOptions();
 }
+
+void HTTPFileSource::setClientOptions(ClientOptions options) {
+    impl->setClientOptions(options.clone());
+}
+
+ClientOptions HTTPFileSource::getClientOptions() {
+    return impl->getClientOptions();
+}
+
 
 } // namespace mbgl

--- a/platform/qt/src/mbgl/http_file_source.hpp
+++ b/platform/qt/src/mbgl/http_file_source.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/storage/http_file_source.hpp>
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/resource_options.hpp>
+#include <mbgl/util/client_options.hpp>
 
 #include <QMap>
 #include <QNetworkAccessManager>
@@ -22,7 +23,7 @@ class HTTPFileSource::Impl : public QObject
     Q_OBJECT
 
 public:
-    Impl(const ResourceOptions& options);
+    Impl(const ResourceOptions& resourceOptions, const ClientOptions& clientOptions);
     virtual ~Impl() = default;
 
     void request(HTTPRequest *);
@@ -31,6 +32,9 @@ public:
     void setResourceOptions(ResourceOptions options);
     ResourceOptions getResourceOptions();
 
+    void setClientOptions(ClientOptions options);
+    ClientOptions getClientOptions();
+
 public slots:
     void onReplyFinished();
 
@@ -38,6 +42,7 @@ private:
     QMap<QUrl, QPair<QPointer<QNetworkReply>, QVector<HTTPRequest *>>> m_pending;
     QNetworkAccessManager *m_manager;
     ResourceOptions m_resourceOptions;
+    ClientOptions m_clientOptions;
 };
 
 } // namespace mbgl

--- a/platform/qt/src/mbgl/http_request.cpp
+++ b/platform/qt/src/mbgl/http_request.cpp
@@ -39,7 +39,18 @@ QNetworkRequest HTTPRequest::networkRequest() const
     QNetworkRequest req = QNetworkRequest(requestUrl());
     req.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache);
 
-    static const QByteArray agent = QString("MapLibreGL/%1 (Qt %2)").arg(version::revision).arg(QT_VERSION_STR).toLatin1();
+    static const QByteArray agent = !m_context->getClientOptions().name().empty()
+        ? QString("%1/%2 (%3) MapLibreGL/%4 (Qt %5)")
+            .arg(QString::fromStdString(m_context->getClientOptions().name()))
+            .arg(QString::fromStdString(m_context->getClientOptions().version()))
+            .arg(QSysInfo::prettyProductName())
+            .arg(version::revision)
+            .arg(QT_VERSION_STR)
+            .toLatin1()
+        : QString("MapLibreGL/%1 (Qt %2)")
+            .arg(version::revision)
+            .arg(QT_VERSION_STR)
+            .toLatin1();
     req.setRawHeader("User-Agent", agent);
 
     if (m_resource.priorEtag) {

--- a/platform/qt/src/settings.cpp
+++ b/platform/qt/src/settings.cpp
@@ -349,6 +349,38 @@ void Settings::setLocalFontFamily(const QString &family)
 }
 
 /*!
+    Returns the client name. Returns an empty string if no client name is set.
+*/
+QString Settings::clientName() const
+{
+    return m_clientName;
+}
+
+/*!
+    Sets the client name.
+*/
+void Settings::setClientName(const QString &name)
+{
+    m_clientName = name;
+}
+
+/*!
+    Returns the client version. Returns an empty string if no client version is set.
+*/
+QString Settings::clientVersion() const
+{
+    return m_clientVersion;
+}
+
+/*!
+    Sets the client version.
+*/
+void Settings::setClientVersion(const QString &version)
+{
+    m_clientVersion = version;
+}
+
+/*!
     Returns resource transformation callback used to transform requested URLs.
 */
 std::function<std::string(const std::string &)> Settings::resourceTransform() const {

--- a/render-test/file_source.cpp
+++ b/render-test/file_source.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/util/async_request.hpp>
+#include <mbgl/util/client_options.hpp>
 #include <mbgl/util/logging.hpp>
 
 #include <atomic>
@@ -15,11 +16,12 @@ std::atomic_size_t transferredSize{0};
 std::atomic_bool active{false};
 std::atomic_bool offline{true};
 
-ProxyFileSource::ProxyFileSource(std::shared_ptr<FileSource> defaultResourceLoader_, const ResourceOptions& options)
-    : defaultResourceLoader(std::move(defaultResourceLoader_)) {
+ProxyFileSource::ProxyFileSource(std::shared_ptr<FileSource> defaultResourceLoader_, const ResourceOptions& resourceOptions_, const ClientOptions& clientOptions_)
+    : defaultResourceLoader(std::move(defaultResourceLoader_)),
+      resourceOptions(resourceOptions_.clone()), clientOptions(clientOptions_.clone()) {
     assert(defaultResourceLoader);
     if (offline) {
-        std::shared_ptr<FileSource> dbfs = FileSourceManager::get()->getFileSource(FileSourceType::Database, options);
+        std::shared_ptr<FileSource> dbfs = FileSourceManager::get()->getFileSource(FileSourceType::Database, resourceOptions_, clientOptions_);
         dbfs->setProperty(READ_ONLY_MODE_KEY, true);
     }
 } 
@@ -81,6 +83,14 @@ void ProxyFileSource::setResourceOptions(ResourceOptions options) {
 
 ResourceOptions ProxyFileSource::getResourceOptions() {
     return resourceOptions.clone();
+}
+
+void ProxyFileSource::setClientOptions(ClientOptions options) {
+   clientOptions = options;
+}
+
+ClientOptions ProxyFileSource::getClientOptions() {
+    return clientOptions.clone();
 }
 
 

--- a/render-test/file_source.hpp
+++ b/render-test/file_source.hpp
@@ -4,11 +4,12 @@
 
 namespace mbgl {
 
+class ClientOptions;
 class ResourceOptions;
 
 class ProxyFileSource : public FileSource {
 public:
-    ProxyFileSource(std::shared_ptr<FileSource>, const ResourceOptions&);
+    ProxyFileSource(std::shared_ptr<FileSource>, const ResourceOptions&, const ClientOptions&);
     ~ProxyFileSource();
 
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
@@ -45,9 +46,14 @@ public:
 
     void setResourceOptions(ResourceOptions) override;
     ResourceOptions getResourceOptions() override;
+
+    void setClientOptions(ClientOptions) override;
+    ClientOptions getClientOptions() override;
+
 private:
     std::shared_ptr<FileSource> defaultResourceLoader;
     ResourceOptions resourceOptions;
+    ClientOptions clientOptions;
 };
 
 } // namespace mbgl

--- a/render-test/runner.hpp
+++ b/render-test/runner.hpp
@@ -57,7 +57,7 @@ private:
     void registerProxyFileSource();
 
     struct Impl {
-        Impl(const TestMetadata&, const mbgl::ResourceOptions&);
+        Impl(const TestMetadata&, const mbgl::ResourceOptions&, const mbgl::ClientOptions&);
         ~Impl();
 
         std::unique_ptr<TestRunnerMapObserver> observer;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -29,12 +29,13 @@ using namespace style;
 Map::Map(RendererFrontend& frontend,
          MapObserver& observer,
          const MapOptions& mapOptions,
-         const ResourceOptions& resourceOptions)
+         const ResourceOptions& resourceOptions,
+         const ClientOptions& clientOptions)
     : impl(std::make_unique<Impl>(
           frontend,
           observer,
           FileSourceManager::get()
-              ? std::shared_ptr<FileSource>(FileSourceManager::get()->getFileSource(ResourceLoader, resourceOptions))
+              ? std::shared_ptr<FileSource>(FileSourceManager::get()->getFileSource(ResourceLoader, resourceOptions, clientOptions))
               : nullptr,
           mapOptions)) {}
 

--- a/src/mbgl/storage/asset_file_source.hpp
+++ b/src/mbgl/storage/asset_file_source.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/storage/resource_options.hpp>
+#include <mbgl/util/client_options.hpp>
 
 namespace mbgl {
 
@@ -11,7 +12,7 @@ template <typename T> class Thread;
 
 class AssetFileSource : public FileSource {
 public:
-    AssetFileSource(const ResourceOptions& options);
+    AssetFileSource(const ResourceOptions& resourceOptions, const ClientOptions& clientOptions);
     ~AssetFileSource() override;
 
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
@@ -21,6 +22,9 @@ public:
 
     void setResourceOptions(ResourceOptions) override;
     ResourceOptions getResourceOptions() override;
+
+    void setClientOptions(ClientOptions) override;
+    ClientOptions getClientOptions() override;
 
 private:
     class Impl;

--- a/src/mbgl/storage/http_file_source.hpp
+++ b/src/mbgl/storage/http_file_source.hpp
@@ -2,15 +2,15 @@
 
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/storage/resource.hpp>
-#include <mbgl/storage/resource_options.hpp>
 
 namespace mbgl {
 
+class ClientOptions;
 class ResourceOptions;
 
 class HTTPFileSource : public FileSource {
 public:
-    HTTPFileSource(const ResourceOptions& options);
+    HTTPFileSource(const ResourceOptions& resourceOptions, const ClientOptions& clientOptions);
     ~HTTPFileSource() override;
 
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
@@ -20,6 +20,9 @@ public:
 
     void setResourceOptions(ResourceOptions) override;
     ResourceOptions getResourceOptions() override;
+
+    void setClientOptions(ClientOptions) override;
+    ClientOptions getClientOptions() override;
 
     class Impl;
 

--- a/src/mbgl/storage/local_file_source.hpp
+++ b/src/mbgl/storage/local_file_source.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/storage/resource_options.hpp>
+#include <mbgl/util/client_options.hpp>
 
 namespace mbgl {
 
@@ -11,7 +12,7 @@ template <typename T> class Thread;
 
 class LocalFileSource : public FileSource {
 public:
-    LocalFileSource(const ResourceOptions& options);
+    LocalFileSource(const ResourceOptions& resourceOptions, const ClientOptions& clientOptions);
     ~LocalFileSource() override;
 
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
@@ -21,6 +22,9 @@ public:
 
     void setResourceOptions(ResourceOptions) override;
     ResourceOptions getResourceOptions() override;
+
+    void setClientOptions(ClientOptions) override;
+    ClientOptions getClientOptions() override;
 
 private:
     class Impl;

--- a/src/mbgl/storage/main_resource_loader.hpp
+++ b/src/mbgl/storage/main_resource_loader.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
 #include <mbgl/storage/file_source.hpp>
-#include <mbgl/storage/resource_options.hpp>
 
 namespace mbgl {
 
+class ClientOptions;
 class ResourceTransform;
 class ResourceOptions;
 
 class MainResourceLoader final : public FileSource {
 public:
-    explicit MainResourceLoader(const ResourceOptions& options);
+    explicit MainResourceLoader(const ResourceOptions& resourceOptions, const ClientOptions& clientOptions);
     ~MainResourceLoader() override;
 
     bool supportsCacheOnlyRequests() const override;
@@ -21,6 +21,9 @@ public:
 
     void setResourceOptions(ResourceOptions) override;
     ResourceOptions getResourceOptions() override;
+
+    void setClientOptions(ClientOptions) override;
+    ClientOptions getClientOptions() override;
 
 private:
     class Impl;

--- a/src/mbgl/storage/mbtiles_file_source.hpp
+++ b/src/mbgl/storage/mbtiles_file_source.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <mbgl/storage/file_source.hpp>
-#include <mbgl/util/thread.hpp>
 #include <mbgl/storage/resource_options.hpp>
+#include <mbgl/util/client_options.hpp>
+#include <mbgl/util/thread.hpp>
 
 
 namespace mbgl {
@@ -10,7 +11,7 @@ namespace mbgl {
 // can only load resource URLS that are absolute paths to local files
 class MBTilesFileSource : public FileSource {
 public:
-    MBTilesFileSource(const ResourceOptions& options);
+    MBTilesFileSource(const ResourceOptions& resourceOptions, const ClientOptions& clientOptions);
     ~MBTilesFileSource() override;
 
     std::unique_ptr <AsyncRequest> request(const Resource &, Callback) override;
@@ -18,6 +19,9 @@ public:
 
     void setResourceOptions(ResourceOptions) override;
     ResourceOptions getResourceOptions() override;
+
+    void setClientOptions(ClientOptions) override;
+    ClientOptions getClientOptions() override;
 
 private:
     class Impl;

--- a/src/mbgl/util/client_options.cpp
+++ b/src/mbgl/util/client_options.cpp
@@ -1,0 +1,41 @@
+#include <mbgl/util/client_options.hpp>
+
+namespace mbgl {
+
+class ClientOptions::Impl {
+public:
+    std::string name;
+    std::string version;
+};
+
+// These requires the complete type of Impl.
+ClientOptions::ClientOptions() : impl_(std::make_unique<Impl>()) {}
+ClientOptions::~ClientOptions() = default;
+ClientOptions::ClientOptions(ClientOptions&&) noexcept = default;
+ClientOptions::ClientOptions(const ClientOptions& other) : impl_(std::make_unique<Impl>(*other.impl_)) {}
+ClientOptions& ClientOptions::operator=(const ClientOptions& other) {impl_ = std::make_unique<Impl>(*other.impl_); return *this; }
+ClientOptions& ClientOptions::operator=(ClientOptions&& options) {swap(impl_, options.impl_); return *this; }
+
+ClientOptions ClientOptions::clone() const {
+    return ClientOptions(*this);
+}
+
+ClientOptions& ClientOptions::withName(std::string name) {
+    impl_->name = std::move(name);
+    return *this;
+}
+
+const std::string& ClientOptions::name() const {
+    return impl_->name;
+}
+
+ClientOptions& ClientOptions::withVersion(std::string version) {
+    impl_->version = std::move(version);
+    return *this;
+}
+
+const std::string& ClientOptions::version() const {
+    return impl_->version;
+}
+
+}  // namespace mbgl

--- a/test/api/recycle_map.cpp
+++ b/test/api/recycle_map.cpp
@@ -24,7 +24,7 @@ TEST(API, RecycleMapUpdateImages) {
 
     HeadlessFrontend frontend { 1 };
     auto map = std::make_unique<MapAdapter>(frontend, MapObserver::nullObserver(),
-                                         std::make_shared<StubFileSource>(ResourceOptions::Default()),
+                                         std::make_shared<StubFileSource>(ResourceOptions::Default(), ClientOptions()),
                                          MapOptions().withMapMode(MapMode::Static).withSize(frontend.getSize()));
 
     EXPECT_TRUE(map);

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -28,6 +28,7 @@
 #include <mbgl/style/sources/vector_source.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/util/async_task.hpp>
+#include <mbgl/util/client_options.hpp>
 #include <mbgl/util/color.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/io.hpp>
@@ -49,7 +50,7 @@ public:
     MapAdapter map;
 
     MapTest(float pixelRatio = 1, MapMode mode = MapMode::Static)
-        : fileSource(std::make_shared<FileSource>(ResourceOptions::Default()))
+        : fileSource(std::make_shared<FileSource>(ResourceOptions::Default(), ClientOptions()))
         , frontend(pixelRatio)
         , map(frontend, observer, fileSource,
               MapOptions().withMapMode(mode).withSize(frontend.getSize()).withPixelRatio(pixelRatio)) {}
@@ -65,7 +66,7 @@ public:
             float pixelRatio = 1,
             MapMode mode = MapMode::Static,
             typename std::enable_if<std::is_same<T, MainResourceLoader>::value>::type* = nullptr)
-        : fileSource(std::make_shared<T>(ResourceOptions().withCachePath(cachePath).withAssetPath(assetPath))),
+        : fileSource(std::make_shared<T>(ResourceOptions().withCachePath(cachePath).withAssetPath(assetPath), ClientOptions())),
           frontend(pixelRatio),
           map(frontend,
               observer,
@@ -73,10 +74,11 @@ public:
               MapOptions().withMapMode(mode).withSize(frontend.getSize()).withPixelRatio(pixelRatio)) {}
     
     template <typename T = FileSource>
-    MapTest(const ResourceOptions& options,
+    MapTest(const ResourceOptions& resourceOptions,
+            const ClientOptions& clientOptions = ClientOptions(),
             float pixelRatio = 1,
             MapMode mode = MapMode::Static)
-        : fileSource(std::make_shared<T>(options)),
+        : fileSource(std::make_shared<T>(resourceOptions, clientOptions)),
           frontend(pixelRatio),
           map(frontend,
               observer,

--- a/test/map/map_snapshotter.test.cpp
+++ b/test/map/map_snapshotter.test.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/style/layers/fill_layer.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/test/util.hpp>
+#include <mbgl/util/client_options.hpp>
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/timer.hpp>
 
@@ -113,7 +114,7 @@ TEST(MapSnapshotter, TEST_REQUIRES_SERVER(cancel)) {
 TEST(MapSnapshotter, TEST_REQUIRES_SERVER(runtimeStyling)) {
     util::RunLoop runLoop;
     SnapshotterObserver observer;
-    MapSnapshotter snapshotter(Size{256, 128}, 1.0f, ResourceOptions(), observer);
+    MapSnapshotter snapshotter(Size{256, 128}, 1.0f, ResourceOptions(), ClientOptions(), observer);
     snapshotter.setStyleURL("http://127.0.0.1:3000/online/style.json");
 
     observer.didFinishLoadingStyleCallback = [&snapshotter, &runLoop] {

--- a/test/src/mbgl/test/stub_file_source.cpp
+++ b/test/src/mbgl/test/stub_file_source.cpp
@@ -1,6 +1,7 @@
+#include <mbgl/storage/resource_options.hpp>
 #include <mbgl/test/stub_file_source.hpp>
 #include <mbgl/util/async_request.hpp>
-#include <mbgl/storage/resource_options.hpp>
+#include <mbgl/util/client_options.hpp>
 
 namespace mbgl {
 
@@ -20,10 +21,10 @@ public:
 };
 
 StubFileSource::StubFileSource(ResponseType type_):
-    StubFileSource::StubFileSource(ResourceOptions().withTileServerOptions(TileServerOptions::MapTilerConfiguration()), type_) {}
+    StubFileSource::StubFileSource(ResourceOptions().withTileServerOptions(TileServerOptions::MapTilerConfiguration()), ClientOptions(), type_) {}
 
-StubFileSource::StubFileSource(const ResourceOptions& options, ResponseType type_)
-        : type(type_), resourceOptions(options.clone()) {
+StubFileSource::StubFileSource(const ResourceOptions& resourceOptions_, const ClientOptions& clientOptions_, ResponseType type_)
+        : type(type_), resourceOptions(resourceOptions_.clone()), clientOptions(clientOptions_.clone()) {
     if (type == ResponseType::Synchronous) {
         return;
     }
@@ -120,6 +121,14 @@ void StubFileSource::setResourceOptions(ResourceOptions options) {
 
 ResourceOptions StubFileSource::getResourceOptions() {
     return resourceOptions.clone();
+}
+
+void StubFileSource::setClientOptions(ClientOptions options) {
+    clientOptions = options;
+}
+
+ClientOptions StubFileSource::getClientOptions() {
+    return clientOptions.clone();
 }
 
 } // namespace mbgl

--- a/test/src/mbgl/test/stub_file_source.hpp
+++ b/test/src/mbgl/test/stub_file_source.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/storage/online_file_source.hpp>
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/resource_options.hpp>
+#include <mbgl/util/client_options.hpp>
 #include <mbgl/util/timer.hpp>
 
 #include <map>
@@ -18,7 +19,7 @@ public:
         Synchronous
     };
 
-    StubFileSource(const ResourceOptions&, ResponseType = ResponseType::Asynchronous);
+    StubFileSource(const ResourceOptions&, const ClientOptions&, ResponseType = ResponseType::Asynchronous);
     StubFileSource(ResponseType = ResponseType::Asynchronous);
     ~StubFileSource() override;
 
@@ -47,6 +48,9 @@ public:
     void setResourceOptions(ResourceOptions options) override;
     ResourceOptions getResourceOptions() override;
 
+    void setClientOptions(ClientOptions options) override;
+    ClientOptions getClientOptions() override;
+
 private:
     friend class StubOnlineFileSource;
 
@@ -59,6 +63,7 @@ private:
     std::map<std::string, mapbox::base::Value> properties;
 
     ResourceOptions resourceOptions;
+    ClientOptions clientOptions;
 };
 
 } // namespace mbgl

--- a/test/storage/asset_file_source.test.cpp
+++ b/test/storage/asset_file_source.test.cpp
@@ -3,6 +3,7 @@
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/util/client_options.hpp>
 #include <mbgl/util/platform.hpp>
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/thread.hpp>
@@ -16,7 +17,7 @@ using namespace mbgl;
 TEST(AssetFileSource, Load) {
     util::RunLoop loop;
 
-    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"));
+    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"), ClientOptions());
 
     // iOS seems to run out of file descriptors...
 #if TARGET_OS_IPHONE
@@ -72,7 +73,7 @@ TEST(AssetFileSource, Load) {
 }
 
 TEST(AssetFileSource, AcceptsURL) {
-    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"));
+    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"), ClientOptions());
     EXPECT_TRUE(fs.canRequest(Resource::style("asset://empty")));
     EXPECT_TRUE(fs.canRequest(Resource::style("asset:///test")));
     EXPECT_FALSE(fs.canRequest(Resource::style("assds://foo")));
@@ -84,7 +85,7 @@ TEST(AssetFileSource, AcceptsURL) {
 TEST(AssetFileSource, EmptyFile) {
     util::RunLoop loop;
 
-    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"));
+    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://empty" }, [&](Response res) {
         req.reset();
@@ -100,7 +101,7 @@ TEST(AssetFileSource, EmptyFile) {
 TEST(AssetFileSource, NonEmptyFile) {
     util::RunLoop loop;
 
-    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"));
+    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://nonempty" }, [&](Response res) {
         req.reset();
@@ -116,7 +117,7 @@ TEST(AssetFileSource, NonEmptyFile) {
 TEST(AssetFileSource, NonExistentFile) {
     util::RunLoop loop;
 
-    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"));
+    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://does_not_exist" }, [&](Response res) {
         req.reset();
@@ -133,7 +134,7 @@ TEST(AssetFileSource, NonExistentFile) {
 TEST(AssetFileSource, InvalidURL) {
     util::RunLoop loop;
 
-    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"));
+    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "test://wrong-scheme" }, [&](Response res) {
         req.reset();
@@ -150,7 +151,7 @@ TEST(AssetFileSource, InvalidURL) {
 TEST(AssetFileSource, ReadDirectory) {
     util::RunLoop loop;
 
-    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"));
+    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://directory" }, [&](Response res) {
         req.reset();
@@ -167,7 +168,7 @@ TEST(AssetFileSource, ReadDirectory) {
 TEST(AssetFileSource, URLEncoding) {
     util::RunLoop loop;
 
-    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"));
+    AssetFileSource fs(ResourceOptions::Default().withAssetPath("test/fixtures/storage/assets"), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://%6eonempty" }, [&](Response res) {
         req.reset();

--- a/test/storage/http_file_source.test.cpp
+++ b/test/storage/http_file_source.test.cpp
@@ -11,7 +11,7 @@ using namespace mbgl;
 
 TEST(HTTPFileSource, TEST_REQUIRES_SERVER(Cancel)) {
     util::RunLoop loop;
-    HTTPFileSource fs(ResourceOptions::Default());
+    HTTPFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, [&](Response) {
         ADD_FAILURE() << "Callback should not be called";
@@ -22,7 +22,7 @@ TEST(HTTPFileSource, TEST_REQUIRES_SERVER(Cancel)) {
 
 TEST(HTTPFileSource, TEST_REQUIRES_SERVER(HTTP200)) {
     util::RunLoop loop;
-    HTTPFileSource fs(ResourceOptions::Default());
+    HTTPFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     auto req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, [&](Response res) {
         EXPECT_EQ(nullptr, res.error);
@@ -40,7 +40,7 @@ TEST(HTTPFileSource, TEST_REQUIRES_SERVER(HTTP200)) {
 
 TEST(HTTPFileSource, TEST_REQUIRES_SERVER(HTTP404)) {
     util::RunLoop loop;
-    HTTPFileSource fs(ResourceOptions::Default());
+    HTTPFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     auto req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/doesnotexist" }, [&](Response res) {
         ASSERT_NE(nullptr, res.error);
@@ -59,7 +59,7 @@ TEST(HTTPFileSource, TEST_REQUIRES_SERVER(HTTP404)) {
 
 TEST(HTTPFileSource, TEST_REQUIRES_SERVER(HTTPTile404)) {
     util::RunLoop loop;
-    HTTPFileSource fs(ResourceOptions::Default());
+    HTTPFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     auto req = fs.request({ Resource::Tile, "http://127.0.0.1:3000/doesnotexist" }, [&](Response res) {
         EXPECT_TRUE(res.noContent);
@@ -77,7 +77,7 @@ TEST(HTTPFileSource, TEST_REQUIRES_SERVER(HTTPTile404)) {
 
 TEST(HTTPFileSource, TEST_REQUIRES_SERVER(HTTP200EmptyData)) {
     util::RunLoop loop;
-    HTTPFileSource fs(ResourceOptions::Default());
+    HTTPFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     auto req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/empty-data" }, [&](Response res) {
         EXPECT_FALSE(res.noContent);
@@ -95,7 +95,7 @@ TEST(HTTPFileSource, TEST_REQUIRES_SERVER(HTTP200EmptyData)) {
 
 TEST(HTTPFileSource, TEST_REQUIRES_SERVER(HTTP204)) {
     util::RunLoop loop;
-    HTTPFileSource fs(ResourceOptions::Default());
+    HTTPFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     auto req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/no-content" }, [&](Response res) {
         EXPECT_TRUE(res.noContent);
@@ -113,7 +113,7 @@ TEST(HTTPFileSource, TEST_REQUIRES_SERVER(HTTP204)) {
 
 TEST(HTTPFileSource, TEST_REQUIRES_SERVER(HTTP500)) {
     util::RunLoop loop;
-    HTTPFileSource fs(ResourceOptions::Default());
+    HTTPFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     auto req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/permanent-error" }, [&](Response res) {
         ASSERT_NE(nullptr, res.error);
@@ -132,7 +132,7 @@ TEST(HTTPFileSource, TEST_REQUIRES_SERVER(HTTP500)) {
 
 TEST(HTTPFileSource, TEST_REQUIRES_SERVER(ExpiresParsing)) {
     util::RunLoop loop;
-    HTTPFileSource fs(ResourceOptions::Default());
+    HTTPFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     auto req = fs.request({ Resource::Unknown,
                  "http://127.0.0.1:3000/test?modified=1420794326&expires=1420797926&etag=foo" }, [&](Response res) {
@@ -151,7 +151,7 @@ TEST(HTTPFileSource, TEST_REQUIRES_SERVER(ExpiresParsing)) {
 
 TEST(HTTPFileSource, TEST_REQUIRES_SERVER(CacheControlParsing)) {
     util::RunLoop loop;
-    HTTPFileSource fs(ResourceOptions::Default());
+    HTTPFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     auto req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test?cachecontrol=max-age=120" }, [&](Response res) {
         EXPECT_EQ(nullptr, res.error);
@@ -169,7 +169,7 @@ TEST(HTTPFileSource, TEST_REQUIRES_SERVER(CacheControlParsing)) {
 
 TEST(HTTPFileSource, TEST_REQUIRES_SERVER(Load)) {
     util::RunLoop loop;
-    HTTPFileSource fs(ResourceOptions::Default());
+    HTTPFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     const int concurrency = 50;
     const int max = 10000;

--- a/test/storage/local_file_source.test.cpp
+++ b/test/storage/local_file_source.test.cpp
@@ -35,7 +35,7 @@ std::string toAbsoluteURL(const std::string& fileName) {
 using namespace mbgl;
 
 TEST(LocalFileSource, AcceptsURL) {
-    LocalFileSource fs(ResourceOptions::Default());
+    LocalFileSource fs(ResourceOptions::Default(), ClientOptions());
     EXPECT_TRUE(fs.canRequest(Resource::style("file://empty")));
     EXPECT_TRUE(fs.canRequest(Resource::style("file:///test")));
     EXPECT_FALSE(fs.canRequest(Resource::style("flie://foo")));
@@ -47,7 +47,7 @@ TEST(LocalFileSource, AcceptsURL) {
 TEST(LocalFileSource, EmptyFile) {
     util::RunLoop loop;
 
-    LocalFileSource fs(ResourceOptions::Default());
+    LocalFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, toAbsoluteURL("empty") }, [&](Response res) {
         req.reset();
@@ -63,7 +63,7 @@ TEST(LocalFileSource, EmptyFile) {
 TEST(LocalFileSource, NonEmptyFile) {
     util::RunLoop loop;
 
-    LocalFileSource fs(ResourceOptions::Default());
+    LocalFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, toAbsoluteURL("nonempty") }, [&](Response res) {
         req.reset();
@@ -79,7 +79,7 @@ TEST(LocalFileSource, NonEmptyFile) {
 TEST(LocalFileSource, NonExistentFile) {
     util::RunLoop loop;
 
-    LocalFileSource fs(ResourceOptions::Default());
+    LocalFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, toAbsoluteURL("does_not_exist") }, [&](Response res) {
         req.reset();
@@ -96,7 +96,7 @@ TEST(LocalFileSource, NonExistentFile) {
 TEST(LocalFileSource, InvalidURL) {
     util::RunLoop loop;
 
-    LocalFileSource fs(ResourceOptions::Default());
+    LocalFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "test://wrong-scheme" }, [&](Response res) {
         req.reset();
@@ -113,7 +113,7 @@ TEST(LocalFileSource, InvalidURL) {
 TEST(LocalFileSource, ReadDirectory) {
     util::RunLoop loop;
 
-    LocalFileSource fs(ResourceOptions::Default());
+    LocalFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, toAbsoluteURL("directory") }, [&](Response res) {
         req.reset();
@@ -130,7 +130,7 @@ TEST(LocalFileSource, ReadDirectory) {
 TEST(LocalFileSource, URLEncoding) {
     util::RunLoop loop;
 
-    LocalFileSource fs(ResourceOptions::Default());
+    LocalFileSource fs(ResourceOptions::Default(), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, toAbsoluteURL("%6eonempty") }, [&](Response res) {
         req.reset();
@@ -147,7 +147,7 @@ TEST(LocalFileSource, URLLimit) {
     util::RunLoop loop;
 
     size_t length = PATH_MAX - toAbsoluteURL("").size();
-    LocalFileSource fs(ResourceOptions::Default());
+    LocalFileSource fs(ResourceOptions::Default(), ClientOptions());
     char* filename = new char[length];
     memset(filename, 'x', length);
 

--- a/test/storage/mbtiles_file_source.test.cpp
+++ b/test/storage/mbtiles_file_source.test.cpp
@@ -36,7 +36,7 @@ std::string toAbsoluteURL(const std::string &fileName) {
 using namespace mbgl;
 
 TEST(MBTilesFileSource, AcceptsURL) {
-    MBTilesFileSource mbtiles(ResourceOptions::Default());
+    MBTilesFileSource mbtiles(ResourceOptions::Default(), ClientOptions());
     EXPECT_TRUE(mbtiles.canRequest(Resource::style("mbtiles:///test")));
     EXPECT_FALSE(mbtiles.canRequest(Resource::style("mbtile://test")));
     EXPECT_FALSE(mbtiles.canRequest(Resource::style("mbtiles:")));
@@ -47,7 +47,7 @@ TEST(MBTilesFileSource, AcceptsURL) {
 TEST(MBTilesFileSource, AbsolutePath) {
     util::RunLoop loop;
 
-    MBTilesFileSource mbtiles(ResourceOptions::Default());
+    MBTilesFileSource mbtiles(ResourceOptions::Default(), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = mbtiles.request(
         {Resource::Unknown, "mbtiles://not_absolute"}, [&](Response res) {
@@ -66,7 +66,7 @@ TEST(MBTilesFileSource, AbsolutePath) {
 TEST(MBTilesFileSource, NonExistentFile) {
     util::RunLoop loop;
 
-    MBTilesFileSource mbtiles(ResourceOptions::Default());
+    MBTilesFileSource mbtiles(ResourceOptions::Default(), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = mbtiles.request(
         {Resource::Unknown, toAbsoluteURL("does_not_exist")}, [&](Response res) {
@@ -85,7 +85,7 @@ TEST(MBTilesFileSource, NonExistentFile) {
 TEST(MBTilesFileSource, TileJSON) {
     util::RunLoop loop;
 
-    MBTilesFileSource mbtiles(ResourceOptions::Default());
+    MBTilesFileSource mbtiles(ResourceOptions::Default(), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = mbtiles.request(
         {Resource::Unknown, toAbsoluteURL("geography-class-png.mbtiles")}, [&](Response res) {
@@ -105,7 +105,7 @@ TEST(MBTilesFileSource, TileJSON) {
 TEST(MBTilesFileSource, Tile) {
     util::RunLoop loop;
 
-    MBTilesFileSource mbtiles(ResourceOptions::Default());
+    MBTilesFileSource mbtiles(ResourceOptions::Default(), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = mbtiles.request(
         Resource::tile(toAbsoluteURL("geography-class-png.mbtiles?file={z}/{x}/{y}.png"), 1.0, 0, 0, 0, Tileset::Scheme::XYZ),
@@ -124,7 +124,7 @@ TEST(MBTilesFileSource, Tile) {
 TEST(MBTilesFileSource, NonExistentTile) {
     util::RunLoop loop;
 
-    MBTilesFileSource mbtiles(ResourceOptions::Default());
+    MBTilesFileSource mbtiles(ResourceOptions::Default(), ClientOptions());
 
     std::unique_ptr<AsyncRequest> req = mbtiles.request(
         Resource::tile(toAbsoluteURL("geography-class-png.mbtiles?file={z}/{x}/{y}.png"), 1.0, 0, 0, 4, Tileset::Scheme::XYZ),

--- a/test/storage/online_file_source.test.cpp
+++ b/test/storage/online_file_source.test.cpp
@@ -15,7 +15,7 @@ using namespace mbgl;
 
 TEST(OnlineFileSource, Cancel) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     fs->request({Resource::Unknown, "http://127.0.0.1:3000/test"},
                 [&](Response) { ADD_FAILURE() << "Callback should not be called"; });
@@ -25,7 +25,7 @@ TEST(OnlineFileSource, Cancel) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(CancelMultiple)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test" };
 
@@ -49,7 +49,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(CancelMultiple)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(TemporaryError)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     const auto start = Clock::now();
     int counter = 0;
@@ -89,7 +89,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(TemporaryError)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(ConnectionError)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     const auto start = Clock::now();
     int counter = 0;
@@ -120,7 +120,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(ConnectionError)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(Timeout)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     int counter = 0;
 
@@ -147,7 +147,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(Timeout)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RetryDelayOnExpiredTile)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     int counter = 0;
 
@@ -167,7 +167,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RetryDelayOnExpiredTile)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RetryOnClockSkew)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     int counter = 0;
 
@@ -196,7 +196,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RetryOnClockSkew)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RespectPriorExpires)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     // Very long expiration time, should never arrive.
     Resource resource1{ Resource::Unknown, "http://127.0.0.1:3000/test" };
@@ -220,7 +220,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RespectPriorExpires)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RespectMinimumUpdateInterval)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     auto start = util::now();
     Resource resource{Resource::Unknown, "http://127.0.0.1:3000/test"};
@@ -238,7 +238,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RespectMinimumUpdateInterval)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(Load)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     const int concurrency = 50;
     const int max = 10000;
@@ -282,7 +282,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(Load)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(NetworkStatusChange)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/delayed" };
 
@@ -312,7 +312,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(NetworkStatusChange)) {
 // reachability issues.
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(NetworkStatusChangePreempt)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
     fs->pause();
 
     const auto start = Clock::now();
@@ -355,7 +355,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(NetworkStatusChangePreempt)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(NetworkStatusOnlineOffline)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test" };
 
@@ -383,7 +383,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(NetworkStatusOnlineOffline)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitStandard)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     auto req = fs->request({Resource::Unknown, "http://127.0.0.1:3000/rate-limit?std=true"}, [&](Response res) {
         ASSERT_NE(nullptr, res.error);
@@ -398,7 +398,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitStandard)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitMBX)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     auto req = fs->request({Resource::Unknown, "http://127.0.0.1:3000/rate-limit?mbx=true"}, [&](Response res) {
         ASSERT_NE(nullptr, res.error);
@@ -413,7 +413,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitMBX)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitDefault)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     auto req = fs->request({Resource::Unknown, "http://127.0.0.1:3000/rate-limit"}, [&](Response res) {
         ASSERT_NE(nullptr, res.error);
@@ -427,7 +427,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitDefault)) {
 
 TEST(OnlineFileSource, GetBaseURLAndApiKeyWhilePaused) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     fs->pause();
 
@@ -443,7 +443,7 @@ TEST(OnlineFileSource, GetBaseURLAndApiKeyWhilePaused) {
 
 TEST(OnlineFileSource, ChangeAPIBaseURL){
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
     EXPECT_EQ(ResourceOptions::Default().tileServerOptions().baseURL(), *fs->getProperty(API_BASE_URL_KEY).getString());
     const std::string customURL = "test.domain";
     fs->setProperty(API_BASE_URL_KEY, customURL);
@@ -455,7 +455,7 @@ TEST(OnlineFileSource, ChangeAPIBaseURL){
 
 TEST(OnlineFileSource, ChangeTileServerOptions){
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
     
     TileServerOptions tileServerOptsChanged;
     tileServerOptsChanged.withApiKeyParameterName("apiKeyChanged")
@@ -501,7 +501,7 @@ TEST(OnlineFileSource, ChangeTileServerOptions){
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequests)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
     std::size_t response_counter = 0;
     const std::size_t NUM_REQUESTS = 3;
 
@@ -543,7 +543,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequests)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequestsMany)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
     int response_counter = 0;
     int correct_low = 0;
     int correct_regular = 0;
@@ -598,7 +598,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequestsMany)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(MaximumConcurrentRequests)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     ASSERT_EQ(*fs->getProperty(MAX_CONCURRENT_REQUESTS_KEY).getUint(), 20u);
 
@@ -608,7 +608,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(MaximumConcurrentRequests)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RequestSameUrlMultipleTimes)) {
     util::RunLoop loop;
-    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default());
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>(ResourceOptions::Default(), ClientOptions());
 
     int count = 0;
     std::vector<std::unique_ptr<AsyncRequest>> requests;

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -23,7 +23,7 @@ using namespace mbgl;
 
 class VectorTileTest {
 public:
-    std::shared_ptr<FileSource> fileSource = std::make_shared<FakeFileSource>(ResourceOptions::Default());
+    std::shared_ptr<FileSource> fileSource = std::make_shared<FakeFileSource>(ResourceOptions::Default(), ClientOptions());
     TransformState transformState;
     util::RunLoop loop;
     style::Style style{fileSource, 1};


### PR DESCRIPTION
Add `ClientOptions` to be able to pass around client name and version. The first client is Qt platform user agent setting. I can try to update other platforms that set user agent later.

The result example is
```
Vremenar/0.6.0 (macOS 12.4) MapLibreGL/9e31d615 (Qt 6.3.1)
```

Will investigate in a separate PR on how to override the git hash with a version when building a release build.