### PR TITLE
Prepare an Android release

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, Linux]
     defaults:
       run:
         working-directory: platform/android
@@ -16,19 +16,12 @@ jobs:
       JOBS: 8
       BUILDTYPE: Release
       IS_LOCAL_DEVELOPMENT: false
-      # Avoids read timeouts, see https://github.com/maplibre/maplibre-gl-native/pull/591
-      MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
     steps:
 
       - uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0
-
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '11'
 
       - name: Ensure source code revision
         run: scripts/ensure-code-revision.sh        

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -7,6 +7,19 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 ### ✨ Features and improvements
 
 * Add your pull request...
+
+### 🐞 Bug fixes
+
+* Add your pull request...
+
+### ⛵ Dependencies
+
+* Add your pull request...
+
+## 9.6.0 - December 18, 2022
+
+### ✨ Features and improvements
+
 * Add missing header guards ([#543](https://github.com/maplibre/maplibre-gl-native/pull/543))
 * Removing unused versions sdk ([#515](https://github.com/maplibre/maplibre-gl-native/pull/515))
 * (tag: node-v5.0.1-pre.0) Upgrade libs and remove Jetifier ([#218](https://github.com/maplibre/maplibre-gl-native/pull/218))
@@ -26,7 +39,6 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 
 ### 🐞 Bug fixes
 
-* Add your pull request...
 * Fixes potential NaN when calling `NativeMapView::nativeMoveBy` ([#501](https://github.com/maplibre/maplibre-gl-native/pull/501))
 * Fix android ci workflows ([#476](https://github.com/maplibre/maplibre-gl-native/pull/476))
 * Fix typo in geo.cpp ([#412](https://github.com/maplibre/maplibre-gl-native/pull/412))
@@ -37,7 +49,6 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 
 ### ⛵ Dependencies
 
-* Add your pull request...
 * Bump semver from 7.3.7 to 7.3.8 in /platform/android ([#530](https://github.com/maplibre/maplibre-gl-native/pull/530))
 * Bump to JDK 11 in android CI and generate Gradle Wrapper ([#474](https://github.com/maplibre/maplibre-gl-native/pull/474))
 * Bump ejs from 3.1.7 to 3.1.8 in /platform/android ([#470](https://github.com/maplibre/maplibre-gl-native/pull/470))

--- a/platform/android/RELEASE.md
+++ b/platform/android/RELEASE.md
@@ -13,7 +13,7 @@ To make an Android release, do the following:
 
 * Due to maven timeouts, the `android-release.yml` workflows currently needs a self-hosted runner
   * Go to https://github.com/maplibre/maplibre-gl-native/settings/actions/runners
-  * Press "New self-hosted runner
+  * Press "New self-hosted runner"
   * Spin up a self-hosted Linux x64 runner
   * Make sure the runner has the tags `Linux` and `self-hosted`
 

--- a/platform/android/RELEASE.md
+++ b/platform/android/RELEASE.md
@@ -1,0 +1,23 @@
+# Release
+
+To make an Android release, do the following:
+
+* Update `CHANGELOG.md` in a pull request
+  * Add a section title containing the version which should be released, e.g. `## 9.6.0 - December 18, 2022`
+  * Remove the `* Add your pull request...` entries
+  * Add a new `main` section at the top of the changelog
+
+* Once the changelog update pull request was merged, tag the commit:
+  * Create a tag locally, e.g. `git tag -a android-v9.6.0 -m "Release android-v9.6.0"`
+  * You need write access to push the tag, e.g. `git push --atomic origin main android-v9.6.0`
+
+* Due to maven timeouts, the `android-release.yml` workflows currently needs a self-hosted runner
+  * Go to https://github.com/maplibre/maplibre-gl-native/settings/actions/runners
+  * Press "New self-hosted runner
+  * Spin up a self-hosted Linux x64 runner
+  * Make sure the runner has the tags `Linux` and `self-hosted`
+
+* Once the tag is pushed, you can run the `release-android.yml` workflow
+  * Go to https://github.com/maplibre/maplibre-gl-native/actions
+  * Press `android-release`
+  * Press `Run workflow` from the `main` branch


### PR DESCRIPTION
Adds some instructions about how to make an android release, updates the changelog in preparation for android-v9.6.0, and adjusts the android-release.yml workflow to something which probably should create a release.

Making a release like proposed here only works if we temprarily revert the gradle update, see #614 