### PR TITLE
Java compatibility tag

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -170,4 +170,4 @@ autoload -Uz compinit && compinit
 ```
 
 ### Kotlin and Java compatibility
-We are moving to Kotlin, which is backward compatible with Java, but if you need a Java version of the Android SDK there is a `before-kotlin-port` tag available.
+We are moving the Android SDK to Kotlin, which is backward compatible with Java, but if you need a Java version of the Android SDK there is a `before-kotlin-port` tag available.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -168,3 +168,6 @@ To add this feature add the following to your zsh.
 zstyle ':completion:*:*:make:*' tag-order 'targets'
 autoload -Uz compinit && compinit
 ```
+
+### Kotlin and Java compat
+We are moving to Kotlin, which is backward compatible with Java, but if you need a Java version of the Android SDK there is a `before-kotlin-port` tag available.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -169,5 +169,5 @@ zstyle ':completion:*:*:make:*' tag-order 'targets'
 autoload -Uz compinit && compinit
 ```
 
-### Kotlin and Java compat
+### Kotlin and Java compatibility
 We are moving to Kotlin, which is backward compatible with Java, but if you need a Java version of the Android SDK there is a `before-kotlin-port` tag available.


### PR DESCRIPTION
Before porting the code to Kotlin, making a clear point in time where the Android SDK is still all Java could become useful later on. The tag is called `before-kotlin-port`, and it was part of the feedback on the Kotlin design proposal. #420 