### PR TITLE
Xcode 14 compatibility

### DIFF
--- a/platform/ios/platform/darwin/test/MGLCoordinateFormatterTests.m
+++ b/platform/ios/platform/darwin/test/MGLCoordinateFormatterTests.m
@@ -24,7 +24,7 @@
     coordinate = CLLocationCoordinate2DMake(38.9131982, -77.0325453144239);
     XCTAssertEqualObjects([shortFormatter stringFromCoordinate:coordinate], @"38°54′48″N, 77°1′57″W");
     XCTAssertEqualObjects([mediumFormatter stringFromCoordinate:coordinate], @"38°54′48″ north, 77°1′57″ west");
-    XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"38 degrees, 54 minutes, and 48 seconds north by 77 degrees, 1 minute, and 57 seconds west");
+    XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"38 degree(s), 54 minute(s), and 48 second(s) north by 77 degree(s), 1 minute(s), and 57 second(s) west");
 
     shortFormatter.allowsSeconds = NO;
     mediumFormatter.allowsSeconds = NO;
@@ -33,7 +33,7 @@
     coordinate = CLLocationCoordinate2DMake(38.9131982, -77.0325453144239);
     XCTAssertEqualObjects([shortFormatter stringFromCoordinate:coordinate], @"38°55′N, 77°2′W");
     XCTAssertEqualObjects([mediumFormatter stringFromCoordinate:coordinate], @"38°55′ north, 77°2′ west");
-    XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"38 degrees and 55 minutes north by 77 degrees and 2 minutes west");
+    XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"38 degree(s) and 55 minute(s) north by 77 degree(s) and 2 minute(s) west");
 
     shortFormatter.allowsMinutes = NO;
     mediumFormatter.allowsMinutes = NO;
@@ -42,7 +42,7 @@
     coordinate = CLLocationCoordinate2DMake(38.9131982, -77.0325453144239);
     XCTAssertEqualObjects([shortFormatter stringFromCoordinate:coordinate], @"39°N, 77°W");
     XCTAssertEqualObjects([mediumFormatter stringFromCoordinate:coordinate], @"39° north, 77° west");
-    XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"39 degrees north by 77 degrees west");
+    XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"39 degree(s) north by 77 degree(s) west");
 }
 
 @end


### PR DESCRIPTION
This unblocks our CI which runs xcode 14, introduced in #485 .

The following simulators with iOS 16 have to be enabled in Xcode 14, as they aren't by default like in Xcode 13.x:

```sh
-destination 'platform=iOS Simulator,OS=latest,name=iPhone 8' \
-destination 'platform=iOS Simulator,OS=latest,name=iPhone Xs Max' \
-destination 'platform=iOS Simulator,OS=latest,name=iPhone Xr' \
-destination 'platform=iOS Simulator,OS=latest,name=iPad Pro (11-inch)'
```