### PR TITLE
Bump maplibre-native-base from 2.0.0 to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### ✨ New features
 
 - *...Add new stuff here...*
+- Bump maplibre-native-base from 2.0.0 to 2.1.0
 
 ### 🐞 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### ✨ New features
 
 - *...Add new stuff here...*
-- Bump maplibre-native-base from 2.0.0 to 2.1.0
+- Bump maplibre-native-base from 2.0.0 to 2.1.0 [#397](https://github.com/maplibre/maplibre-gl-native/pull/397)
 
 ### 🐞 Bug fixes
 


### PR DESCRIPTION
**Bump maplibre-native-base from 2.0.0 to 2.1.0**

This will:
- Update [args](https://github.com/Taywee/args) from 6.2.3 to 6.4.1
- Update [rapidjson](https://github.com/Tencent/rapidjson) from (28 Jun 2019 - [d87b698d](https://github.com/Tencent/rapidjson/commit/d87b698d)) to (20 Jun 2022 - [27c3a8d](https://github.com/Tencent/rapidjson/commit/27c3a8d))