### PR TITLE
Use Dokka instead of Javadoc for Android API docs

### DIFF
--- a/.github/workflows/gh-pages-android-api.yml
+++ b/.github/workflows/gh-pages-android-api.yml
@@ -1,32 +1,24 @@
 name: gh-pages-android-api
 
-on: 
+on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version'     
-        required: true
-        default: '9.5.2'
 
 jobs:
   gh-pages-android-api:
+    defaults:
+      run:
+        working-directory: platform/android
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
 
-      - name: Download javadoc from Maven
-        run: |
-          wget https://repo1.maven.org/maven2/org/maplibre/gl/android-sdk/${{ github.event.inputs.version }}/android-sdk-${{ github.event.inputs.version }}-javadoc.jar -O javadoc.zip
-      
-      - name: Unzip
-        run: |
-          mkdir unzipped/
-          unzip javadoc.zip -d unzipped/
-      
+      - name: Generate documentation
+        run: ./gradlew dokkaHtml
+
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: gh-pages
-          folder: unzipped
+          folder: MapboxGLAndroidSDK/build/dokka/html
           target-folder: android/api/

--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'org.jmailen.kotlinter'
+    id 'org.jetbrains.dokka' version '1.7.20'
 }
 
 apply plugin: 'com.android.library'

--- a/platform/android/MapboxGLAndroidSDK/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDK/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=9.1.0-SNAPSHOT
+VERSION_NAME=9.6.0
 
 # Only build native dependencies for the current ABI
 # See https://code.google.com/p/android/issues/detail?id=221098#c20


### PR DESCRIPTION
Dokka seems way better for Kotlin. Styling is also a lot more modern.

Try it out locally:

```
cd platform/android
./gradlew dokkaHtml
cd MapboxGLAndroidSDK/build/dokka/html/
python -m http.server
```

![image](https://user-images.githubusercontent.com/649392/215526605-c2fadcb7-58b7-4c3d-93ae-e664bc4be4da.png)

I tried playing around with the `sourceLink` which creates link that link to the source code on GitHub, but I couldn't get it to work, maybe because I have an error in my Groovy syntax.

Dokka also supports versioned docs which is also something to look into in the future.

Closes  #672
