### PR TITLE
[iOS]Use custom gesture to solve the map jump on m1 simulator

### DIFF
--- a/platform/ios/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/platform/ios/src/MGLMapView.mm
@@ -74,7 +74,7 @@
 #include <cstdlib>
 #include <map>
 #include <unordered_set>
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_IPHONE_SIMULATOR & (TARGET_CPU_X86 | TARGET_CPU_X86_64)
 #include <sys/sysctl.h>
 
 // The m1 simulator's gesture's velocity is wrong and here is a workaround to fix it.
@@ -753,7 +753,7 @@ public:
     
     self.anchorRotateOrZoomGesturesToCenterCoordinate = NO;
     
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_IPHONE_SIMULATOR & (TARGET_CPU_X86 | TARGET_CPU_X86_64)
     bool isM1Simulator = processIsTranslated() > 0;
     if (isM1Simulator) {
         _pan = [[MBGLPanGesture alloc] initWithTarget:self action:@selector(handlePanGesture:)];
@@ -769,7 +769,7 @@ public:
     _scrollEnabled = YES;
     _panScrollingMode = MGLPanScrollingModeDefault;
 
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_IPHONE_SIMULATOR & (TARGET_CPU_X86 | TARGET_CPU_X86_64)
     if (isM1Simulator) {
         _pinch = [[MBGLPinchGesture alloc] initWithTarget:self action:@selector(handlePinchGesture:)];
     } else {
@@ -782,7 +782,7 @@ public:
     [self addGestureRecognizer:_pinch];
     _zoomEnabled = YES;
 
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_IPHONE_SIMULATOR & (TARGET_CPU_X86 | TARGET_CPU_X86_64)
     if (isM1Simulator) {
         _rotate = [[MBGLRotationGesture alloc] initWithTarget:self action:@selector(handleRotateGesture:)];
     } else {

--- a/platform/ios/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/platform/ios/src/MGLMapView.mm
@@ -74,6 +74,161 @@
 #include <cstdlib>
 #include <map>
 #include <unordered_set>
+#if TARGET_IPHONE_SIMULATOR
+#include <sys/sysctl.h>
+
+// The m1 simulator's gesture's velocity is wrong and here is a workaround to fix it.
+// These custom gestures will calculate the correct velocity.
+// This may because the system time is incorrect.
+
+@interface MBGLPanGesture : UIPanGestureRecognizer
+@end
+
+@interface MBGLPinchGesture : UIPinchGestureRecognizer
+@end
+
+@interface MBGLRotationGesture : UIRotationGestureRecognizer
+@end
+
+@implementation MBGLPanGesture {
+    bool customVelocity;
+    NSTimeInterval _lastTime;
+    CGPoint _lastTouch;
+    CGPoint __velocity;
+}
+
+- (CGPoint)velocityInView:(nullable UIView *)view {
+    if (customVelocity) {
+        return __velocity;
+    }
+    
+    return [super velocityInView:view];
+}
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    _lastTime = NSProcessInfo.processInfo.systemUptime;
+
+    UITouch *touch = [touches anyObject];
+    _lastTouch = [touch locationInView:self.view];
+    customVelocity = true;
+  
+    [super touchesBegan:touches withEvent:event];
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    if (customVelocity && touches.count) {
+        CFTimeInterval now = NSProcessInfo.processInfo.systemUptime;
+        UITouch *touch = [touches anyObject];
+        CGPoint touchLoc = [touch locationInView:self.view];
+        auto delta = now - _lastTime;
+        if (delta > 0) {
+            __velocity.x = ((touchLoc.x - _lastTouch.x) / delta) * 0.9 + __velocity.x * 0.1;
+            __velocity.y = ((touchLoc.y - _lastTouch.y) / delta) * 0.9 + __velocity.y * 0.1;
+        }
+        _lastTouch = touchLoc;
+        _lastTime = now;
+    }
+    [super touchesMoved:touches withEvent:event];
+
+}
+@end
+
+@implementation MBGLPinchGesture {
+    bool customVelocity;
+    NSTimeInterval _lastTime;
+    CGFloat _lastScale;
+    CGFloat __velocity;
+}
+
+- (CGFloat)velocity {
+    if (customVelocity) {
+        return __velocity;
+    }
+    
+    return [super velocity];
+}
+
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    _lastTime = NSProcessInfo.processInfo.systemUptime;
+    
+    _lastScale = 0;
+    customVelocity = true;
+
+    [super touchesBegan:touches withEvent:event];
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    [super touchesMoved:touches withEvent:event];
+
+    if (customVelocity && touches.count) {
+        CFTimeInterval now = NSProcessInfo.processInfo.systemUptime;
+        CGFloat scale = [super scale];
+        auto delta = now - _lastTime;
+        if (delta > 0) {
+            __velocity = ((scale - _lastScale) / delta) * 0.9 + __velocity * 0.1;
+        }
+        _lastScale = scale;
+        _lastTime = now;
+    }
+}
+@end
+
+@implementation MBGLRotationGesture {
+    bool customVelocity;
+    NSTimeInterval _lastTime;
+    CGFloat _lastRotation;
+    CGFloat __velocity;
+}
+
+- (CGFloat)velocity {
+    if (customVelocity) {
+        return __velocity;
+    }
+    
+    return [super velocity];
+}
+
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    _lastTime = NSProcessInfo.processInfo.systemUptime;
+
+    _lastRotation = 0;
+    customVelocity = true;
+
+    [super touchesBegan:touches withEvent:event];
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    [super touchesMoved:touches withEvent:event];
+
+    if (customVelocity && touches.count) {
+        CFTimeInterval now = NSProcessInfo.processInfo.systemUptime;
+        CGFloat rotation = [super rotation];
+        auto delta = now - _lastTime;
+        if (delta > 0) {
+            __velocity = ((rotation - _lastRotation) / delta) * 0.9 + __velocity * 0.1;
+        }
+        _lastRotation = rotation;
+        _lastTime = now;
+    }
+}
+@end
+
+int processIsTranslated() {
+    int ret = 0;
+    size_t size = sizeof(ret);
+
+    // Call the sysctl and if successful return the result
+    if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) != -1)
+        return ret;
+    // If "sysctl.proc_translated" is not present then must be native
+    if (errno == ENOENT)
+        return 0;
+    return -1;
+}
+
+#endif
 
 class MGLAnnotationContext;
 
@@ -598,19 +753,44 @@ public:
     
     self.anchorRotateOrZoomGesturesToCenterCoordinate = NO;
     
+#if TARGET_IPHONE_SIMULATOR
+    bool isM1Simulator = processIsTranslated() > 0;
+    if (isM1Simulator) {
+        _pan = [[MBGLPanGesture alloc] initWithTarget:self action:@selector(handlePanGesture:)];
+    } else {
+        _pan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePanGesture:)];
+    }
+#else
     _pan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePanGesture:)];
+#endif
     _pan.delegate = self;
     _pan.maximumNumberOfTouches = 1;
     [self addGestureRecognizer:_pan];
     _scrollEnabled = YES;
     _panScrollingMode = MGLPanScrollingModeDefault;
 
+#if TARGET_IPHONE_SIMULATOR
+    if (isM1Simulator) {
+        _pinch = [[MBGLPinchGesture alloc] initWithTarget:self action:@selector(handlePinchGesture:)];
+    } else {
+        _pinch = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(handlePinchGesture:)];
+    }
+#else
     _pinch = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(handlePinchGesture:)];
+#endif
     _pinch.delegate = self;
     [self addGestureRecognizer:_pinch];
     _zoomEnabled = YES;
 
+#if TARGET_IPHONE_SIMULATOR
+    if (isM1Simulator) {
+        _rotate = [[MBGLRotationGesture alloc] initWithTarget:self action:@selector(handleRotateGesture:)];
+    } else {
+        _rotate = [[UIRotationGestureRecognizer alloc] initWithTarget:self action:@selector(handleRotateGesture:)];
+    }
+#else
     _rotate = [[UIRotationGestureRecognizer alloc] initWithTarget:self action:@selector(handleRotateGesture:)];
+#endif
     _rotate.delegate = self;
     [self addGestureRecognizer:_rotate];
     _rotateEnabled = YES;
@@ -1991,7 +2171,6 @@ public:
     else if (pan.state == UIGestureRecognizerStateChanged)
     {
         CGPoint delta = [pan translationInView:pan.view];
-
         MGLMapCamera *toCamera = [self cameraByPanningWithTranslation:delta panGesture:pan];
 
         if ([self _shouldChangeFromCamera:oldCamera toCamera:toCamera])


### PR DESCRIPTION
This Fixes #563

In Grab, our Apps don't use the arm64 version of iOS simulator SDKs for some reason. That means our code architecture is x86_64 and running under the rosetta stone on the m1 simulator. The project setting is:
<img width="769" alt="Screen Shot 2022-12-13 at 16 44 55" src="https://user-images.githubusercontent.com/5135389/207268628-79b27ba6-5bd0-44cf-984b-cbace759412d.png">


But at this condition, the gesture's velocity will become very large or keep zero, and this also can reproduce with Maplibre, you can see the map jump very far when the pan over:


https://user-images.githubusercontent.com/5135389/207269457-4cf955fb-4320-40f3-9719-1b2b8353455c.mp4


The rotate gesture and the pinch gesture have the same problem.


So I create this fix, which is actually a workaround for m1 simulator users, I create custom gestures to calculate velocity and make the map handle correctly.
And this is the final result of this fix:


https://user-images.githubusercontent.com/5135389/207270549-4a233ca0-8da3-42e1-8935-d12ce876e58a.mp4




I know this may not be necessary for most situations.  But it is a must-have fix or workaround for Grab because a lot of developers running their maps in this situation. So please assess whether this PR needs to be merged into Maplibre.



