### PR TITLE
[qt] Force enable moc for Qt6

### DIFF
--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -134,6 +134,9 @@ include(GNUInstallDirs)
 include(${PROJECT_SOURCE_DIR}/vendor/nunicode.cmake)
 
 set_property(TARGET mbgl-core PROPERTY AUTOMOC ON)
+if (Qt6_FOUND AND COMMAND qt_enable_autogen_tool)
+    qt_enable_autogen_tool(mbgl-core "moc" ON)
+endif()
 
 target_link_libraries(
     mbgl-core
@@ -201,6 +204,9 @@ set_target_properties(
     SOVERSION ${MBGL_QT_VERSION_COMPATIBILITY}
     PUBLIC_HEADER "${qmaplibregl_headers}"
 )
+if (Qt6_FOUND AND COMMAND qt_enable_autogen_tool)
+    qt_enable_autogen_tool(qmaplibregl "moc" ON)
+endif()
 if (APPLE AND NOT MBGL_QT_STATIC AND NOT MBGL_QT_INSIDE_PLUGIN)
     set_target_properties(
         qmaplibregl PROPERTIES


### PR DESCRIPTION
When I try to build this repo as part of Qt distribution the `moc` tool does not seem to be enabled and needs to be forced. Not 100 % sure this is needed so keeping draft for now to allow more testing.