### PR TITLE
Node workflow - Add version to commit, simplify cmake commands

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -165,8 +165,14 @@ jobs:
           ccache --show-stats --set-config cache_dir=~/.ccache
 
       - name: CMake
+        if: runner.os == 'MacOS'
         run: |
-          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }}
+          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} -DMBGL_WITH_COVERAGE=ON
+
+      - name: CMake
+        if: runner.os == 'Linux'
+        run: |
+          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
 
       - name: Build
         run: |

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -167,12 +167,12 @@ jobs:
       - name: CMake
         if: runner.os == 'MacOS'
         run: |
-          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} -DMBGL_WITH_COVERAGE=ON
+          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }}
 
       - name: CMake
         if: runner.os == 'Linux'
         run: |
-          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
+          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
 
       - name: Build
         run: |

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -165,14 +165,8 @@ jobs:
           ccache --show-stats --set-config cache_dir=~/.ccache
 
       - name: CMake
-        if: runner.os == 'MacOS'
         run: |
-          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} -DMBGL_WITH_COVERAGE=ON
-
-      - name: CMake
-        if: runner.os == 'Linux'
-        run: |
-          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
+          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }}
 
       - name: Build
         run: |

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -144,14 +144,8 @@ jobs:
           ccache --show-stats --set-config cache_dir=~/.ccache
 
       - name: CMake
-        if: runner.os == 'MacOS'
         run: |
-          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} -DMBGL_WITH_COVERAGE=ON
-
-      - name: CMake
-        if: runner.os == 'Linux'
-        run: |
-          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
+          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }}
 
       - name: Build
         run: |

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git commit -a -m "Update node version to ${{ steps.npmversion.outputs.NPM_VERSION }}"
+          git commit -a -m "Update node version to ${{ steps.npmversion.outputs.NPM_VERSION }} (${{ github.event.inputs.version }})"
           git push
 
   publish_binaries:

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: choice
         options:
-          - prerelease
+          - prepatch
           - preminor
           - premajor
           - patch
@@ -233,7 +233,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
 
       - name: Publish to NPM (prerelease)
-        if: github.ref == 'refs/heads/main' && (github.event.inputs.version == 'prerelease' || github.event.inputs.version == 'preminor' || github.event.inputs.version == 'premajor')
+        if: github.ref == 'refs/heads/main' && (github.event.inputs.version == 'prepatch' || github.event.inputs.version == 'preminor' || github.event.inputs.version == 'premajor')
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
           npm publish --tag next --access public

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -146,14 +146,8 @@ jobs:
           ccache --show-stats --set-config cache_dir=~/.ccache
 
       - name: CMake
-        if: runner.os == 'MacOS'
         run: |
-          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} -DMBGL_WITH_COVERAGE=ON
-
-      - name: CMake
-        if: runner.os == 'Linux'
-        run: |
-          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
+          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }}
 
       - name: Build
         run: |

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -148,12 +148,12 @@ jobs:
       - name: CMake
         if: runner.os == 'MacOS'
         run: |
-          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} -DMBGL_WITH_COVERAGE=ON
+          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }}
 
       - name: CMake
         if: runner.os == 'Linux'
         run: |
-          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
+          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
 
       - name: Build
         run: |

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -8,7 +8,9 @@ on:
         required: true
         type: choice
         options:
-          - prerelease 
+          - prerelease
+          - preminor
+          - premajor
           - patch
           - minor
           - major
@@ -144,8 +146,14 @@ jobs:
           ccache --show-stats --set-config cache_dir=~/.ccache
 
       - name: CMake
+        if: runner.os == 'MacOS'
         run: |
-          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }}
+          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} -DMBGL_WITH_COVERAGE=ON
+
+      - name: CMake
+        if: runner.os == 'Linux'
+        run: |
+          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
 
       - name: Build
         run: |

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -239,4 +239,3 @@ jobs:
           npm publish --tag next --access public
         env:
           NPM_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
-     

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -8,6 +8,7 @@ on:
         required: true
         type: choice
         options:
+          - prerelease
           - prepatch
           - preminor
           - premajor
@@ -233,7 +234,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
 
       - name: Publish to NPM (prerelease)
-        if: github.ref == 'refs/heads/main' && (github.event.inputs.version == 'prepatch' || github.event.inputs.version == 'preminor' || github.event.inputs.version == 'premajor')
+        if: github.ref == 'refs/heads/main' && (github.event.inputs.version == 'prerelease' || github.event.inputs.version == 'prepatch' || github.event.inputs.version == 'preminor' || github.event.inputs.version == 'premajor')
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
           npm publish --tag next --access public

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -233,3 +233,4 @@ jobs:
           npm publish --tag next --access public
         env:
           NPM_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
+     

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -219,7 +219,7 @@ jobs:
           node-version: 18
 
       - name: Publish to NPM (release)
-        if: github.ref == 'refs/heads/main' && github.event.inputs.version != 'prerelease'
+        if: github.ref == 'refs/heads/main' && (github.event.inputs.version == 'patch' || github.event.inputs.version == 'minor' || github.event.inputs.version == 'major')
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
           npm publish --access public
@@ -227,7 +227,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
 
       - name: Publish to NPM (prerelease)
-        if: github.ref == 'refs/heads/main' && github.event.inputs.version == 'prerelease'
+        if: github.ref == 'refs/heads/main' && (github.event.inputs.version == 'prerelease' || github.event.inputs.version == 'preminor' || github.event.inputs.version == 'premajor')
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
           npm publish --tag next --access public

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -146,8 +146,14 @@ jobs:
           ccache --show-stats --set-config cache_dir=~/.ccache
 
       - name: CMake
+        if: runner.os == 'MacOS'
         run: |
-          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }}
+          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} -DMBGL_WITH_COVERAGE=ON
+
+      - name: CMake
+        if: runner.os == 'Linux'
+        run: |
+          cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
 
       - name: Build
         run: |

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -33,11 +33,18 @@ jobs:
         with:
           node-version: 18
 
-      - name: Bump Version
+      - name: npm version
+        id: npmversion
+        run: >-
+          echo "::set-output name=NPM_VERSION::$(
+            npm version ${{ github.event.inputs.version }} --preid pre --no-git-tag-version
+          )"
+
+      - name: Push version to git
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          npm version ${{ github.event.inputs.version }} --preid pre -m "Update node version to (${{ github.event.inputs.version }})"
+          git commit -a -m "Update node version to ${{ steps.npmversion.outputs.NPM_VERSION }}"
           git push
 
   publish_binaries:


### PR DESCRIPTION
The PR does two things discussed in slack.

1.) It adds the package version to the commit message when the version is bumped.

2.) It uses the same cmake command for both macos and linux. It removes DMBGL_WITH_COVERAGE from macos build and adds DCMAKE_BUILD_TYPE to the linux build by using the following command for both
`cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }}`

EDIT:
I also added one extra thing. I added the ability to chose a preminor or premajor release type, so we could to something lile use premajor to release v6.0.0-pre.0