### PR TITLE
Add Qt attribution file

### DIFF
--- a/qt_attribution.json
+++ b/qt_attribution.json
@@ -1,0 +1,13 @@
+{
+  "Id": "maplibre-gl-native",
+  "Name": "MapLibre GL Native",
+  "QDocModule": "qtlocation",
+  "QtUsage": "Used in the MapLibre backend of Qt Location.",
+
+  "Description": "MapLibre GL Native is a community led fork derived from mapbox-gl-native.",
+  "Homepage": "https://github.com/maplibre/maplibre-gl-native",
+  "LicenseId": "BSD-2-Clause",
+  "License": "BSD 2-Clause License",
+  "LicenseFile": "LICENSE.md",
+  "Copyright": "Copyright (c) 2021 MapLibre contributors Copyright (c) 2018-2021 MapTiler.com Copyright (c) 2014-2020 Mapbox"
+}


### PR DESCRIPTION
Qt project would appreciate having a Qt attribution JSON file which helps them properly attribute their usage of MapLibre. It will also help get MapLibre included which may increase adoption. This way they can include this repo as submodule directly.

Note that our LICENSE.md should probably bump the year, but this should be in a separate PR.