### PR TITLE
Removing unused versions sdk

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 apply plugin: "com.jaredsburrows.license"
 apply plugin: 'kotlin-android'
 apply from: "${rootDir}/gradle/native-build.gradle"
-apply plugin: 'com.mapbox.android.sdk.versions'
 
 dependencies {
     lintChecks project(":MapboxGLAndroidSDKLint")

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -13,7 +13,6 @@ buildscript {
         classpath dependenciesList.licensesPlugin
         classpath dependenciesList.kotlinPlugin
         // classpath dependenciesList.jacocoPlugin
-        classpath dependenciesList.mapboxSdkVersions
         classpath dependenciesList.gradleNexus
     }
 }

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -34,7 +34,6 @@ ext {
             appcenter        : '1.4',
             ktlint           : '0.40.0',
             commonsIO        : '2.6',
-            mapboxSdkVersions: '1.0.1',
             assertj          : "3.11.1",
             gradleNexus      : "1.1.0"
     ]
@@ -80,7 +79,6 @@ ext {
             lintChecks             : "com.android.tools.lint:lint-checks:${versions.lint}",
             lintTests              : "com.android.tools.lint:lint-tests:${versions.lint}",
             ktlint                 : "com.pinterest:ktlint:${versions.ktlint}",
-            mapboxSdkVersions      : "com.mapbox.mapboxsdk:mapbox-android-sdk-versions:${versions.mapboxSdkVersions}",
 
             gradleNexus            : "io.github.gradle-nexus:publish-plugin:${versions.gradleNexus}"
     ]


### PR DESCRIPTION
Fixes #484 by removing a problematic [package](https://github.com/mapbox/android-sdk-versions-plugin) that was used for telemetry in the past but is not in use anymore.

