### PR TITLE
Replace upstream base repo with maplibre-native-base

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,7 +27,7 @@
 	url = https://github.com/mapbox/eternal.git
 [submodule "vendor/mapbox-base"]
 	path = vendor/mapbox-base
-	url = https://github.com/mapbox/mapbox-base.git
+	url = https://github.com/maplibre/maplibre-native-base.git
 [submodule "vendor/googletest"]
 	path = vendor/googletest
 	url = https://github.com/google/googletest.git


### PR DESCRIPTION
This changes the upstream repo for mapbox-base to [maplibre-native-base](https://github.com/maplibre/maplibre-native-base). The mapbox-base references are left as is to keep this pr minimal.