### PR TITLE
Add typings for Node Platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lib"
   ],
   "main": "platform/node/index.js",
+  "types": "platform/node/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maplibre/maplibre-gl-native.git"

--- a/platform/node/index.d.ts
+++ b/platform/node/index.d.ts
@@ -1,0 +1,39 @@
+declare module '@maplibre/maplibre-gl-native' {
+  export type RequestResponse = {
+    data: ArrayBuffer;
+    modified?: Date;
+    expires?: Date;
+    etag?: string;
+  };
+
+  export type MapOptions = {
+    request: (
+      request: { url: string; kind: number },
+      callback: (error?: Error, response?: RequestResponse) => void,
+    ) => void;
+    ration?: number;
+  };
+
+  export type RenderOptions = {
+    zoom?: number; // defaults to 0
+    width?: number; // px, defaults to 512
+    height?: number; // px, defaults to 512
+    center?: [number, number]; // coordinates, defaults to [0,0]
+    bearing?: number; // degrees, counter-clockwise from north, defaults to 0
+    pitch?: number; // degrees, arcing towards the horizon, defaults to 0
+    classes?: string[]; // array of strings
+  };
+
+  export class Map {
+    constructor(mapOptions: MapOptions);
+
+    load: (style: any) => void;
+
+    render: (
+      renderOptions: RenderOptions,
+      callback: (...args: [error: Error, buffer: undefined] | [error: undefined, buffer: Uint8Array]) => void,
+    ) => void;
+
+    release: () => void;
+  }
+}


### PR DESCRIPTION
I augmented the module as far as I could figure out the types from the docs and usage. As I see there are a few more hidden function from the native module. I'm not sure if these should also be augmented and if so how:

```js
  setBackendType: [Function: setBackendType],
  ParseError: [class ParseError extends Error],
  Map: [Function: Map], // this is alreade augmented
  Expression: [Function: Expression] { parse: [Function: parse] },
  Resource: {
    Unknown: 0,
    Style: 1,
    Source: 2,
    Tile: 3,
    Glyphs: 4,
    SpriteImage: 5,
    SpriteJSON: 6
  },
```