### PR TITLE
force 'linux' as target platform for node-pre-gyp in ubuntu arm64 binary

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -287,4 +287,4 @@ jobs:
           BUILDTYPE: RelWithDebInfo
           NODE_PRE_GYP_GITHUB_TOKEN: ${{ secrets.NODE_PRE_GYP_GITHUB_TOKEN }}
         run: |
-          ./platform/node/scripts/publish.sh --target_arch=arm64
+          ./platform/node/scripts/publish.sh --target_platform=linux --target_arch=arm64


### PR DESCRIPTION
Set the node-pre-gyp target_platform to linux when uploading the binary.  

Because we switched the runner to macos arm64, node-pre-gyp defaults to 'darwin'. However, the binary generated in the docker image is made for ubuntu 20.04, so it should be set to 'linux'. This causes the binary to fail to upload, since the proper darwin arm64 is generated by a different part of the job.

The error looks like this
![image](https://user-images.githubusercontent.com/3792408/206839283-f364012b-9075-4d4c-ac62-861bcfe41121.png)
