### PR TITLE
Exclude Node 19 (ABI 111) because it breaks the node build

### DIFF
--- a/platform/node/CMakeLists.txt
+++ b/platform/node/CMakeLists.txt
@@ -15,6 +15,7 @@ add_node_module(
         47
         48
         51
+        111
 )
 find_package(PkgConfig REQUIRED)
 pkg_search_module(LIBUV libuv REQUIRED)


### PR DESCRIPTION
This excludes Node 19 ABI version 111 because it breaks the build. With 111 included the build and node-ci in main are failing with an error like 

> FAILED: platform/node/CMakeFiles/mbgl-node.abi-111.dir/src/node_map.cpp.o
> ccache /usr/bin/g++-10 -DBUILDING_NODE_EXTENSION -DMODULE_NAME=mbgl_node -DRAPIDJSON_HAS_STDSTRING=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Dmbgl_node_abi_111_EXPORTS -I../include -I../platform/default/include -I../src -isystem headers/node/v19.0.0 -isystem headers/nan/2.14.2 -isystem ../vendor/mapbox-base/include -isystem ../vendor/mapbox-base/extras/expected-lite/include -isystem ../vendor/mapbox-base/deps/geojson-vt-cpp/include -isystem ../vendor/mapbox-base/deps/geojson.hpp/include -isystem ../vendor/mapbox-base/deps/geometry.hpp/include -isystem ../vendor/mapbox-base/deps/jni.hpp/include -isystem ../vendor/mapbox-base/deps/optional -isystem ../vendor/mapbox-base/deps/pixelmatch-cpp/include -isystem ../vendor/mapbox-base/deps/shelf-pack-cpp/include -isystem ../vendor/mapbox-base/deps/supercluster.hpp/include -isystem ../vendor/mapbox-base/deps/variant/include -isystem ../vendor/mapbox-base/deps/cheap-ruler-cpp/include -isystem ../vendor/mapbox-base/extras/rapidjson/include -O3 -DNDEBUG -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -std=c++11 -std=c++17 -MD -MT platform/node/CMakeFiles/mbgl-node.abi-111.dir/src/node_map.cpp.o -MF platform/node/CMakeFiles/mbgl-node.abi-111.dir/src/node_map.cpp.o.d -o platform/node/CMakeFiles/mbgl-node.abi-111.dir/src/node_map.cpp.o -c ../platform/node/src/node_map.cpp
> In file included from headers/nan/2.14.2/nan.h:176,
>                  from ../platform/node/src/node_map.hpp:15,
>                  from ../platform/node/src/node_map.cpp:1:
> headers/nan/2.14.2/nan_callbacks.h:55:23: error: ‘AccessorSignature’ is not a member of ‘v8’
>    55 | typedef v8::Local<v8::AccessorSignature> Sig;
>       |                       ^~~~~~~~~~~~~~~~~
> headers/nan/2.14.2/nan_callbacks.h:55:40: error: template argument 1 is invalid
>    55 | typedef v8::Local<v8::AccessorSignature> Sig;
>       |                                        ^
> In file included from ../platform/node/src/node_map.hpp:15,
>                  from ../platform/node/src/node_map.cpp:1:
> headers/nan/2.14.2/nan.h: In function ‘void Nan::SetAccessor(v8::Local<v8::ObjectTemplate>, v8::Local<v8::String>, Nan::GetterCallback, Nan::SetterCallback, v8::Local<v8::Value>, v8::AccessControl, v8::PropertyAttribute, Nan::imp::Sig)’:
> headers/nan/2.14.2/nan.h:2549:16: error: no matching function for call to ‘v8::ObjectTemplate::SetAccessor(v8::Local<v8::String>&, void (*&)(v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Value>&), void (*&)(v8::Local<v8::Name>, v8::Local<v8::Value>, const v8::PropertyCallbackInfo<void>&), v8::Local<v8::Object>&, v8::AccessControl&, v8::PropertyAttribute&, Nan::imp::Sig&)’
>  2549 |     , signature);
>       |                ^
> In file included from headers/node/v19.0.0/v8-function.h:15,
>                  from headers/node/v19.0.0/v8.h:33,
>                  from headers/node/v19.0.0/node.h:73,
>                  from headers/nan/2.14.2/nan.h:56,
>                  from ../platform/node/src/node_map.hpp:15,
>                  from ../platform/node/src/node_map.cpp:1:
> headers/node/v19.0.0/v8-template.h:807:8: note: candidate: ‘void v8::ObjectTemplate::SetAccessor(v8::Local<v8::String>, v8::AccessorGetterCallback, v8::AccessorSetterCallback, v8::Local<v8::Value>, v8::AccessControl, v8::PropertyAttribute, v8::SideEffectType, v8::SideEffectType)’
>   807 |   void SetAccessor(
>       |        ^~~~~~~~~~~
> headers/node/v19.0.0/v8-template.h:812:22: note:   no known conversion for argument 7 from ‘Nan::imp::Sig’ {aka ‘int’} to ‘v8::SideEffectType’
>   812 |       SideEffectType getter_side_effect_type = SideEffectType::kHasSideEffect,
>       |       ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> headers/node/v19.0.0/v8-template.h:814:8: note: candidate: ‘void v8::ObjectTemplate::SetAccessor(v8::Local<v8::Name>, v8::AccessorNameGetterCallback, v8::AccessorNameSetterCallback, v8::Local<v8::Value>, v8::AccessControl, v8::PropertyAttribute, v8::SideEffectType, v8::SideEffectType)’
>   814 |   void SetAccessor(
>       |        ^~~~~~~~~~~
> headers/node/v19.0.0/v8-template.h:819:22: note:   no known conversion for argument 7 from ‘Nan::imp::Sig’ {aka ‘int’} to ‘v8::SideEffectType’
>   819 |       SideEffectType getter_side_effect_type = SideEffectType::kHasSideEffect,
>       |       ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> ../platform/node/src/node_map.cpp: In static member function ‘static void node_mbgl::NodeMap::Init(v8::Local<v8::Object>)’:
> ../platform/node/src/node_map.cpp:121:46: error: ‘class v8::Object’ has no member named ‘CreationContext’; did you mean ‘GetCreationContext’?
>   121 |     v8::Local<v8::Context> context = target->CreationContext();
>       |                                              ^~~~~~~~~~~~~~~
>       |                                              GetCreationContext
> [643/668] Building C object CMakeFiles/mbgl-vendor-sqlite.dir/vendor/sqlite/src/sqlite3.c.o
> ../vendor/sqlite/src/sqlite3.c: In function ‘sqlite3SelectNew’:
> ../vendor/sqlite/src/sqlite3.c:121468:10: warning: function may return address of local variable [-Wreturn-local-addr]
> 121468 |   return pNew;
>        |          ^~~~
> ../vendor/sqlite/src/sqlite3.c:121430:10: note: declared here
> 121430 |   Select standin;
>        |          ^~~~~~~
> ../vendor/sqlite/src/sqlite3.c:121430:10: note: declared here
> ninja: build stopped: subcommand failed.


Excluding ABI 111 allows the build to complete again. We should still look into why this fails eventually.