### PR TITLE
Actually build core in core-build.yml

### DIFF
--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -53,3 +53,4 @@ jobs:
         run: |
           cmake --version
           cmake -B build -DCMAKE_BUILD_TYPE=Debug -DMBGL_WITH_CORE_ONLY=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMBGL_WITH_COVERAGE=ON
+          cmake --build build

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - "src/**"
       - "include/**"
-      - "workflows/core-ci.yml"
+      - "workflows/core-build.yml"
       - "CMakeLists.txt"
 
 concurrency:


### PR DESCRIPTION
I noticed that the new workflow that builds the core just configures CMake, and doesn't actually build the core.

This should fix it.