### PR TITLE
Run iOS and Qt CI on main

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -31,7 +31,9 @@ on:
       - ".github/workflows/qt-ci-windows.yml"
       - ".github/workflows/qt-ci.yml"
       - ".github/workflows/update-gl-js.yml"
-
+    branches:
+      - main
+  
   pull_request:
     branches:
       - main

--- a/.github/workflows/qt-ci-windows.yml
+++ b/.github/workflows/qt-ci-windows.yml
@@ -30,6 +30,8 @@ on:
       - ".github/workflows/node-ci.yml"
       - ".github/workflows/qt-ci.yml"
       - ".github/workflows/update-gl-js.yml"
+    branches:
+      - main
 
   pull_request:
     branches:

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -30,7 +30,9 @@ on:
       - ".github/workflows/node-ci.yml"
       - ".github/workflows/qt-ci-windows.yml"
       - ".github/workflows/update-gl-js.yml"
-
+    branches:
+      - main
+  
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Currently we don't run all CI workflows on main, see #366. This pull request adds iOS and Qt to the workflows running on main. Still have to do the android stuff.