### PR TITLE
Don't offset views rendered on top of snapshots

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -1161,7 +1161,9 @@ final class NativeMapView implements NativeMap {
         } else {
           Bitmap viewContent = viewCallback.getViewContent();
           if (viewContent != null) {
-            snapshotReadyCallback.onSnapshotReady(BitmapUtils.mergeBitmap(mapContent, viewContent));
+            snapshotReadyCallback.onSnapshotReady(
+                    BitmapUtils.mergeBitmap(mapContent, viewContent, 0f, 0f)
+            );
           }
         }
       }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -1162,7 +1162,7 @@ final class NativeMapView implements NativeMap {
           Bitmap viewContent = viewCallback.getViewContent();
           if (viewContent != null) {
             snapshotReadyCallback.onSnapshotReady(
-                    BitmapUtils.mergeBitmap(mapContent, viewContent, 0f, 0f)
+                    BitmapUtils.mergeBitmaps(mapContent, viewContent)
             );
           }
         }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java
@@ -53,9 +53,23 @@ public class BitmapUtils {
    * @param background The bitmap placed in the background
    * @param foreground The bitmap placed in the foreground
    * @return the merged bitmap
+   * @deprecated {@link #mergeBitmaps(Bitmap, Bitmap)} should be used instead, as it does not
+   * shift the input by 10px to the right and bottom.
    */
+  @Deprecated
   public static Bitmap mergeBitmap(@NonNull Bitmap background, @NonNull Bitmap foreground) {
     return mergeBitmap(background, foreground, 10f, 10f);
+  }
+
+  /**
+   * Create a bitmap from a background and a foreground bitmap.
+   *
+   * @param background The bitmap placed in the background
+   * @param foreground The bitmap placed in the foreground
+   * @return the merged bitmap
+   */
+  public static Bitmap mergeBitmaps(@NonNull Bitmap background, @NonNull Bitmap foreground) {
+    return mergeBitmap(background, foreground, 0f, 0f);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java
@@ -47,14 +47,15 @@ public class BitmapUtils {
   }
 
   /**
-   * Create a bitmap from a background and a foreground bitmap
+   * Create a bitmap from a background and a foreground bitmap. The foreground bitmap
+   * will be shifted 10px to the right and 10px to the bottom relative to the background.
    *
    * @param background The bitmap placed in the background
    * @param foreground The bitmap placed in the foreground
    * @return the merged bitmap
    */
   public static Bitmap mergeBitmap(@NonNull Bitmap background, @NonNull Bitmap foreground) {
-    return mergeBitmap(background, foreground, 0f, 0f);
+    return mergeBitmap(background, foreground, 10f, 10f);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java
@@ -54,7 +54,7 @@ public class BitmapUtils {
    * @return the merged bitmap
    */
   public static Bitmap mergeBitmap(@NonNull Bitmap background, @NonNull Bitmap foreground) {
-    return mergeBitmap(background, foreground, 10f, 10f);
+    return mergeBitmap(background, foreground, 0f, 0f);
   }
 
   /**


### PR DESCRIPTION
This PR fixes view rendered on top of the map during snapshots being offset incorrectly.

For no discernible reason, in https://github.com/mapbox/mapbox-gl-native/issues/9179#issuecomment-308046352, it was introduced that a view that is a child of the map view is rendered 10px to the right, 10px to the bottom of its original position.

This introduces visual glitches already visible in the screenshot linked above. Therefore, this PR removes this offset.

It also fixes any other child views a user may choose to put on a map (the use case I have in mind is custom info windows).


In the following screenshots, bottom is live map, top is snapshot – it is the "Snapshot Activity" in the sample app:

Before | After
---|---
![Screenshot_1674726209](https://user-images.githubusercontent.com/16943720/214804771-28eb8b74-4fee-4122-afef-deca09384a7e.png) | ![Screenshot_1674726117](https://user-images.githubusercontent.com/16943720/214804776-2fc022f0-85ae-46fc-b54a-534d7206223f.png)
