### PR TITLE
Fix Maven read timeouts in Android release workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -19,6 +19,7 @@ jobs:
       JOBS: 8
       BUILDTYPE: Release
       IS_LOCAL_DEVELOPMENT: false
+      # Avoids read timeouts, see https://github.com/maplibre/maplibre-gl-native/pull/591
       MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
     steps:
 

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -19,6 +19,7 @@ jobs:
       JOBS: 8
       BUILDTYPE: Release
       IS_LOCAL_DEVELOPMENT: false
+      MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
     steps:
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
The android-release.yml workflow keeps timing out when reading from maven, see #585. This seems to be a known problem and one solution seems to be to change the maven connection settings, see https://github.com/actions/runner-images/issues/1499#issuecomment-718396233.