### PR TITLE
Wrap forward declared Qt classes with Qt namespace macros

### DIFF
--- a/platform/qt/app/mapwindow.hpp
+++ b/platform/qt/app/mapwindow.hpp
@@ -10,9 +10,13 @@
 
 #include <memory>
 
+QT_BEGIN_NAMESPACE
+
 class QKeyEvent;
 class QMouseEvent;
 class QWheelEvent;
+
+QT_END_NAMESPACE
 
 class MapWindow : public QOpenGLWidget
 {


### PR DESCRIPTION
I noticed that the forward declarations of Qt classes are not wrapped with the Qt namespace macros.

Usually the Qt namespace macros are not defined and this is not an issue. 
However, when Qt is compiled to a different namespace then not wrapping the forward declarations breaks the build. 