### PR TITLE
Remove node matix from workflow

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -195,7 +195,7 @@ jobs:
           ./platform/node/scripts/publish.sh --target_arch=arm64
 
       - name: Publish to NPM (release)
-        if: matrix.os == 'ubuntu-20.04' && matrix.node == '18' && github.ref == 'refs/heads/main' && github.event.inputs.version != 'prerelease'
+        if: matrix.os == 'ubuntu-20.04' && github.ref == 'refs/heads/main' && github.event.inputs.version != 'prerelease'
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
           npm publish --access public
@@ -203,7 +203,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
 
       - name: Publish to NPM (prerelease)
-        if: matrix.os == 'ubuntu-20.04' && matrix.node == '18' && github.ref == 'refs/heads/main' && github.event.inputs.version == 'prerelease'
+        if: matrix.os == 'ubuntu-20.04' && github.ref == 'refs/heads/main' && github.event.inputs.version == 'prerelease'
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
           npm publish --tag next --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - *...Add new stuff here...*
 - [core] Add `ClientOptions` to configure client information [#365](https://github.com/maplibre/maplibre-gl-native/pull/365).
+- [node] Add workflow to create node binary releases for Ubuntu 20.04 x64 and MacOS 12 x64/arm64 [#378](https://github.com/maplibre/maplibre-gl-native/pull/378), [#459](https://github.com/maplibre/maplibre-gl-native/pull/459).
 
 ### ✨ Technical Improvements
 

--- a/package.json
+++ b/package.json
@@ -61,9 +61,7 @@
     "test-memory": "node --expose-gc platform/node/test/memory.test.js",
     "test-expressions": "node -r esm platform/node/test/expression.test.js",
     "test-render": "node -r esm platform/node/test/render.test.js",
-    "test-query": "node -r esm platform/node/test/query.test.js",
-    "package": "node-pre-gyp package",
-    "release": "node-pre-gyp-github publish --release"
+    "test-query": "node -r esm platform/node/test/query.test.js"
   },
   "gypfile": true,
   "binary": {


### PR DESCRIPTION
Removed "matrix.node" condintion that is no longer needed in this workflow.
Removed package/release from package.json since it is no longer needed by this workflow.
Added CHANGELOG for node binary release workflow.
