### PR TITLE
Fix memory access violation exception in vector_tile_data.cpp

### DIFF
--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/tile/vector_tile_data.hpp>
 #include <mbgl/util/constants.hpp>
+#include <mbgl/util/logging.hpp>
 
 namespace mbgl {
 
@@ -40,7 +41,15 @@ FeatureIdentifier VectorTileFeature::getID() const {
 const GeometryCollection& VectorTileFeature::getGeometries() const {
     if (!lines) {
         const auto scale = static_cast<float>(util::EXTENT) / feature.getExtent();
-        lines = feature.getGeometries<GeometryCollection>(scale);
+
+        try {
+            lines = feature.getGeometries<GeometryCollection>(scale);
+        }
+        catch(const std::runtime_error& ex) {
+            Log::Error(Event::ParseTile, "Could not get geometries: %s", ex.what());
+            lines = GeometryCollection();
+        }
+
         if (feature.getVersion() < 2 && feature.getType() == mapbox::vector_tile::GeomType::POLYGON) {
             lines = fixupPolygons(*lines);
         }


### PR DESCRIPTION
I was having some random crashes when browsing my map, then I discovered an unhandled exception when calling `mapbox::vector_tile::feature::getGeometries<T>(float scale)` in `VectorTileFeature::getGeometries()`. So I propose a very basic handling of this situation. I don't know if this is the best solution, but no more crashes since then.