### PR TITLE
Bump wagyu from 0.4.3 to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 ## main
 
 ### ✨ New features
+
+- *...Add new stuff here...*
 - [core] Add `ClientOptions` to configure client information [#365](https://github.com/maplibre/maplibre-gl-native/pull/365).
 - [qt] Build user agent based on `ClientOptions`, if available [#365](https://github.com/maplibre/maplibre-gl-native/pull/365).
 
 ### ✨ Technical Improvements
+
 - *...Add new stuff here...*
 - Bump [maplibre-native-base](https://github.com/maplibre/maplibre-native-base) from 2.0.0 to 2.1.0 [#397](https://github.com/maplibre/maplibre-gl-native/pull/397)
 - Bump [wagyu](https://github.com/mapbox/wagyu) from 0.4.3 to 0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - *...Add new stuff here...*
 - Bump [maplibre-native-base](https://github.com/maplibre/maplibre-native-base) from 2.0.0 to 2.1.0 [#397](https://github.com/maplibre/maplibre-gl-native/pull/397)
-- Bump [wagyu](https://github.com/mapbox/wagyu) from 0.4.3 to 0.5.0
+- Bump [wagyu](https://github.com/mapbox/wagyu) from 0.4.3 to 0.5.0 [#398](https://github.com/maplibre/maplibre-gl-native/pull/398)
 
 ### 🐞 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@
 - *...Add new stuff here...*
 - [core] Add `ClientOptions` to configure client information [#365](https://github.com/maplibre/maplibre-gl-native/pull/365).
 - [qt] Build user agent based on `ClientOptions`, if available [#365](https://github.com/maplibre/maplibre-gl-native/pull/365).
-- Bump maplibre-native-base from 2.0.0 to 2.1.0 [#397](https://github.com/maplibre/maplibre-gl-native/pull/397)
+
+
+## Technical Improvements
+- Bump [maplibre-native-base](https://github.com/maplibre/maplibre-native-base) from 2.0.0 to 2.1.0 [#397](https://github.com/maplibre/maplibre-gl-native/pull/397)
+- Bump [wagyu](https://github.com/mapbox/wagyu) from 0.4.3 to 0.5.0
 
 ### 🐞 Bug fixes
 
 - *...Add new stuff here...*
 
-- [core] `MaptilerFileSource` renamed to `MBTilesFileSource` (#198)[https://github.com/maplibre/maplibre-gl-native/pull/198].
+- [core] `MaptilerFileSource` renamed to `MBTilesFileSource` [#198](https://github.com/maplibre/maplibre-gl-native/pull/198).
 
 ## maps-v1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,11 @@
 ## main
 
 ### ✨ New features
-
-- *...Add new stuff here...*
 - [core] Add `ClientOptions` to configure client information [#365](https://github.com/maplibre/maplibre-gl-native/pull/365).
 - [qt] Build user agent based on `ClientOptions`, if available [#365](https://github.com/maplibre/maplibre-gl-native/pull/365).
 
-
-## Technical Improvements
+### ✨ Technical Improvements
+- *...Add new stuff here...*
 - Bump [maplibre-native-base](https://github.com/maplibre/maplibre-native-base) from 2.0.0 to 2.1.0 [#397](https://github.com/maplibre/maplibre-gl-native/pull/397)
 - Bump [wagyu](https://github.com/mapbox/wagyu) from 0.4.3 to 0.5.0
 


### PR DESCRIPTION
The strategy for getting this repo up to date is to take each of the ~15 outdated submodules, make a PR, test, merge, and only then proceed with the next. That way we can be sure they are tested against the latest master, and thus avoid wasting cycles on the test runners.