### PR TITLE
Fix bitcode on iOS for nunicode

### DIFF
--- a/platform/qt/CHANGELOG.md
+++ b/platform/qt/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Upcoming
+
+### 🐞 Bug fixes
+
+- Fixed bitcode issues on iOS.
+
 ## v2.0.1
 
 ### 🐞 Bug fixes

--- a/vendor/nunicode.cmake
+++ b/vendor/nunicode.cmake
@@ -24,6 +24,11 @@ target_compile_definitions(
     PRIVATE NU_BUILD_STATIC
 )
 
+target_link_libraries(
+    mbgl-vendor-nunicode
+    PRIVATE mbgl-compiler-options
+)
+
 if(MSVC)
     target_compile_options(mbgl-vendor-nunicode PRIVATE /wd4146)
 else()


### PR DESCRIPTION
This dependency had missing `mbgl-compiler-options`.