### PR TITLE
Fix mode switch not working in node version

### DIFF
--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -642,7 +642,7 @@ void NodeMap::cancel() {
     map = std::make_unique<mbgl::Map>(*frontend, mapObserver,
                                       mbgl::MapOptions().withSize(frontend->getSize())
                                       .withPixelRatio(pixelRatio)
-                                      .withMapMode(mbgl::MapMode::Static)
+                                      .withMapMode(mode)
                                       .withCrossSourceCollisions(crossSourceCollisions),
                                       mbgl::ResourceOptions().withPlatformContext(reinterpret_cast<void*>(this)),
                                       mbgl::ClientOptions());
@@ -1421,7 +1421,7 @@ NodeMap::NodeMap(v8::Local<v8::Object> options)
     , map(std::make_unique<mbgl::Map>(*frontend, mapObserver,
                                       mbgl::MapOptions().withSize(frontend->getSize())
                                       .withPixelRatio(pixelRatio)
-                                      .withMapMode(mbgl::MapMode::Static)
+                                      .withMapMode(mode)
                                       .withCrossSourceCollisions(crossSourceCollisions),
                                       mbgl::ResourceOptions().withPlatformContext(reinterpret_cast<void*>(this)),
                                       mbgl::ClientOptions()))


### PR DESCRIPTION
This is a fix for the label clipping issue mentioned here https://github.com/maplibre/maplibre-gl-native/issues/284

I decided to take a look at the node mappings again today, since in the linux tests I ran it seemed tile mode worked fine. I was looking before at the mode switch in [node_map.cpp#L1403-L1409](https://github.com/maplibre/maplibre-gl-native/blob/main/platform/node/src/node_map.cpp#L1403-L1409)  , but today I realized that when the map was created the 'withMapMode' was set it was not using the 'mode' variable. Instead it was hardcoded to static tile mode 'mbgl::MapMode::Static' on [L1424](https://github.com/maplibre/maplibre-gl-native/blob/main/platform/node/src/node_map.cpp#L1424) and [L645](https://github.com/maplibre/maplibre-gl-native/blob/main/platform/node/src/node_map.cpp#L645)

Changing from a hardcoded 'mbgl::MapMode::Static' to using the 'mode' variable seems to have fixed the issue I was having with clipping, which make sense since the map was not being created in tile mode before. 

After finding this I went and looked at the mapbox 5.0.2 release which was working and I found that version also used the 'mode; variable on [L642](https://github.com/mapbox/mapbox-gl-native/blob/node-v5.0.2/platform/node/src/node_map.cpp#L642) and [L1449](https://github.com/mapbox/mapbox-gl-native/blob/node-v5.0.2/platform/node/src/node_map.cpp#L1449)

This change has been tested in 
[@acalcutt/maplibre-gl-native 5.0.25](https://www.npmjs.com/package/@acalcutt/maplibre-gl-native)
[@acalcutt/tileserver-gl v4.0.21](https://github.com/acalcutt/tileserver-gl/)
[maplibre-label-clipping-test](https://github.com/acalcutt/maplibre-label-clipping-test)
