### PR TITLE
MapLibre GL Core Build or Pull Request

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -2,8 +2,9 @@ name: core-build
 
 on:
   workflow_dispatch:
-  push:
   pull_request:
+    branches:
+      - main
     paths:
       - "src/**"
       - "include/**"

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -3,8 +3,6 @@ name: core-build
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     paths:
       - "src/**"
       - "include/**"

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -2,6 +2,7 @@ name: core-build
 
 on:
   workflow_dispatch:
+  push:
   pull_request:
     paths:
       - "src/**"

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -1,0 +1,55 @@
+name: core-build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "include/**"
+      - "workflows/core-ci.yml"
+      - "CMakeLists.txt"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # INFO: We are cancelling the concurrency group if the change is on PR. For workflow dispatch, this will not work.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Get ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ env.cache-name }}-${{ runner.os }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}-${{ github.head_ref }}
+
+      - name: Get latest CMake and Ninja
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: 3.24.1
+          ninjaVersion: latest
+
+      - name: Clear ccache
+        run: ccache --clear
+
+      - name: Save and restore ccache keys
+        uses: actions/cache@v3
+        env:
+          cache-name: ccache-maplibre-core
+        with:
+          path: ~/.ccache
+          key: ${{ env.cache-name }}-${{ runner.os }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}-${{ github.head_ref }}
+          # INFO: No fallback restore. Only restoring keys that have the same github reference. Rerunning the same workflow
+          # will be faster. New workflow invocation with different code, sha1, or head will not be.
+
+      - name: Build Maplibre GL Core
+        run: |
+          cmake --version
+          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DMBGL_WITH_CORE_ONLY=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMBGL_WITH_COVERAGE=ON


### PR DESCRIPTION
Added a simple Github Workflow that will be triggered if any MapLibre GL Core path is changed. It will ignore all paths for any platform specific code.

test: Have tested with my local fork for include and src directory.

Next change is to deduce how we can export sources and binaries from this build that Android build can use. Or find a way for Android to rely on core build.