### PR TITLE
Remove unneeded credentials

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -11,9 +11,6 @@ jobs:
         working-directory: platform/android
     container:
       image: ghcr.io/maplibre/android-ndk-r21b
-      credentials:
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.CR_PAT }}
     env:
       LIBSYSCONFCPUS: 8
       JOBS: 8


### PR DESCRIPTION
For read access to the GitHub container registry, we do not need any credentials like the `CR_PAT` secret which I think stands for "container registry personal access token".

This pull request removes the unneeded credentials from the android-release.yml workflow.
