### PR TITLE
Bump maplibre-native-base from 2.1.0 to 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### ✨ Technical Improvements
 
 - *...Add new stuff here...*
-- Bump [maplibre-native-base](https://github.com/maplibre/maplibre-native-base) from 2.0.0 to 2.1.1 [#397](https://github.com/maplibre/maplibre-gl-native/pull/397)
+- Bump [maplibre-native-base](https://github.com/maplibre/maplibre-native-base) from 2.0.0 to 2.1.1 ([#397](https://github.com/maplibre/maplibre-gl-native/pull/397), [#406](https://github.com/maplibre/maplibre-gl-native/pull/406))
 - Bump [wagyu](https://github.com/mapbox/wagyu) from 0.4.3 to 0.5.0 [#398](https://github.com/maplibre/maplibre-gl-native/pull/398)
 - Bump [eternal](https://github.com/mapbox/eternal.git) from 1.0.0 to 1.0.1
 - Bump [protozero](https://github.com/mapbox/protozero.git) from 1.7.0 to 1.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### ✨ Technical Improvements
 
 - *...Add new stuff here...*
-- Bump [maplibre-native-base](https://github.com/maplibre/maplibre-native-base) from 2.0.0 to 2.1.0 [#397](https://github.com/maplibre/maplibre-gl-native/pull/397)
+- Bump [maplibre-native-base](https://github.com/maplibre/maplibre-native-base) from 2.0.0 to 2.1.1 [#397](https://github.com/maplibre/maplibre-gl-native/pull/397)
 - Bump [wagyu](https://github.com/mapbox/wagyu) from 0.4.3 to 0.5.0 [#398](https://github.com/maplibre/maplibre-gl-native/pull/398)
 - Bump [eternal](https://github.com/mapbox/eternal.git) from 1.0.0 to 1.0.1
 - Bump [protozero](https://github.com/mapbox/protozero.git) from 1.7.0 to 1.7.1


### PR DESCRIPTION
Effectively:
[variant](https://github.com/mapbox/variant.git) from 1.1.6 to 1.2.0
[expected-lite](https://github.com/martinmoene/expected-lite) from 0.4.0 to 0.6.2
[filesystem](https://github.com/gulrak/filesystem.git) from 1.5.10 to 1.5.12
[googletest](https://github.com/google/googletest) 1.10.0 to 1.12.1