### PR TITLE
Update github actions, and add dependabot to keep track of them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/android-ci-pull.yml
+++ b/.github/workflows/android-ci-pull.yml
@@ -52,13 +52,13 @@ jobs:
       MBGL_ANDROID_STL: c++_static
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -77,7 +77,7 @@ jobs:
         run: ccache --clear
 
       - name: Cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: ccache-v1
         with:
@@ -95,7 +95,7 @@ jobs:
           ccache --show-stats
 
       - name: restore-gradle-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: gradle-v1
         with:
@@ -117,7 +117,7 @@ jobs:
         run: make test-code-android
 
       - name: Store debug artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: debug-artifacts
           path: |

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -51,13 +51,13 @@ jobs:
       MBGL_ANDROID_STL: c++_static
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -75,7 +75,7 @@ jobs:
         run: ccache --clear
 
       - name: Cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: ccache-v1
         with:
@@ -93,7 +93,7 @@ jobs:
           ccache --show-stats
 
       - name: restore-gradle-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: gradle-v1
         with:
@@ -154,7 +154,7 @@ jobs:
         shell: bash
 
       - name: Store debug artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: debug-artifacts
           path: |

--- a/.github/workflows/android-docker-base.yml
+++ b/.github/workflows/android-docker-base.yml
@@ -7,21 +7,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
       - name: Build and push android-base image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: ./platform/android/docker/android-base        
           context: ./platform/android/docker

--- a/.github/workflows/android-docker-ndk-r21b.yml
+++ b/.github/workflows/android-docker-ndk-r21b.yml
@@ -7,21 +7,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
       - name: Build and push android-ndk-r21b image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: ./platform/android/docker/android-ndk-r21b        
           context: ./platform/android/docker

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -21,7 +21,7 @@ jobs:
       IS_LOCAL_DEVELOPMENT: false
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0
@@ -32,7 +32,7 @@ jobs:
         shell: bash 
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -51,7 +51,7 @@ jobs:
         run: ccache --clear       
 
       - name: Cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: ccache-v1     
         with:
@@ -69,7 +69,7 @@ jobs:
           ccache --show-stats   
 
       - name: restore-gradle-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: gradle-v1
         with:

--- a/.github/workflows/gh-pages-android-api.yml
+++ b/.github/workflows/gh-pages-android-api.yml
@@ -25,7 +25,7 @@ jobs:
           unzip javadoc.zip -d unzipped/
       
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.3.0
+        uses: JamesIves/github-pages-deploy-action@v4.4.0
         with:
           branch: gh-pages
           folder: unzipped

--- a/.github/workflows/gh-pages-ios-api.yml
+++ b/.github/workflows/gh-pages-ios-api.yml
@@ -30,7 +30,7 @@ jobs:
           brew list glfw3 || brew install glfw3
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -48,7 +48,7 @@ jobs:
         run: ccache --clear
 
       - name: Cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: ccache-v1
         with:
@@ -69,7 +69,7 @@ jobs:
         run: make idocument
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.3.0
+        uses: JamesIves/github-pages-deploy-action@v4.4.0
         with:
           branch: gh-pages
           folder: platform/ios/documentation/

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -80,7 +80,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0
@@ -93,7 +93,7 @@ jobs:
           brew list glfw3 || brew install glfw3
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -111,7 +111,7 @@ jobs:
         run: ccache --clear
 
       - name: Cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: ccache-v1
         with:

--- a/.github/workflows/ios-pre-release.yml
+++ b/.github/workflows/ios-pre-release.yml
@@ -17,7 +17,7 @@ jobs:
         shell: bash 
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0
@@ -33,7 +33,7 @@ jobs:
           gem list -i xcpretty || sudo gem install xcpretty
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -51,7 +51,7 @@ jobs:
         run: ccache --clear       
 
       - name: Cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: ccache-v1     
         with:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -16,7 +16,7 @@ jobs:
         shell: bash 
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0
@@ -29,7 +29,7 @@ jobs:
           brew list glfw3 || brew install glfw3
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -47,7 +47,7 @@ jobs:
         run: ccache --clear       
 
       - name: Cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: ccache-v1     
         with:

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -81,7 +81,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0
@@ -94,7 +94,7 @@ jobs:
           brew list glfw3 || brew install glfw3
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -112,7 +112,7 @@ jobs:
         run: ccache --clear
 
       - name: Cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: ccache-v1
         with:

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -18,7 +18,7 @@ jobs:
         shell: bash 
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0
@@ -31,7 +31,7 @@ jobs:
           brew list glfw3 || brew install glfw3
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -49,7 +49,7 @@ jobs:
         run: ccache --clear       
 
       - name: Cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: ccache-v1     
         with:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -74,9 +74,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-12
-          - macos-11
-          - ubuntu-22.04
+          - macos-10.15
+          - macos-11.0
           - ubuntu-20.04
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -74,10 +74,10 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-11.0
-          - macos-10.15
+          - macos-12
+          - macos-11
+          - ubuntu-22.04
           - ubuntu-20.04
-          - ubuntu-18.04
     runs-on: ${{ matrix.os }}
     env:
       BUILDTYPE: ${{github.ref == 'refs/heads/main' && 'Release' || 'Debug'}}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -88,7 +88,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0
@@ -133,7 +133,7 @@ jobs:
         run: ccache --clear --set-config cache_dir=~/.ccache
 
       - name: Cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: ccache-v1
         with:

--- a/.github/workflows/qt-ci-windows.yml
+++ b/.github/workflows/qt-ci-windows.yml
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
           fetch-depth: 0
@@ -144,7 +144,7 @@ jobs:
           ninja install
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: maplibre-gl-native_${{ matrix.name }}_Qt${{ matrix.qt }}
           path: install

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
           submodules: recursive
@@ -146,7 +146,7 @@ jobs:
           ccache --set-config cache_dir=~/.ccache
 
       - name: Cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: ccache-v1
         with:
@@ -204,7 +204,7 @@ jobs:
         uses: ./source/.github/actions/qt5-build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: maplibre-gl-native_${{ matrix.name }}_Qt${{ matrix.qt }}
           path: install


### PR DESCRIPTION
We use many old versions of github actions, and dependabot can keep them evergreen for us. Most of these changes does that the node environment in the runners is node 16 by default.