### PR TITLE
Fix macos-ci using darwin-style-code instead of nitpick

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -139,5 +139,5 @@ jobs:
       - name: Lint plist files
         run: make macos-lint
 
-      - name: Nitpick Darwin code generation
-        run: scripts/nitpick/generated-code.js darwin
+      - name: Darwin Style Code check
+        run: make darwin-style-code


### PR DESCRIPTION
As proposed in here #411 we can run `make darwin-style-code` instead of the `scripts/nitpick/generated-code.js darwin` to check darwin style code.

```diff 
-      - name: Nitpick Darwin code generation
-        run: scripts/nitpick/generated-code.js darwin
+      - name: make darwin-style-code
+        run: make darwin-style-code
```