### PR TITLE
Fixes potential NaN when calling `NativeMapView::nativeMoveBy`

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -245,7 +245,14 @@ final class NativeMapView implements NativeMap {
     if (checkState("moveBy")) {
       return;
     }
-    nativeMoveBy(dx / pixelRatio, dy / pixelRatio, duration);
+
+    try {
+      nativeMoveBy(dx / pixelRatio, dy / pixelRatio, duration);
+    } catch (java.lang.Error error) {
+      // workaround for latitude must not be NaN issue
+      // which is thrown when gl-native can't convert a screen coordinate to location
+      Logger.d(TAG, "Error when executing NativeMapView#moveBy", error);
+    }
   }
 
   @Override


### PR DESCRIPTION
The code may crash at runtime due to NaN being created when calling `NativeMapView::nativeMoveBy`

I've just applied the same fix, which is already present in the most recent Mapbox codebase.

https://github.com/mapbox/mapbox-gl-native-android/blob/a82dcd9d8aa21dd9a285f319d33755d9333f917a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java#L269