### PR TITLE
Enable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: "🙏 Q&A - GitHub Discussions"
     url: https://github.com/maplibre/maplibre-gl-native/discussions/categories/q-a


### PR DESCRIPTION
Not all issues fit into the templates.

I suggest we enable blank issues to make it easier to create issues that don't.