### PR TITLE
Remove info plist variables

### DIFF
--- a/platform/ios/platform/ios/framework/Info-static.plist
+++ b/platform/ios/platform/ios/framework/Info-static.plist
@@ -16,8 +16,6 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>15256</string>
-	<key>MGLCommitHash</key>
-	<string>$(CURRENT_COMMIT_HASH)</string>
 	<key>MGLSemanticVersionString</key>
 	<string>$(CURRENT_SEMANTIC_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/platform/ios/platform/ios/framework/Info.plist
+++ b/platform/ios/platform/ios/framework/Info.plist
@@ -20,8 +20,6 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>15256</string>
-	<key>MGLCommitHash</key>
-	<string>$(CURRENT_COMMIT_HASH)</string>
 	<key>MGLSemanticVersionString</key>
 	<string>$(CURRENT_SEMANTIC_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/platform/ios/platform/ios/scripts/package.sh
+++ b/platform/ios/platform/ios/scripts/package.sh
@@ -60,14 +60,9 @@ fi
 step "Recording library version…"
 VERSION="${OUTPUT}"/version.txt
 echo -n "https://github.com/maplibre/maplibre-gl-native/commit/" > ${VERSION}
-HASH=`git log | head -1 | awk '{ print $2 }' | cut -c 1-10` && true
-echo -n "maplibre-gl-native-ios "
-echo ${HASH}
-echo ${HASH} >> ${VERSION}
 
 PROJ_VERSION=$(git rev-list --count HEAD)
 SEM_VERSION=$( git describe --tags --match=ios-v*.*.* --abbrev=0 | sed 's/^ios-v//' )
-SHORT_VERSION=${SEM_VERSION%-*}
 
 step "Building targets (build ${PROJ_VERSION}, version ${SEM_VERSION})"
 
@@ -86,7 +81,6 @@ fi
 step "Building ${FORMAT} framework for iOS Simulator using ${SCHEME} scheme"
 xcodebuild \
     CURRENT_SEMANTIC_VERSION=${SEM_VERSION} \
-    CURRENT_COMMIT_HASH=${HASH} \
     ONLY_ACTIVE_ARCH=NO \
     ${CI_XCCONFIG} \
     -derivedDataPath ${DERIVED_DATA} \
@@ -100,7 +94,6 @@ if [[ ${BUILD_FOR_DEVICE} == true ]]; then
     step "Building ${FORMAT} framework for iOS devices using ${SCHEME} scheme"
     xcodebuild \
         CURRENT_SEMANTIC_VERSION=${SEM_VERSION} \
-        CURRENT_COMMIT_HASH=${HASH} \
         ONLY_ACTIVE_ARCH=NO \
         ${CI_XCCONFIG} \
         -derivedDataPath ${DERIVED_DATA} \

--- a/platform/ios/platform/ios/scripts/xcpackage.sh
+++ b/platform/ios/platform/ios/scripts/xcpackage.sh
@@ -42,14 +42,9 @@ mkdir -p ${BINOUT}
 step "Recording library version…"
 VERSION="${OUTPUT}"/version.txt
 echo -n "https://github.com/maplibre/maplibre-gl-native/commit/" > ${VERSION}
-HASH=`git log | head -1 | awk '{ print $2 }' | cut -c 1-10` && true
-echo -n "maplibre-gl-native-ios "
-echo ${HASH}
-echo ${HASH} >> ${VERSION}
 
 PROJ_VERSION=$(git rev-list --count HEAD)
 SEM_VERSION=$( git describe --tags --match=ios-v*.*.* --abbrev=0 | sed 's/^ios-v//' )
-SHORT_VERSION=${SEM_VERSION%-*}
 
 step "Building targets (build ${PROJ_VERSION}, version ${SEM_VERSION})"
 
@@ -66,7 +61,6 @@ step "Building ${FORMAT} archive for iOS Simulator using ${SCHEME} scheme -> ${B
 xcodebuild \
     archive \
     CURRENT_SEMANTIC_VERSION=${SEM_VERSION} \
-    CURRENT_COMMIT_HASH=${HASH} \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
     -workspace ./platform/ios/ios.xcworkspace \
@@ -80,7 +74,6 @@ step "Building ${FORMAT} archive for iOS devices using ${SCHEME} scheme  -> ${BI
 xcodebuild \
     archive \
     CURRENT_SEMANTIC_VERSION=${SEM_VERSION} \
-    CURRENT_COMMIT_HASH=${HASH} \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
     -workspace ./platform/ios/ios.xcworkspace \


### PR DESCRIPTION
*I previously removed both the semantic version and the commit hash but I found that the semantic version is the good version string like "5.12.0" and not linked to the build.*

I could not find any usage of MGLCommitHash anywhere so it seems to be outright dead code. Ultimately there might have been some kind of specific scenario where this was used but from what I can tell it's no longer useful within Maplibre.