### PR TITLE
Redirect users to GitHub Discussions and Slack

### DIFF
--- a/.github/ISSUE_TEMPLATE/.config.yml
+++ b/.github/ISSUE_TEMPLATE/.config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "🙏 Q&A - GitHub Discussions"
+    url: https://github.com/maplibre/maplibre-gl-native/discussions/categories/q-a
+    about: If you have a question about using MapLibre GL Native
+  - name: "💬 Chat with us on Slack"
+    url: https://slack.openstreetmap.us/
+    about: "Join #maplibre-native on the Open Street Map Slack"
+


### PR DESCRIPTION
To make users aware of the fact that questions can be asked on GitHub Discussions and Slack. Looks as follows:

![image](https://user-images.githubusercontent.com/649392/210614386-4d29b8dd-6388-483f-89a1-9448586abd30.png)
