### PR TITLE
Remove requirement to run android release on self-hosted runner

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: platform/android


### PR DESCRIPTION
I think the Android release workflow does not work at the moment because it want to run on a self-hosted ubuntu runner, but we don't have any as far as I know.

This pull request makes the android release workflow run on a normal ubuntu github instance, a bit like in the `android-ci.yml` file...