### PR TITLE
Change visibility of bazel packages

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -44,3 +44,5 @@ cc_library(
         "//vendor:wagyu",
     ],
 )
+
+exports_files(["LICENSE.md"], visibility = ["//visibility:public"])

--- a/platform/darwin/BUILD.bazel
+++ b/platform/darwin/BUILD.bazel
@@ -17,7 +17,7 @@ objc_library(
     includes = [
         "include",
     ],
-    visibility = ["//visibility:public"],
+    visibility = ["//platform/ios:__pkg__"],
     deps = [
         "//:mbgl-core",
         "//platform/default:mbgl-default",
@@ -57,7 +57,7 @@ objc_library(
         "CoreText",
         "ImageIO",
     ],
-    visibility = ["//visibility:public"],
+    visibility = ["//platform/ios:__pkg__"],
     deps = [
         "//:mbgl-core",
         "//platform/default:mbgl-default",
@@ -78,7 +78,7 @@ objc_library(
         "OpenGLES",
         "SystemConfiguration",
     ],
-    visibility = ["//visibility:public"],
+    visibility = ["//platform/default:__pkg__"],
     deps = [
         "//:mbgl-core",
     ],

--- a/platform/default/BUILD.bazel
+++ b/platform/default/BUILD.bazel
@@ -48,7 +48,10 @@ cc_library(
     includes = [
         "include",
     ],
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//platform/darwin:__pkg__",
+        "//platform/ios:__pkg__",
+    ],
     deps = [
         "//:mbgl-core",
         "//platform/darwin:darwin-loop",

--- a/platform/ios/BUILD.bazel
+++ b/platform/ios/BUILD.bazel
@@ -96,6 +96,7 @@ apple_static_xcframework(
     minimum_os_versions = {"ios": "9.0"},
     public_hdrs = _PUBLIC_HEADERS,
     umbrella_header = "platform/ios/src/Mapbox.h",
+    visibility = ["//visibility:public"],
     deps = ["sdk"],
 )
 
@@ -113,6 +114,7 @@ apple_xcframework(
     minimum_os_versions = {"ios": "9.0"},
     public_hdrs = _PUBLIC_HEADERS,
     umbrella_header = "platform/ios/src/Mapbox.h",
+    visibility = ["//visibility:public"],
     deps = ["sdk"],
 )
 
@@ -249,7 +251,6 @@ objc_library(
         "OpenGLES",
         "QuartzCore",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         "objc-headers",
         "//:mbgl-core",
@@ -301,7 +302,6 @@ objc_library(
     includes = [
         "platform/darwin/include",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         "objc-headers",
         "//:mbgl-core",

--- a/platform/ios/platform/ios/vendor/BUILD.bazel
+++ b/platform/ios/platform/ios/vendor/BUILD.bazel
@@ -18,7 +18,5 @@ objc_library(
     ),
     copts = WARNING_FLAGS,
     includes = ["SMCalloutView"],
-    visibility = [
-        "//platform/ios:__pkg__",
-    ],
+    visibility = ["//platform/ios:__pkg__"],
 )

--- a/platform/ios/platform/ios/vendor/BUILD.bazel
+++ b/platform/ios/platform/ios/vendor/BUILD.bazel
@@ -18,5 +18,7 @@ objc_library(
     ),
     copts = WARNING_FLAGS,
     includes = ["SMCalloutView"],
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//platform/ios:__pkg__",
+    ],
 )


### PR DESCRIPTION
This updates some of the bazel visibility settings for packaging. Settings on Mapbox.static, Mapbox.dynamic and exports_files are all there when integrating with other bazel scripts (but doesn't affect the sh script).

The other changes are just aligning some more narrow visibilities in between packages which actually helps to hint on what depends on each one.