### PR TITLE
Adding a small development setup for Visual Studio Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@
 /platform/android/MapboxGLAndroidSDKTestApp/local.properties
 /new_offline.db
 *.gpg
-/.vscode
+
 /platform/android/node_modules
 /platform/android/signing-key.text
 /platform/android/.java-version

--- a/.vscode/cmake-variants.json
+++ b/.vscode/cmake-variants.json
@@ -1,0 +1,32 @@
+{
+    "buildType": {
+        "default": "debug",
+        "choices": {
+            "debug": {
+                "short": "Debug",
+                "long": "Building with debugging information",
+                "buildType": "Debug"
+            },
+            "release": {
+                "short": "Release",
+                "long": "Building with release configuration, binaries without symbols",
+                "buildType": "Release"
+            }
+        }
+    },
+    "platform": {
+        "default": "core",
+        "choices": {
+            "core":{
+                "short": "CoreOnly",
+                "long": "Mapbox GL Core Build Only",
+                "settings": {
+                    "MBGL_WITH_CORE_ONLY": "On"
+                }
+            },
+            "all":{
+                "short": "All"
+            }
+        }
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "cmake.generator": "Ninja",
+    "cmake.preferredGenerators": [
+        "Ninja",
+        "Ninja Multi-Config",
+        "Unix Makefiles"
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "cmake",
+			"label": "CMake: build",
+			"command": "build",
+			"targets": [
+				"all"
+			],
+			"group": "build",
+			"problemMatcher": [],
+			"detail": "CMake template build task"
+		}
+	]
+}


### PR DESCRIPTION
Working on this code base without useful build setup can be tiring.
I created a small build setup, at least for maplibre core right
now in Visual Studio Code. Its not user specific and shareable.
This small config allows a build task to build all shaders, platforms,
and core or simply the core. It also has default Debug and Release
variants to make life easier.

I don't expect this pull request to be merged. My plan is to add debug
and other targets here so an open source developer can use free tools
to consistently build and develop this.

test: traditional cmake configre, build, testing tasks from Visual
Studio Code.
