### PR TITLE
Do not parallelise Qt release deployment

### DIFF
--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -254,6 +254,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build
     strategy:
+      max-parallel: 1
       matrix:
         name: [Linux, macOS, win64_msvc2019, win64_mingw]
         qt_version: [5.15.2, 6.3.2]


### PR DESCRIPTION
Do not parallelise Qt release deployment as it may cause multiple draft releases. Force one execution at once. As these are fast jobs (just repacking) it should not matter.