### PR TITLE
Fix ubuntu arm64 binary getting published to last version

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -249,6 +249,9 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Get Latest Version
+        run: git pull
+
       - name: Install dependencies macOS
         if: runner.os == 'macOS'
         env:


### PR DESCRIPTION
The first job in this workflow bumps the version number, but the ubuntu arm64 job did not do a 'git pull' to get those changes. This made it publish the binary files to the last release instead of the current one.

This change just adds a 'git pull' like the other jobs in the workflow use to pick up the correct version,