### PR TITLE
Remove Mapbox from iOS Public Docs

### DIFF
--- a/platform/ios/platform/ios/CHANGELOG.md
+++ b/platform/ios/platform/ios/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog for Mapbox Maps SDK for iOS
+# Changelog for MapLibre GL Native for iOS 
 
 MapLibre welcomes participation and contributions from everyone. Please read [`Contributing Guide`](https://github.com/maplibre/maplibre-gl-native/blob/master/CONTRIBUTING.md) to get started.
 

--- a/platform/ios/platform/ios/docs/pod-README.md
+++ b/platform/ios/platform/ios/docs/pod-README.md
@@ -1,16 +1,16 @@
-# [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/)
+# MapLibre GL Native for iOS
 
-The Mapbox Maps SDK for iOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 9.0 and above using Objective-C, Swift, or Interface Builder. It takes stylesheets that conform to the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://www.mapbox.com/developers/vector-tiles/), and renders them using OpenGL.
+MapLibre GL Native for iOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 9.0 and above using Objective-C, Swift, or Interface Builder. It takes stylesheets that conform to the [MapLibre Style Specification](https://maplibre.org/maplibre-gl-js-docs/style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://docs.mapbox.com/data/tilesets/guides/vector-tiles-standards/), and renders them using OpenGL.
 
-For more information, check out the [Mapbox Maps SDK for iOS homepage](https://www.mapbox.com/ios-sdk/) and the [full changelog](https://github.com/mapbox/mapbox-gl-native-ios/blob/master/platform/ios/CHANGELOG.md) online.
+For more information, check out the [MapLibre GL Native for iOS repository](https://github.com/maplibre/maplibre-gl-native) and the [full changelog](https://github.com/maplibre/maplibre-gl-native/blob/main/platform/ios/platform/ios/CHANGELOG.md) online.
 
 [![](https://raw.githubusercontent.com/mapbox/mapbox-gl-native-ios/master/platform/ios/docs/img/screenshot.png)]()
 
 ## Installation
 
-The Mapbox Maps SDK for iOS may be installed as either a dynamic framework or a static framework. (To reduce the download size, the static framework is omitted from some distributions; you may need to download the full package from the [release page](https://github.com/mapbox/mapbox-gl-native-ios/releases/).)
+MapLibre GL Native for iOS may be installed as either a dynamic framework or a static framework. (To reduce the download size, the static framework is omitted from some distributions; you may need to download the full package from the [release page](https://github.com/mapbox/mapbox-gl-native-ios/releases/).)
 
-Integrating the Mapbox Maps SDK for iOS requires Xcode 8.0 or higher.
+Integrating MapLibre GL Native for iOS requires Xcode 8.0 or higher.
 
 {{DYNAMIC}}
 
@@ -62,8 +62,6 @@ You can alternatively install the SDK as a static framework:
 
 1. In order to show the user’s current location on the map, the SDK must ask for the user’s permission to access Location Services. Go to the Info tab of the project editor. If your application supports iOS 7, set the `NSLocationUsageDescription` key to a message that explains to the user what their location is used for. If your application supports iOS 8 and above, set the `NSLocationAlwaysUsageDescription` and/or `NSLocationWhenInUseUsageDescription` key to this message instead.
 
-1. _(Optional)_ Mapbox Telemetry is a [powerful location analytics platform](https://www.mapbox.com/telemetry/) included in this SDK. By default, anonymized location and usage data is sent to Mapbox whenever the host application causes it to be gathered. This SDK provides users with a way to individually opt out of Mapbox Telemetry. You can also add this opt-out setting to your application’s Settings screen using a Settings bundle. An example Settings.bundle is provided with this SDK; drag it into the Project navigator, checking “Copy items if needed” when prompted. In the project editor, verify that the following change occurred automatically:
-
    - In the General tab, Settings.bundle is listed in the “Copy Bundle Resources” build phase.
 
 ## Usage
@@ -94,6 +92,6 @@ class ViewController: UIViewController {
 }
 ```
 
-Full API documentation is included in this package, within the `documentation` folder. For more details, read “[First steps with the Mapbox Maps SDK for iOS](https://www.mapbox.com/help/first-steps-ios-sdk/)” and consult the [online examples](https://www.mapbox.com/ios-sdk/examples/).
+Full API documentation is included in this package, within the `documentation` folder. 
 
-If you have any questions, please see [our help page](https://www.mapbox.com/help/). We welcome your [bug reports, feature requests, and contributions](https://github.com/mapbox/mapbox-gl-native-ios/issues/).
+We welcome your [bug reports, feature requests, and contributions](https://github.com/maplibre/maplibre-gl-native/issues).

--- a/platform/ios/platform/ios/jazzy.yml
+++ b/platform/ios/platform/ios/jazzy.yml
@@ -1,8 +1,7 @@
-module: Mapbox
-author: Mapbox
+module: MapLibre
+author: MapLibre Contributors
 author_url: https://maplibre.org/
 github_url: https://github.com/maplibre/maplibre-gl-native
-dash_url: https://docs.mapbox.com/ios/docsets/Mapbox.xml
 copyright: '[License](https://github.com/maplibre/maplibre-gl-native/blob/main/platform/ios/LICENSE.md)'
 
 head: |

--- a/platform/ios/platform/ios/scripts/document.sh
+++ b/platform/ios/platform/ios/scripts/document.sh
@@ -48,5 +48,5 @@ jazzy \
     --theme ${THEME} \
     --head "${CUSTOM_HEAD}" \
     --output ${OUTPUT} \
-    --title "Maps SDK for iOS" \
+    --title "MapLibre GL Native for iOS" \
     --module-version ${SHORT_VERSION}

--- a/platform/ios/platform/ios/scripts/document.sh
+++ b/platform/ios/platform/ios/scripts/document.sh
@@ -9,7 +9,8 @@ function finish { >&2 echo -en "\033[0m"; }
 trap finish EXIT
 
 if [ -z `which jazzy` ]; then
-    ./platform/ios/scripts/install-packaging-dependencies.sh
+	echo "jazzy not installed" >&2
+	exit 1
 fi
 
 DEFAULT_THEME="platform/darwin/docs/theme"
@@ -44,7 +45,7 @@ jazzy \
     --module-version ${SHORT_VERSION} \
     --readme ${README} \
     --documentation="platform/{darwin,ios}/docs/guides/*.md" \
-    --root-url https://docs.mapbox.com/ios/api/maps/${RELEASE_VERSION}/ \
+    --root-url https://maplibre.org/maplibre-gl-native/ios/api/ \
     --theme ${THEME} \
     --head "${CUSTOM_HEAD}" \
     --output ${OUTPUT} \

--- a/platform/ios/platform/ios/scripts/release-notes-jazzy.md.ejs
+++ b/platform/ios/platform/ios/scripts/release-notes-jazzy.md.ejs
@@ -1,12 +1,10 @@
-# [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/)
+# MapLibre GL Native for iOS
 
-The Mapbox Maps SDK for iOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 9.0 and above using Objective-C, Swift, or Interface Builder. It takes stylesheets that conform to the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://www.mapbox.com/developers/vector-tiles/), and renders them using OpenGL.
+MapLibre GL Native for iOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 9.0 and above using Objective-C, Swift, or Interface Builder. It takes stylesheets that conform to the [MapLibre Style Specification](https://maplibre.org/maplibre-gl-js-docs/style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://docs.mapbox.com/data/tilesets/guides/vector-tiles-standards/), and renders them using OpenGL.
 
-![Mapbox Maps SDK for iOS screenshots](img/screenshot.png)
+![MapLibre GL Native for iOS screenshots](img/screenshot.png)
 
-For setup information, check out the [Mapbox Maps SDK for iOS homepage](https://www.mapbox.com/ios-sdk/). For detailed usage instructions, read “[First steps with the Mapbox Maps SDK for iOS](https://www.mapbox.com/help/first-steps-ios-sdk/)” and consult the [online examples](https://www.mapbox.com/ios-sdk/examples/).
-
-If you have any questions, please see [our help page](https://www.mapbox.com/help/). We welcome your [bug reports, feature requests, and contributions](https://github.com/mapbox/mapbox-gl-native-ios/issues/).
+We welcome your [bug reports, feature requests, and contributions](https://github.com/maplibre/maplibre-gl-native/issues).
 
 ## Changes in version <%-CURRENTVERSION%>
 
@@ -20,4 +18,4 @@ If you have any questions, please see [our help page](https://www.mapbox.com/hel
 <%-release.changelog%>
 <% }) -%>
 
-See the [full changelog](https://github.com/mapbox/mapbox-gl-native-ios/blob/ios-v<%-CURRENTVERSION%>/platform/ios/CHANGELOG.md) for previous releases.
+See the [full changelog](https://github.com/maplibre/maplibre-gl-native/blob/main/platform/ios/platform/ios/CHANGELOG.md) for previous releases.


### PR DESCRIPTION
Closes #608

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/649392/214039151-7246dad4-2d22-4ee8-8b87-86067c1eb03f.png">

We need to run the iOS GitHub Pages deploy manually after merging.