### PR TITLE
Bump benchmark from 1.5.0 to 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Bump [googletest](https://github.com/google/googletest.git) from 1.10.0 to 1.12.1
 - Bump [zip-archive](https://github.com/ZipArchive/ZipArchive.git) from 2.2.3 to 2.5.2
 - Bump [cpp-httplib](https://github.com/yhirose/cpp-httplib) from [this commit](https://github.com/yhirose/cpp-httplib/commit/b557ac9328f3571edbb8efa25905b950f6654e9d) (~0.5.1) to 0.11.1
+- Bump [benchmark](https://github.com/google/benchmark) from 1.5.0 to 1.7.0
 
 ### 🐞 Bug fixes
 


### PR DESCRIPTION
The 1.6.0 introduced a breaking API change. https://github.com/google/benchmark/pull/1208

There might be some issues we have to resolve.