### PR TITLE
[qt] Support GeoJSON feature collection as std::list

### DIFF
--- a/platform/qt/CHANGELOG.md
+++ b/platform/qt/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming
 
+### ✨ New features
+
+- Support for GeoJSON feature collections using std::list ([#541](https://github.com/maplibre/maplibre-gl-native/pull/541)).
+
 ### 🐞 Bug fixes
 
 - Fixed bitcode issues on iOS.

--- a/platform/qt/src/utils/conversion.hpp
+++ b/platform/qt/src/utils/conversion.hpp
@@ -50,7 +50,8 @@ public:
 #endif
             || QString(value.typeName()) == QStringLiteral("QMapLibreGL::Feature")
             || value.userType() == qMetaTypeId<QVector<QMapLibreGL::Feature>>()
-            || value.userType() == qMetaTypeId<QList<QMapLibreGL::Feature>>();
+            || value.userType() == qMetaTypeId<QList<QMapLibreGL::Feature>>()
+            || value.userType() == qMetaTypeId<std::list<QMapLibreGL::Feature>>();
     }
 
     static optional<QVariant> objectMember(const QVariant& value, const char* key) {
@@ -176,6 +177,8 @@ public:
             return featureCollectionToGeoJSON(value.value<QVector<QMapLibreGL::Feature>>());
         } else if (value.userType() == qMetaTypeId<QList<QMapLibreGL::Feature>>()) {
             return featureCollectionToGeoJSON(value.value<QList<QMapLibreGL::Feature>>());
+        } else if (value.userType() == qMetaTypeId<std::list<QMapLibreGL::Feature>>()) {
+            return featureCollectionToGeoJSON(value.value<std::list<QMapLibreGL::Feature>>());
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         } else if (value.typeId() != QMetaType::QByteArray) {
 #else


### PR DESCRIPTION
The current conversion routine supports GeoJSON feature collections using QList/QVector and QByteArray (JSON string). This adds support for feature collections using std::list.