### PR TITLE
Remove account from xcconfig

### DIFF
--- a/platform/ios/platform/ios/ios.xcconfig
+++ b/platform/ios/platform/ios/ios.xcconfig
@@ -4,5 +4,3 @@
 //   [Map a configuration settings file to a build configuration](https://help.apple.com/xcode/mac/11.4/index.html?localePath=en.lproj#/deve97bde215?sub=dev40b8becae)
 
 #include "../darwin/darwin.xcconfig"
-
-LIBRARY_SEARCH_PATHS = $(LIBRARY_SEARCH_PATHS) $(PROJECT_DIR)/vendor/mapbox-accounts-ios

--- a/platform/ios/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/platform/ios/ios.xcodeproj/project.pbxproj
@@ -3822,7 +3822,6 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					"$(PROJECT_DIR)/vendor/mapbox-accounts-ios",
 				);
 				LLVM_LTO = YES;
 				OTHER_LDFLAGS = (
@@ -4491,7 +4490,6 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					"$(PROJECT_DIR)/vendor/mapbox-accounts-ios",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -4531,7 +4529,6 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					"$(PROJECT_DIR)/vendor/mapbox-accounts-ios",
 				);
 				LLVM_LTO = YES;
 				OTHER_LDFLAGS = (


### PR DESCRIPTION
This was previously used to support the compiled in Mapbox account code. It's not longer in the project but this search path does remain.