### PR TITLE
[qt] Fix QThreadStorage cast

### DIFF
--- a/platform/qt/src/mbgl/thread_local.cpp
+++ b/platform/qt/src/mbgl/thread_local.cpp
@@ -16,7 +16,7 @@ using StorageType = QThreadStorage<std::array<void*, 1>>;
 ThreadLocalBase::ThreadLocalBase() {
     static_assert(sizeof(storage) >= sizeof(StorageType), "storage is too small");
     static_assert(alignof(decltype(storage)) % alignof(StorageType) == 0, "storage is incorrectly aligned");
-    new (&reinterpret_cast<StorageType&>(storage)) QThreadStorage<void*>();
+    new (&reinterpret_cast<StorageType&>(storage)) QThreadStorage<std::array<void*, 1>>();
 }
 
 ThreadLocalBase::~ThreadLocalBase() {


### PR DESCRIPTION
Fix `QThreadStorage` cast. This fixes compilation issues in some setups.