### PR TITLE
Fix Bazel build file for dynamic linked targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ git checkout tags/$TAG -b $TAG
 # clean, if you need to troubleshoot build dependencies by using `make clean`
 ```
 
-## Build using Bazel
+### Build using Bazel
 
 [Bazel](https://bazel.build) is also supported as a build option for getting a packaged release of the xcframework compiled for either static or dynamic linking.
 
@@ -171,7 +171,7 @@ Firstly you will have to ensure that Bazel is installed
 
 From there you can use the script in platform/ios/platform/ios/scripts/package-bazel.sh
 
-# There are 4 options:
+#### There are 4 options:
 
 `cd platform/ios/platform/ios/scripts`
 
@@ -193,7 +193,7 @@ Also you can use the link option to ensure that the framework is able to link.
 
 `./bazel-package.sh --link`
 
-# Bazel build files are placed in a few places throughout the project:
+#### Bazel build files are placed in a few places throughout the project:
 
 `BUILD.bazel`
 - Covering the base cpp in the root `src` directory.
@@ -213,7 +213,7 @@ Also you can use the link option to ensure that the framework is able to link.
 `platform/ios/BUILD.bazel`
 - Covering the source in `platform/ios/platform/ios/src` and `platform/ios/platform/darwin/src` as well as defining all the other BUILD.bazel files and defining the xcframework targets.
 
-# There are also some other areas that make bazel work:
+#### There are also some other areas that make bazel work:
 
 `WORKSPACE`
 - Defines the "repo" and the different modules that are loaded in order to compile for Apple.

--- a/platform/ios/BUILD.bazel
+++ b/platform/ios/BUILD.bazel
@@ -155,6 +155,26 @@ objc_library(
     ],
 )
 
+# sdk for the dynamic target. Lacking the resources bundle since for dynamic
+# they are in the main package.
+objc_library(
+    name = "sdk-dynamic",
+    sdk_dylibs = [
+        "libz",
+        "libsqlite3",
+        "libc++",
+    ],
+    sdk_frameworks = [
+        "MobileCoreServices",
+        "Security",
+        "WebKit",
+    ],
+    deps = [
+        "objc-sdk",
+        "objcpp-sdk",
+    ],
+)
+
 apple_resource_bundle(
     name = "resources",
     bundle_id = "com.maplibre.mapbox",

--- a/platform/ios/BUILD.bazel
+++ b/platform/ios/BUILD.bazel
@@ -102,7 +102,12 @@ apple_static_xcframework(
 
 apple_xcframework(
     name = "Mapbox.dynamic",
+    bundle_id = "com.maplibre.mapbox",
     bundle_name = "Mapbox",
+    data = glob([
+        "platform/ios/resources/*.lproj/**",
+        "platform/ios/resources/*.xcassets/**",
+    ]),
     infoplists = ["build/Info.plist"],
     ios = {
         "simulator": [
@@ -115,7 +120,7 @@ apple_xcframework(
     public_hdrs = _PUBLIC_HEADERS,
     umbrella_header = "platform/ios/src/Mapbox.h",
     visibility = ["//visibility:public"],
-    deps = ["sdk"],
+    deps = ["sdk-dynamic"],
 )
 
 # This target allows you to link the SDK to emulate linking it in the app
@@ -130,6 +135,7 @@ ios_framework(
     deps = ["sdk"],
 )
 
+# sdk for the static target which includes the resources.
 objc_library(
     name = "sdk",
     data = ["resources"],

--- a/platform/ios/platform/ios/scripts/bazel-package.sh
+++ b/platform/ios/platform/ios/scripts/bazel-package.sh
@@ -88,4 +88,4 @@ bazel build //platform/ios:"$target" --apple_platform_type=ios \
 popd
 
 echo "Done."
-echo "Package will be available in \"/bazel-bin/platform/ios/platform/ios/$target.xcframework.zip\""
+echo "Package will be available in \"/bazel-bin/platform/ios/$target.xcframework.zip\""


### PR DESCRIPTION
- Previously the bundle_id was missing from the dynamic target, which is required.
- The resources were previously bundled in a Mapbox.bundle instead of in the root of the framework itself. Mapbox dynamic depends on it being in the root of the framework
- I realized that my README formatting was incorrect as well as a message from the build script.