### PR TITLE
Add fix for running jazzy on M1/ARM

### DIFF
--- a/platform/ios/platform/ios/scripts/document.sh
+++ b/platform/ios/platform/ios/scripts/document.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+source ~/.bashrc
+
 function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
 function finish { >&2 echo -en "\033[0m"; }
 trap finish EXIT

--- a/platform/ios/platform/ios/scripts/install-packaging-dependencies.sh
+++ b/platform/ios/platform/ios/scripts/install-packaging-dependencies.sh
@@ -21,6 +21,11 @@ else
     echo "Found awscli"
 fi
 
+if [[ "${CILAUNCH}" == true ]]; then
+    sudo="sudo"
+else
+    sudo=""
+fi
 
 ##
 ## jazzy
@@ -28,11 +33,7 @@ fi
 if [[ -z `which jazzy` || $(jazzy -v) != "jazzy version: ${JAZZY_VERSION}" ]]; then
     step "Installing jazzy…"
 
-    if [[ "${CILAUNCH}" == true ]]; then
-        sudo gem install jazzy -v $JAZZY_VERSION --no-document
-    else
-        gem install jazzy -v $JAZZY_VERSION --no-document
-    fi
+    $sudo gem install jazzy -v $JAZZY_VERSION --no-document
 
     if [ -z `which jazzy` ]; then
         echo "Unable to install jazzy ($JAZZY_VERSION). See https://github.com/mapbox/mapbox-gl-native-ios/blob/master/platform/ios/INSTALL.md"
@@ -40,6 +41,12 @@ if [[ -z `which jazzy` || $(jazzy -v) != "jazzy version: ${JAZZY_VERSION}" ]]; t
     fi
 else
     echo "Found jazzy (${JAZZY_VERSION})"
+fi
+
+# fix for jazzy on M1/ARM https://github.com/realm/jazzy/issues/1259
+if [[ $(uname -p) == 'arm' ]]; then
+    step "Installing ffi, to run jazzy on M1/ARM chip…"
+    $sudo gem install --user-install ffi -- --enable-libffi-alloc
 fi
 
 step "Finished installing packaging dependencies"

--- a/platform/ios/platform/ios/scripts/install-packaging-dependencies.sh
+++ b/platform/ios/platform/ios/scripts/install-packaging-dependencies.sh
@@ -21,32 +21,4 @@ else
     echo "Found awscli"
 fi
 
-if [[ "${CILAUNCH}" == true ]]; then
-    sudo="sudo"
-else
-    sudo=""
-fi
-
-##
-## jazzy
-##
-if [[ -z `which jazzy` || $(jazzy -v) != "jazzy version: ${JAZZY_VERSION}" ]]; then
-    step "Installing jazzy…"
-
-    $sudo gem install jazzy -v $JAZZY_VERSION --no-document
-
-    if [ -z `which jazzy` ]; then
-        echo "Unable to install jazzy ($JAZZY_VERSION). See https://github.com/mapbox/mapbox-gl-native-ios/blob/master/platform/ios/INSTALL.md"
-        exit 1
-    fi
-else
-    echo "Found jazzy (${JAZZY_VERSION})"
-fi
-
-# fix for jazzy on M1/ARM https://github.com/realm/jazzy/issues/1259
-if [[ $(uname -p) == 'arm' ]]; then
-    step "Installing ffi, to run jazzy on M1/ARM chip…"
-    $sudo gem install --user-install ffi -- --enable-libffi-alloc
-fi
-
 step "Finished installing packaging dependencies"


### PR DESCRIPTION
Ran into an issue when running the GitHub action for the iOS release: https://github.com/maplibre/maplibre-gl-native/actions/runs/3848364221/jobs/6556050541

It is a known problem that is caused by running jazzy on M1/ARM chip:

- https://github.com/realm/jazzy/issues/1259
- https://github.com/ffi/ffi/issues/864