### PR TITLE
Fix issue with iOS network logging

### DIFF
--- a/platform/ios/platform/darwin/src/MGLLoggingConfiguration.mm
+++ b/platform/ios/platform/darwin/src/MGLLoggingConfiguration.mm
@@ -76,6 +76,10 @@ public:
     
 }
 
+- (void)logCallingFunction:(const char *)callingFunction functionLine:(NSUInteger)functionLine messageType:(MGLLoggingLevel)type message:(NSString *)message {
+    _handler(type, @(callingFunction), functionLine, message);
+}
+
 - (MGLLoggingBlockHandler)defaultBlockHandler {
     MGLLoggingBlockHandler mapboxHandler = ^(MGLLoggingLevel level, NSString *fileName, NSUInteger line, NSString *message) {
         

--- a/platform/ios/platform/darwin/src/MGLLoggingConfiguration_Private.h
+++ b/platform/ios/platform/darwin/src/MGLLoggingConfiguration_Private.h
@@ -22,14 +22,17 @@ NS_INLINE NSString *MGLStringFromNSEdgeInsets(NSEdgeInsets insets) {
 
 #if MGL_LOGGING_ENABLE_DEBUG
     #define MGLLogDebug(message, ...) MGLLogWithType(MGLLoggingLevelDebug, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
+    #define MGLLogDebugMessage(message) MGLLogWithTypeMessage(MGLLoggingLevelDebug, __PRETTY_FUNCTION__, __LINE__, message)
 #else
     #define MGLLogDebug(...)
+    #define MGLLogDebugMessage(...)
 #endif
 
 #define MGLLogInfo(message, ...)     MGLLogWithType(MGLLoggingLevelInfo, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
 #define MGLLogWarning(message, ...)  MGLLogWithType(MGLLoggingLevelWarning, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
 #define MGLLogError(message, ...)    MGLLogWithType(MGLLoggingLevelError, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
 #define MGLLogFault(message, ...)    MGLLogWithType(MGLLoggingLevelFault, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
+#define MGLLogErrorMessage(message)  MGLLogWithTypeMessage(MGLLoggingLevelError, __PRETTY_FUNCTION__, __LINE__, message)
 
 #endif
 
@@ -59,9 +62,18 @@ NS_INLINE NSString *MGLStringFromNSEdgeInsets(NSEdgeInsets insets) {
     } \
 }
 
+#define MGLLogWithTypeMessage(type, function, line, message) \
+{ \
+    if ([MGLLoggingConfiguration sharedConfiguration].loggingLevel != MGLLoggingLevelNone && type <= [MGLLoggingConfiguration sharedConfiguration].loggingLevel) \
+    { \
+        [[MGLLoggingConfiguration sharedConfiguration] logCallingFunction:function functionLine:line messageType:type message:(message)]; \
+    } \
+}
+
 @interface MGLLoggingConfiguration (Private)
 
 - (void)logCallingFunction:(const char *)callingFunction functionLine:(NSUInteger)functionLine messageType:(MGLLoggingLevel)type format:(id)messageFormat, ...;
+- (void)logCallingFunction:(const char *)callingFunction functionLine:(NSUInteger)functionLine messageType:(MGLLoggingLevel)type message:(NSString *)message;
 
 @end
 #endif

--- a/platform/ios/platform/darwin/src/MGLNetworkConfiguration.mm
+++ b/platform/ios/platform/darwin/src/MGLNetworkConfiguration.mm
@@ -122,11 +122,11 @@ NSString * const kMGLDownloadPerformanceEvent = @"mobile.performance_trace";
 }
 
 - (void)debugLog:(NSString *)message {
-    MGLLogDebug(message);
+    MGLLogDebugMessage(message)
 }
 
 - (void)errorLog:(NSString *)message {
-    MGLLogError(message);
+    MGLLogErrorMessage(message)
 }
 
 #pragma mark - Event management


### PR DESCRIPTION
A change I had made a while back which integrated networking errors into the logging stack (which was previously just a stub) ended up creating an error. Ultimately the logs were never format strings and were just NSStrings instead but they were being put through a variadic function. This was not a problem _unless_ the string going through had a format in it.

Unfortunately it's very possible for that to occur, specifically if there is a URL that has a space in it which ends up as "%20" which end up being picked up as a format. va_list then assumes that it's a format string and then puts in some kind of garbage information into those parts of the string. This means the URL itself can be completely garbled, often appearing to have random UTF characters (seemingly usually an asian language) and also creates a non-contiguous UTF-8 string which can cause some even greater issues depending on what you're doing with the string.

There is no way to do something like check if there are actual additional arguments provided in a variadic function. I also didn't want to do anything like scan the string itself or sanitize it. So it seems like the best thing to do is to just create a specific pathway for those logs that doesn't use variadic arguments. This ensures the log is still accurate and can't contain mangled information.