### PR TITLE
Increase minimum node version to 14

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -78,7 +78,7 @@ jobs:
         os:
           - macos-12
           - ubuntu-20.04
-        node: [ 10, 14, 16, 18 ]
+        node: [ 14, 16, 18 ]
     name: OS ${{ matrix.os }} Node ${{ matrix.node }}
     runs-on: ${{ matrix.os }}
     continue-on-error: true

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -47,7 +47,7 @@ jobs:
         os:
           - macos-12
           - ubuntu-20.04
-        node: [ 10, 14, 16, 18 ]
+        node: [ 14, 16, 18 ]
     name: OS ${{ matrix.os }} Node ${{ matrix.node }}
     runs-on: ${{ matrix.os }}
     needs: bump_version

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # main
 * Add support for [image expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-types-image). ([#15877](https://github.com/mapbox/mapbox-gl-native/pull/15877))
-* Remove node 10 support. v5.x of the node package can be used a compatibility version.
+* [Breaking] Remove node 10 support. v5.x of the node package can be used a compatibility version.
 
 # 5.0.0
 * No longer supporting source-compile fallback ([#15748](https://github.com/mapbox/mapbox-gl-native/pull/15748))

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 # main
 * Add support for [image expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-types-image). ([#15877](https://github.com/mapbox/mapbox-gl-native/pull/15877))
+* Remove node 10 support. v5.x of the node package can be used a compatibility version.
 
 # 5.0.0
 * No longer supporting source-compile fallback ([#15748](https://github.com/mapbox/mapbox-gl-native/pull/15748))


### PR DESCRIPTION
We recently released @maplibre/maplibre-gl-native to npm, with node 10 support (thanks @acalcutt !).

PR here: https://github.com/maplibre/maplibre-gl-native/pull/378 

This can be used as a compatibility version for migration (v5.0.1), but as node 10 passed the end of life a while ago, this PR deprecates it again, raising the minimum supported node version to 14.