### PR TITLE
Configure dependabot for nested package.json files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,23 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 3
+    versioning-strategy: increase
+  - package-ecosystem: "npm"
+    directory: "/platform/android"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    versioning-strategy: increase
+  - package-ecosystem: "npm"
+    directory: "/platform/ios"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
     versioning-strategy: increase
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
Dependabot only covers the root package.json currently. This extend it to the platform directories:

/package.json
platform/ios/package.json
platform/android/package.json

It also set a limit for each of them to 3 PRs simultaneously because the previous limit of 20 wasn't efficient. This was because the packages would keep invalidating each other's CI results.