### PR TITLE
Run ci on macos-12

### DIFF
--- a/.github/workflows/gh-pages-ios-api.yml
+++ b/.github/workflows/gh-pages-ios-api.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-api:
-    runs-on: macos-10.15
+    runs-on: macos-12
     env:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -5,7 +5,7 @@ on:
  
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-12
     env:
       BUILDTYPE: Release
       SYMBOLS: NO

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-12
+          - [self-hosted, macOS, ARM64]
           - ubuntu-20.04
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -74,8 +74,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-10.15
-          - macos-11.0
+          - macos-12
           - ubuntu-20.04
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/update-gl-js.yml
+++ b/.github/workflows/update-gl-js.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update-gl-js:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
since github has removed macos 10.15, and most of our code runs on macos-12, this changes the rest to use the same os verison.