### PR TITLE
Avoid implicit casts and make code more portable

### DIFF
--- a/benchmark/api/query.benchmark.cpp
+++ b/benchmark/api/query.benchmark.cpp
@@ -23,7 +23,7 @@ public:
         map.getStyle().loadJSON(util::read_file("benchmark/fixtures/api/style.json"));
         map.jumpTo(CameraOptions().withCenter(LatLng { 40.726989, -73.992857 }).withZoom(15.0)); // Manhattan
         map.getStyle().addImage(std::make_unique<style::Image>("test-icon",
-            decodeImage(util::read_file("benchmark/fixtures/api/default_marker.png")), 1.0));
+            decodeImage(util::read_file("benchmark/fixtures/api/default_marker.png")), 1.0f));
 
         frontend.render(map);
     }

--- a/benchmark/api/render.benchmark.cpp
+++ b/benchmark/api/render.benchmark.cpp
@@ -39,7 +39,7 @@ void prepare(Map& map, optional<std::string> json = nullopt) {
     map.jumpTo(CameraOptions().withCenter(LatLng { 40.726989, -73.992857 }).withZoom(15.0)); // Manhattan
 
     auto image = decodeImage(util::read_file("benchmark/fixtures/api/default_marker.png"));
-    map.getStyle().addImage(std::make_unique<style::Image>("test-icon", std::move(image), 1.0));
+    map.getStyle().addImage(std::make_unique<style::Image>("test-icon", std::move(image), 1.0f));
 }
 
 void prepare_map2(Map& map, optional<std::string> json = nullopt) {
@@ -47,7 +47,7 @@ void prepare_map2(Map& map, optional<std::string> json = nullopt) {
     map.jumpTo(CameraOptions().withCenter(LatLng{41.379800, 2.176810}).withZoom(15.0)); // Barcelona
 
     auto image = decodeImage(util::read_file("benchmark/fixtures/api/default_marker.png"));
-    map.getStyle().addImage(std::make_unique<style::Image>("test-icon", std::move(image), 1.0));
+    map.getStyle().addImage(std::make_unique<style::Image>("test-icon", std::move(image), 1.0f));
 }
 
 } // end namespace

--- a/benchmark/util/dtoa.benchmark.cpp
+++ b/benchmark/util/dtoa.benchmark.cpp
@@ -28,20 +28,20 @@ static void Util_dtoa(::benchmark::State& state) {
 
 static void Util_standardDtoa(::benchmark::State& state) {
     while (state.KeepRunning()) {
-        std::to_string(0.);
-        std::to_string(M_E);
-        std::to_string(M_LOG2E);
-        std::to_string(M_LOG10E);
-        std::to_string(M_LN2);
-        std::to_string(M_LN10);
-        std::to_string(M_PI);
-        std::to_string(M_PI_2);
-        std::to_string(M_PI_4);
-        std::to_string(M_1_PI);
-        std::to_string(M_2_PI);
-        std::to_string(M_2_SQRTPI);
-        std::to_string(M_SQRT2);
-        std::to_string(M_SQRT1_2);
+        std::ignore = std::to_string(0.);
+        std::ignore = std::to_string(M_E);
+        std::ignore = std::to_string(M_LOG2E);
+        std::ignore = std::to_string(M_LOG10E);
+        std::ignore = std::to_string(M_LN2);
+        std::ignore = std::to_string(M_LN10);
+        std::ignore = std::to_string(M_PI);
+        std::ignore = std::to_string(M_PI_2);
+        std::ignore = std::to_string(M_PI_4);
+        std::ignore = std::to_string(M_1_PI);
+        std::ignore = std::to_string(M_2_PI);
+        std::ignore = std::to_string(M_2_SQRTPI);
+        std::ignore = std::to_string(M_SQRT2);
+        std::ignore = std::to_string(M_SQRT1_2);
     }
 }
 
@@ -54,8 +54,8 @@ static void Util_dtoaLimits(::benchmark::State& state) {
 
 static void Util_standardDtoaLimits(::benchmark::State& state) {
     while (state.KeepRunning()) {
-        std::to_string(DBL_MIN);
-        std::to_string(DBL_MAX);
+        std::ignore = std::to_string(DBL_MIN);
+        std::ignore = std::to_string(DBL_MAX);
     }
 }
 

--- a/bin/offline.cpp
+++ b/bin/offline.cpp
@@ -144,7 +144,7 @@ int main(int argc, char *argv[]) {
             try {
                 std::string json = readFile(geometryValue.Get());
                 auto geometry = parseGeometry(json);
-                return OfflineRegionDefinition{ OfflineGeometryRegionDefinition(style, geometry, minZoom, maxZoom, pixelRatio, includeIdeographs) };
+                return OfflineRegionDefinition{ OfflineGeometryRegionDefinition(style, geometry, minZoom, maxZoom, static_cast<float>(pixelRatio), includeIdeographs) };
             } catch(const std::runtime_error& e) {
                 std::cerr << "Could not parse geojson file " << geometryValue.Get() << ": " << e.what() << std::endl;
                 exit(1);
@@ -156,7 +156,7 @@ int main(int argc, char *argv[]) {
             const double south = southValue ? args::get(southValue) : 38.1;
             const double east = eastValue ? args::get(eastValue) : -121.7;
             LatLngBounds boundingBox = LatLngBounds::hull(LatLng(north, west), LatLng(south, east));
-            return OfflineRegionDefinition{ OfflineTilePyramidRegionDefinition(style, boundingBox, minZoom, maxZoom, pixelRatio, includeIdeographs) };
+            return OfflineRegionDefinition{ OfflineTilePyramidRegionDefinition(style, boundingBox, minZoom, maxZoom, static_cast<float>(pixelRatio), includeIdeographs) };
         }
     }();
 

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -78,9 +78,9 @@ int main(int argc, char *argv[]) {
 
     util::RunLoop loop;
 
-    HeadlessFrontend frontend({ width, height }, pixelRatio);
+    HeadlessFrontend frontend({ width, height }, static_cast<float>(pixelRatio));
     Map map(frontend, MapObserver::nullObserver(),
-            MapOptions().withMapMode(MapMode::Static).withSize(frontend.getSize()).withPixelRatio(pixelRatio),
+            MapOptions().withMapMode(MapMode::Static).withSize(frontend.getSize()).withPixelRatio(static_cast<float>(pixelRatio)),
             ResourceOptions().withCachePath(cache_file).withAssetPath(asset_root).withApiKey(apikey).withTileServerOptions(mapTilerConfiguration));
 
     if (style.find("://") == std::string::npos) {

--- a/expression-test/expression_test_parser.cpp
+++ b/expression-test/expression_test_parser.cpp
@@ -29,7 +29,7 @@ void writeJSON(rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer, const V
         [&] (bool b) { writer.Bool(b); },
         [&] (uint64_t u) { writer.Uint64(u); },
         [&] (int64_t i) { writer.Int64(i); },
-        [&] (double d) { d == std::floor(d) ? writer.Int64(d) : writer.Double(d); },
+        [&] (double d) { d == std::floor(d) ? writer.Int64(static_cast<int64_t>(d)) : writer.Double(d); },
         [&] (const std::string& s) { writer.String(s); },
         [&] (const std::vector<Value>& arr) {
             writer.StartArray();
@@ -217,7 +217,7 @@ void parsePropertySpec(const JSValue& value, TestData& data) {
 
     if (propertySpec.HasMember("length")) {
         assert(propertySpec["length"].IsNumber());
-        spec.length = propertySpec["length"].GetDouble();
+        spec.length = static_cast<size_t>(propertySpec["length"].GetDouble());
     }
 
     if (propertySpec.HasMember("property-type")) {
@@ -246,7 +246,7 @@ bool parseInputs(const JSValue& inputsValue, TestData& data) {
         const auto& evaluationContext = input[0].GetObject();
         if (evaluationContext.HasMember("zoom")) {
             assert(evaluationContext["zoom"].IsNumber());
-            zoom = evaluationContext["zoom"].GetDouble();
+            zoom = static_cast<float>(evaluationContext["zoom"].GetDouble());
         }
 
         // Parse heatmap density

--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -58,6 +58,11 @@ inline std::string toString(unsigned long long t) {
     return toString(static_cast<uint64_t>(t));
 }
 
+template <typename = std::enable_if<!std::is_same<int64_t, long>::value>>
+inline std::string toString(long t) {
+    return toString(static_cast<int64_t>(t));
+}
+
 template <typename = std::enable_if<!std::is_same<int64_t, long long>::value>>
 inline std::string toString(long long t) {
     return toString(static_cast<int64_t>(t));

--- a/platform/default/src/mbgl/storage/http_file_source.cpp
+++ b/platform/default/src/mbgl/storage/http_file_source.cpp
@@ -194,18 +194,18 @@ int HTTPFileSource::Impl::handleSocket(CURL * /* handle */, curl_socket_t s, int
     switch (action) {
     case CURL_POLL_IN: {
         using namespace std::placeholders;
-        util::RunLoop::Get()->addWatch(s, util::RunLoop::Event::Read,
+        util::RunLoop::Get()->addWatch(static_cast<int>(s), util::RunLoop::Event::Read,
                 std::bind(&Impl::perform, context, _1, _2));
         break;
     }
     case CURL_POLL_OUT: {
         using namespace std::placeholders;
-        util::RunLoop::Get()->addWatch(s, util::RunLoop::Event::Write,
+        util::RunLoop::Get()->addWatch(static_cast<int>(s), util::RunLoop::Event::Write,
                 std::bind(&Impl::perform, context, _1, _2));
         break;
     }
     case CURL_POLL_REMOVE:
-        util::RunLoop::Get()->removeWatch(s);
+        util::RunLoop::Get()->removeWatch(static_cast<int>(s));
         break;
     default:
         throw std::runtime_error("Unhandled CURL socket action");

--- a/platform/default/src/mbgl/util/jpeg_reader.cpp
+++ b/platform/default/src/mbgl/util/jpeg_reader.cpp
@@ -121,7 +121,7 @@ PremultipliedImage decodeJPEG(const uint8_t* data, size_t size) {
     PremultipliedImage image({ static_cast<uint32_t>(width), static_cast<uint32_t>(height) });
     uint8_t* dst = image.data.get();
 
-    JSAMPARRAY buffer = (*cinfo.mem->alloc_sarray)(reinterpret_cast<j_common_ptr>(&cinfo), JPOOL_IMAGE, rowStride, 1);
+    JSAMPARRAY buffer = (*cinfo.mem->alloc_sarray)(reinterpret_cast<j_common_ptr>(&cinfo), JPOOL_IMAGE, static_cast<JDIMENSION>(rowStride), 1);
 
     while (cinfo.output_scanline < cinfo.output_height) {
         jpeg_read_scanlines(&cinfo, buffer, 1);

--- a/platform/default/src/mbgl/util/png_reader.cpp
+++ b/platform/default/src/mbgl/util/png_reader.cpp
@@ -18,7 +18,7 @@ static std::string sprintf(const char *msg, Args... args) {
     return std::string(res, len);
 }
 
-const static bool png_version_check __attribute__((unused)) = []() {
+const static bool png_version_check [[maybe_unused]] = []() {
     const png_uint_32 version = png_access_version_number();
     if (version != PNG_LIBPNG_VER) {
         throw std::runtime_error(sprintf<96>(

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -283,7 +283,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
             case GLFW_KEY_S:
                 if (view->changeStyleCallback) view->changeStyleCallback();
                 break;
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
         case GLFW_KEY_B: {
             auto debug = view->map->getDebug();
             if (debug & mbgl::MapDebugOptions::StencilClip) {
@@ -679,7 +679,7 @@ void GLFWView::updateAnimatedAnnotations() {
 
 void GLFWView::cycleDebugOptions() {
     auto debug = map->getDebug();
-#if not MBGL_USE_GLES2
+#if !MBGL_USE_GLES2
     if (debug & mbgl::MapDebugOptions::StencilClip)
         debug = mbgl::MapDebugOptions::NoDebug;
     else if (debug & mbgl::MapDebugOptions::Overdraw)

--- a/platform/node/src/node_conversion.hpp
+++ b/platform/node/src/node_conversion.hpp
@@ -39,7 +39,7 @@ public:
         Nan::EscapableHandleScope scope;
         // const_cast because v8::Local<T>::As is not marked const until node v8.0
         v8::Local<v8::Array> array = const_cast<v8::Local<v8::Value>&>(value).As<v8::Array>();
-        return scope.Escape(Nan::Get(array, i).ToLocalChecked());
+        return scope.Escape(Nan::Get(array, static_cast<uint32_t>(i)).ToLocalChecked());
     }
 
     static bool isObject(const v8::Local<v8::Value>& value) {

--- a/platform/node/src/node_expression.cpp
+++ b/platform/node/src/node_expression.cpp
@@ -79,9 +79,7 @@ void NodeExpression::Parse(const Nan::FunctionCallbackInfo<v8::Value>& info) {
 
     auto success = [&cons, &info](std::unique_ptr<Expression> result) {
         auto nodeExpr = new NodeExpression(std::move(result));
-        const int argc = 0;
-        v8::Local<v8::Value> argv[0] = {};
-        auto wrapped = Nan::NewInstance(cons, argc, argv).ToLocalChecked();
+        auto wrapped = Nan::NewInstance(cons).ToLocalChecked();
         nodeExpr->Wrap(wrapped);
         info.GetReturnValue().Set(wrapped);
     };
@@ -243,7 +241,7 @@ void NodeExpression::Evaluate(const Nan::FunctionCallbackInfo<v8::Value>& info) 
 
     mbgl::optional<float> zoom;
     v8::Local<v8::Value> v8zoom = Nan::Get(info[0]->ToObject(context).ToLocalChecked(), Nan::New("zoom").ToLocalChecked()).ToLocalChecked();
-    if (v8zoom->IsNumber()) zoom = Nan::To<double>(v8zoom).FromJust();
+    if (v8zoom->IsNumber()) zoom = static_cast<float>(Nan::To<double>(v8zoom).FromJust());
 
     mbgl::optional<double> heatmapDensity;
     v8::Local<v8::Value> v8heatmapDensity = Nan::Get(info[0]->ToObject(context).ToLocalChecked(), Nan::New("heatmapDensity").ToLocalChecked()).ToLocalChecked();

--- a/platform/node/src/node_feature.cpp
+++ b/platform/node/src/node_feature.cpp
@@ -62,7 +62,7 @@ public:
         Nan::EscapableHandleScope scope;
         v8::Local<v8::Array> result = Nan::New<v8::Array>(vector.size());
         for (std::size_t i = 0; i < vector.size(); ++i) {
-            Nan::Set(result, i, operator()(vector[i]));
+            Nan::Set(result, static_cast<uint32_t>(i), operator()(vector[i]));
         }
         return scope.Escape(result);
     }
@@ -113,7 +113,7 @@ struct ToValue {
         Nan::EscapableHandleScope scope;
         v8::Local<v8::Array> result = Nan::New<v8::Array>();
         for (std::size_t i = 0; i < array.size(); i++) {
-            Nan::Set(result, i, toJS(array[i]));
+            Nan::Set(result, static_cast<uint32_t>(i), toJS(array[i]));
         }
         return scope.Escape(result);
     }

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -32,8 +32,6 @@
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/premultiply.hpp>
 
-#include <unistd.h>
-
 namespace node_mbgl {
 
 struct NodeMap::RenderOptions {
@@ -344,11 +342,11 @@ NodeMap::RenderOptions NodeMap::ParseOptions(v8::Local<v8::Object> obj) {
     }
 
     if (Nan::Has(obj, Nan::New("width").ToLocalChecked()).FromJust()) {
-        options.size.width = Nan::To<int64_t>(Nan::Get(obj, Nan::New("width").ToLocalChecked()).ToLocalChecked()).ToChecked();
+        options.size.width = static_cast<uint32_t>(Nan::To<int64_t>(Nan::Get(obj, Nan::New("width").ToLocalChecked()).ToLocalChecked()).ToChecked());
     }
 
     if (Nan::Has(obj, Nan::New("height").ToLocalChecked()).FromJust()) {
-        options.size.height = Nan::To<int64_t>(Nan::Get(obj, Nan::New("height").ToLocalChecked()).ToLocalChecked()).ToChecked();
+        options.size.height = static_cast<uint32_t>(Nan::To<int64_t>(Nan::Get(obj, Nan::New("height").ToLocalChecked()).ToLocalChecked()).ToChecked());
     }
 
     if (Nan::Has(obj, Nan::New("classes").ToLocalChecked()).FromJust()) {
@@ -852,8 +850,8 @@ void NodeMap::SetLayerZoomRange(const Nan::FunctionCallbackInfo<v8::Value>& info
         return Nan::ThrowTypeError("layer not found");
     }
 
-    layer->setMinZoom(Nan::To<double>(info[1]).ToChecked());
-    layer->setMaxZoom(Nan::To<double>(info[2]).ToChecked());
+    layer->setMinZoom(static_cast<float>(Nan::To<double>(info[1]).ToChecked()));
+    layer->setMaxZoom(static_cast<float>(Nan::To<double>(info[2]).ToChecked()));
 }
 
 void NodeMap::SetLayerProperty(const Nan::FunctionCallbackInfo<v8::Value>& info) {
@@ -1385,7 +1383,7 @@ void NodeMap::QueryRenderedFeatures(const Nan::FunctionCallbackInfo<v8::Value>& 
 
         auto array = Nan::New<v8::Array>();
         for (std::size_t i = 0; i < optional.size(); i++) {
-            Nan::Set(array, i, toJS(optional[i]));
+            Nan::Set(array, static_cast<uint32_t>(i), toJS(optional[i]));
         }
         info.GetReturnValue().Set(array);
     } catch (const std::exception &ex) {
@@ -1397,9 +1395,9 @@ NodeMap::NodeMap(v8::Local<v8::Object> options)
     : pixelRatio([&] {
           Nan::HandleScope scope;
           return Nan::Has(options, Nan::New("ratio").ToLocalChecked()).FromJust()
-                     ? Nan::To<double>(Nan::Get(options, Nan::New("ratio").ToLocalChecked())
-                           .ToLocalChecked()).ToChecked()
-                     : 1.0;
+                     ? static_cast<float>(Nan::To<double>(Nan::Get(options, Nan::New("ratio").ToLocalChecked())
+                           .ToLocalChecked()).ToChecked())
+                     : 1.0f;
       }())
     , mode([&] {
             Nan::HandleScope scope;

--- a/render-test/metadata.hpp
+++ b/render-test/metadata.hpp
@@ -76,11 +76,11 @@ struct MemoryProbe {
     float tolerance;
 
     static std::tuple<bool, float> checkPeak(const MemoryProbe& expected, const MemoryProbe& actual) {
-        return checkValue(expected.peak, actual.peak, actual.tolerance);
+        return checkValue(static_cast<float>(expected.peak), static_cast<float>(actual.peak), actual.tolerance);
     }
 
     static std::tuple<bool, float> checkAllocations(const MemoryProbe& expected, const MemoryProbe& actual) {
-        return checkValue(expected.allocations, actual.allocations, actual.tolerance);
+        return checkValue(static_cast<float>(expected.allocations), static_cast<float>(actual.allocations), actual.tolerance);
     }
 };
 

--- a/render-test/parser.cpp
+++ b/render-test/parser.cpp
@@ -103,7 +103,7 @@ void writeJSON(rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer, const m
                 [&writer](bool b) { writer.Bool(b); },
                 [&writer](uint64_t u) { writer.Uint64(u); },
                 [&writer](int64_t i) { writer.Int64(i); },
-                [&writer](double d) { d == std::floor(d) ? writer.Int64(d) : writer.Double(d); },
+                [&writer](double d) { d == std::floor(d) ? writer.Int64(static_cast<int64_t>(d)) : writer.Double(d); },
                 [&writer](const std::string& s) { writer.String(s); },
                 [&writer](const std::vector<mbgl::Value>& arr) {
                     writer.StartArray();
@@ -929,7 +929,7 @@ TestOperations parseTestOperations(TestMetadata& metadata) {
             std::string path = std::string(operationArray[2].GetString(), operationArray[2].GetStringLength());
             assert(!path.empty());
 
-            float tolerance = operationArray[3].GetDouble();
+            float tolerance = static_cast<float>(operationArray[3].GetDouble());
             mbgl::filesystem::path filePath(path);
 
             bool compressed = false;
@@ -1189,7 +1189,7 @@ TestOperations parseTestOperations(TestMetadata& metadata) {
             }
 
             std::string mark = operationArray[1].GetString();
-            int duration = operationArray[2].GetFloat();
+            int duration = static_cast<int>(operationArray[2].GetFloat());
             mbgl::LatLng startPos, endPos;
             double startZoom, endZoom;
 
@@ -1235,7 +1235,7 @@ TestOperations parseTestOperations(TestMetadata& metadata) {
                     samples.push_back(frameTime);
                 }
 
-                float averageFps = totalTime > 0.0 ? frames / totalTime : 0.0;
+                float averageFps = totalTime > 0.0f ? frames / totalTime : 0.0f;
                 float minFrameTime = 0.0;
 
                 // Use 1% of the longest frames to compute the minimum fps

--- a/render-test/runner.cpp
+++ b/render-test/runner.cpp
@@ -257,13 +257,14 @@ void TestRunner::checkRenderTestResults(mbgl::PremultipliedImage&& actualImage, 
 
             expectedImage = mbgl::decodeImage(*maybeExpectedImage);
 
-            pixels = // implicitly converting from uint64_t
+            pixels = static_cast<double>(
                 mapbox::pixelmatch(actualImage.data.get(),
                                    expectedImage.data.get(),
                                    expectedImage.size.width,
                                    expectedImage.size.height,
                                    imageDiff.data.get(),
-                                   0.1285); // Defined in GL JS
+                                   0.1285) // Defined in GL JS
+            );
 
             metadata.diff = mbgl::encodePNG(imageDiff);
 
@@ -349,7 +350,7 @@ void TestRunner::checkProbingResults(TestMetadata& resultMetadata) {
                 return;
             }
 
-            auto result = checkValue(expected.second.size, actual->second.size, actual->second.tolerance);
+            auto result = checkValue(static_cast<float>(expected.second.size), static_cast<float>(actual->second.size), actual->second.tolerance);
             if (!std::get<bool>(result)) {
                 std::stringstream ss;
                 ss << "File size does not match at probe \"" << expected.first << "\" for file \""
@@ -663,7 +664,7 @@ LatLng getTileCenterCoordinates(const UnwrappedTileID& tileId) {
 }
 
 uint32_t getTileScreenPixelSize(float pixelRatio) {
-    return util::tileSize_D * pixelRatio;
+    return static_cast<uint32_t>(util::tileSize_D * pixelRatio);
 }
 
 uint32_t getImageTileOffset(const std::set<uint32_t>& dims, uint32_t dim, float pixelRatio) {
@@ -757,7 +758,7 @@ void TestRunner::run(TestMetadata& metadata) {
     if (metadata.mapMode == MapMode::Tile) {
         assert(camera.zoom);
         assert(camera.center);
-        auto tileIds = util::tileCover(map.latLngBoundsForCamera(camera), *camera.zoom);
+        auto tileIds = util::tileCover(map.latLngBoundsForCamera(camera), static_cast<uint8_t>(*camera.zoom));
         assert(!tileIds.empty());
         std::set<uint32_t> xDims;
         std::set<uint32_t> yDims;


### PR DESCRIPTION
There are a lot of implicit casts everywhere: from double to float, from double to int, from int to double, etc. This PR changes them to explicit casts as long as they generate warnings like `warning C4244: '=' : conversion from 'double' to 'float', possible loss of data`. Also warnings like `warning C4834: discarding return value of function with 'nodiscard' attribute` are fixed. MSVC won't compile with these warnings.