### PR TITLE
update to node-pre-gyp with LF line endings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@acalcutt/node-pre-gyp": "^1.0.10",
+        "@acalcutt/node-pre-gyp": "^1.0.11",
         "@acalcutt/node-pre-gyp-github": "1.4.8",
         "@mapbox/cmake-node-module": "^1.2.0",
         "minimatch": "^5.1.0",
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@acalcutt/node-pre-gyp": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@acalcutt/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
-      "integrity": "sha512-vA48avL6+DaEznRusKKSgzNKp/2+KhG1UHwGU8ALUUpcV+L+WZzzUgRdpF5dP9Mb4k5/B0cJIxUYIlvqoPE4rQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@acalcutt/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-aeT0m5l3TdO0Mzs0lVIN6Qq+RYGyUu8XoE46r/o2mpZ/ve5o9B/AQT12S1ACIrQGHf0BrGGSy9yhV9SUe7ogJw==",
       "dependencies": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -4216,9 +4216,9 @@
   },
   "dependencies": {
     "@acalcutt/node-pre-gyp": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@acalcutt/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
-      "integrity": "sha512-vA48avL6+DaEznRusKKSgzNKp/2+KhG1UHwGU8ALUUpcV+L+WZzzUgRdpF5dP9Mb4k5/B0cJIxUYIlvqoPE4rQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@acalcutt/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-aeT0m5l3TdO0Mzs0lVIN6Qq+RYGyUu8XoE46r/o2mpZ/ve5o9B/AQT12S1ACIrQGHf0BrGGSy9yhV9SUe7ogJw==",
       "requires": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "@mapbox/cmake-node-module": "^1.2.0",
-    "@acalcutt/node-pre-gyp": "^1.0.10",
+    "@acalcutt/node-pre-gyp": "^1.0.11",
     "@acalcutt/node-pre-gyp-github": "1.4.8",
     "minimatch": "^5.1.0",
     "npm-run-all": "^4.0.2"


### PR DESCRIPTION
node-pre-gyp 1.0.10 was published from windows, which added CRLF line endings, which fail in yarn (they work in npm). This node-pre-gyp was published from linux so it has the correct LF line endings