### PR TITLE
Update how ios and macos CMake files read from the ARCHS_STANDARD environment variable

### DIFF
--- a/platform/ios/ios.cmake
+++ b/platform/ios/ios.cmake
@@ -7,7 +7,7 @@ endif()
 # Override default CMake NATIVE_ARCH_ACTUAL
 # https://gitlab.kitware.com/cmake/cmake/-/issues/20893
 # https://stackoverflow.com/a/22689917/5531400
-set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)")
+set(CMAKE_OSX_ARCHITECTURES $ENV{ARCHS_STANDARD})
 set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH[variant=Debug] "YES")
 
 macro(initialize_ios_target target)

--- a/platform/macos/macos.cmake
+++ b/platform/macos/macos.cmake
@@ -4,7 +4,7 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11")
 # Override default CMake NATIVE_ARCH_ACTUAL
 # https://gitlab.kitware.com/cmake/cmake/-/issues/20893
 # https://stackoverflow.com/a/22689917/5531400
-set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)")
+set(CMAKE_OSX_ARCHITECTURES $ENV{ARCHS_STANDARD})
 set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH[variant=Debug] "YES")
 
 set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)


### PR DESCRIPTION
Using the standard way to access environment variables.

This will avoid the manual workaround like [this](https://github.com/maplibre/maplibre-gl-native/issues/255#issuecomment-1069093435), when trying to build the entire project with CMake by:

``` shell
ARCHS_STANDARD=$(uname -m) cmake . -B build
cmake --build build
```

