### PR TITLE
[Android] Catch exception onMove

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -10,7 +10,7 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 
 ### 🐞 Bug fixes
 
-* Add your pull request...
+* Catches NaN for onMove event
 
 ### ⛵ Dependencies
 

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -10,7 +10,7 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 
 ### 🐞 Bug fixes
 
-* Catches NaN for onMove event
+* Catches NaN for onMove event ([621](https://github.com/maplibre/maplibre-gl-native/pull/621))
 
 ### ⛵ Dependencies
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -480,7 +480,7 @@ final class MapGestureDetector {
     @Override
     public boolean onMove(@NonNull MoveGestureDetector detector, float distanceX, float distanceY) {
       // first move event is often delivered with no displacement
-      if (distanceX != 0 || distanceY != 0) {
+      if (!Float.isNaN(distanceX) && !Float.isNaN(distanceY) && (distanceX != 0 || distanceY != 0)) {
         // dispatching camera start event only when the movement actually occurred
         cameraChangeDispatcher.onCameraMoveStarted(CameraChangeDispatcher.REASON_API_GESTURE);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -41,6 +41,8 @@ import static com.mapbox.mapboxsdk.constants.MapboxConstants.ZOOM_RATE;
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveStartedListener.REASON_API_GESTURE;
 import static com.mapbox.mapboxsdk.utils.MathUtils.normalize;
 
+import timber.log.Timber;
+
 /**
  * Manages gestures events on a MapView.
  */
@@ -493,6 +495,8 @@ final class MapGestureDetector {
         transform.moveBy(-distanceX, -distanceY, 0 /*no duration*/);
 
         notifyOnMoveListeners(detector);
+      } else {
+        Timber.e("Could not call onMove with parameters %s,%s", distanceX, distanceY);
       }
       return true;
     }


### PR DESCRIPTION
This is an exception that showed up in our Crashlytics log.

```
Fatal Exception: java.lang.Error: latitude must not be NaN
       at com.mapbox.mapboxsdk.maps.NativeMapView.nativeMoveBy(NativeMapView.java)
       at com.mapbox.mapboxsdk.maps.NativeMapView.moveBy(NativeMapView.java:248)
       at com.mapbox.mapboxsdk.maps.Transform.moveBy(Transform.java:314)
       at com.mapbox.mapboxsdk.maps.MapGestureDetector$MoveGestureListener.onMove(MapGestureDetector.java:493)
       at com.mapbox.android.gestures.MoveGestureDetector.analyzeMovement(MoveGestureDetector.java:158)
       at com.mapbox.android.gestures.MultiFingerGesture.analyzeEvent(MultiFingerGesture.java:106)
       at com.mapbox.android.gestures.ProgressiveGesture.analyzeEvent(ProgressiveGesture.java:55)
       at com.mapbox.android.gestures.MoveGestureDetector.analyzeEvent(MoveGestureDetector.java:141)
       at com.mapbox.android.gestures.BaseGesture.analyze(BaseGesture.java:61)
       at com.mapbox.android.gestures.BaseGesture.onTouchEvent(BaseGesture.java:39)
       at com.mapbox.android.gestures.AndroidGesturesManager.onTouchEvent(AndroidGesturesManager.java:193)
       at com.mapbox.mapboxsdk.maps.MapGestureDetector.onTouchEvent(MapGestureDetector.java:218)
       at com.mapbox.mapboxsdk.maps.MapView.onTouchEvent(MapView.java:523)
```