### PR TITLE
Update node (ubuntu-20.04, arm64) docker build workflow

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -199,6 +199,9 @@ jobs:
         run: |
           brew install docker docker-compose
 
+      - name: Docker Prune
+        run: docker system prune --force
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -208,9 +211,19 @@ jobs:
           context: .
           platforms: linux/arm64
           file: platform/node/scripts/Dockerfile_Build
-          tags: build
+          tags: node-test-${{ github.run_id }}-${{ github.run_attempt }}
           push: false
           load: true
 
       - name: Run the docker build image and create node libs
-        run:  docker run --rm -v $(pwd):/data build
+        run:  docker run --rm -v $(pwd):/data node-test-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Clean up the docker build image
+        if: always()
+        run:  docker rmi $(docker images | grep node-test-${{ github.run_id }}-${{ github.run_attempt }} | tr -s ' ' | cut -d ' ' -f 3) --force
+
+      # On PRs make sure that the npm package can be packaged.
+      - name: Pack
+        if: github.ref != 'refs/heads/main'
+        run: |
+          npm pack --dry-run

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -130,11 +130,11 @@ jobs:
           cache-name: ccache-v1
         with:
           path: ~/.ccache
-          key: ${{ env.cache-name }}-${{ matrix.os }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}-${{ github.head_ref }}
+          key: ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}-${{ github.head_ref }}
           restore-keys: |
-            ${{ env.cache-name }}-${{ matrix.os }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}
-            ${{ env.cache-name }}-${{ matrix.os }}-${{ github.job }}-${{ github.ref }}
-            ${{ env.cache-name }}-${{ matrix.os }}-${{ github.job }}
+            ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}
+            ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ github.ref }}
+            ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}
 
       - name: Clear ccache statistics
         run: |

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -182,8 +182,7 @@ jobs:
           npm pack --dry-run
           
   test_linux_arm:
-    #runs-on: ubuntu-latest
-    runs-on: macos-12-arm
+    runs-on: ${{ (github.action_repository == 'maplibre/maplibre-gl-native' && 'macos-12-arm') || 'ubuntu-latest' }}
     name: test (ubuntu-20.04, arm64)
     steps:
       - name: Checkout

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -182,6 +182,7 @@ jobs:
           npm pack --dry-run
           
   test_linux_arm:
+    #runs-on: ubuntu-latest
     runs-on: macos-12-arm
     name: test (ubuntu-20.04, arm64)
     steps:
@@ -190,6 +191,12 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64'
 
       - name: Install dependencies macOS
         if: runner.os == 'macOS'

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -184,6 +184,8 @@ jobs:
   test_linux_arm:
     runs-on: ${{ (github.repository == 'maplibre/maplibre-gl-native' && 'macos-12-arm') || 'ubuntu-latest' }}
     name: test (ubuntu-20.04, arm64)
+    env:
+      DOCKERTAG: node-test-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -214,16 +216,16 @@ jobs:
           context: .
           platforms: linux/arm64
           file: platform/node/scripts/Dockerfile_Build
-          tags: node-test-${{ github.run_id }}-${{ github.run_attempt }}
+          tags: ${{ env.DOCKERTAG }}
           push: false
           load: true
 
       - name: Run the docker build image and create node libs
-        run:  docker run --rm -v $(pwd):/data node-test-${{ github.run_id }}-${{ github.run_attempt }}
+        run:  docker run --rm -v $(pwd):/data ${{ env.DOCKERTAG }}
 
       - name: Clean up the docker build image
         if: always()
-        run:  docker rmi $(docker images | grep node-test-${{ github.run_id }}-${{ github.run_attempt }} | tr -s ' ' | cut -d ' ' -f 3) --force
+        run:  docker rmi $(docker images | grep ${{ env.DOCKERTAG }} | tr -s ' ' | cut -d ' ' -f 3) --force
 
       # On PRs make sure that the npm package can be packaged.
       - name: Pack

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -182,7 +182,7 @@ jobs:
           npm pack --dry-run
           
   test_linux_arm:
-    runs-on: ${{ (github.action_repository == 'maplibre/maplibre-gl-native' && 'macos-12-arm') || 'ubuntu-latest' }}
+    runs-on: ${{ (github.repository == 'maplibre/maplibre-gl-native' && 'macos-12-arm') || 'ubuntu-latest' }}
     name: test (ubuntu-20.04, arm64)
     steps:
       - name: Checkout

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -182,7 +182,7 @@ jobs:
           npm pack --dry-run
           
   test_linux_arm:
-    runs-on: ${{ (github.repository == 'maplibre/maplibre-gl-native' && 'macos-12-arm') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     name: test (ubuntu-20.04, arm64)
     env:
       DOCKERTAG: node-test-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -206,9 +206,6 @@ jobs:
         run: |
           brew install docker docker-compose
 
-      - name: Docker Prune
-        run: docker system prune --force
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -269,12 +269,16 @@ jobs:
           context: .
           platforms: linux/arm64
           file: platform/node/scripts/Dockerfile_Build
-          tags: build
+          tags: node-build-${{ github.run_id }}-${{ github.run_attempt }}
           push: false
           load: true
 
       - name: Run the docker build image and create node libs
-        run:  docker run --rm -v $(pwd):/data build
+        run:  docker run --rm -v $(pwd):/data node-build-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Clean up the docker build image
+        if: always()
+        run:  docker rmi $(docker images | grep node-build-${{ github.run_id }}-${{ github.run_attempt }} | tr -s ' ' | cut -d ' ' -f 3) --force
 
       - name: Setup node
         uses: actions/setup-node@v3

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -242,6 +242,8 @@ jobs:
     runs-on: ${{ (github.repository == 'maplibre/maplibre-gl-native' && 'macos-12-arm') || 'ubuntu-latest' }}
     needs: bump_version
     name: publish_binary (ubuntu-20.04, arm64)
+    env:
+      DOCKERTAG: node-build-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -275,16 +277,16 @@ jobs:
           context: .
           platforms: linux/arm64
           file: platform/node/scripts/Dockerfile_Build
-          tags: node-build-${{ github.run_id }}-${{ github.run_attempt }}
+          tags: ${{ env.DOCKERTAG }}
           push: false
           load: true
 
       - name: Run the docker build image and create node libs
-        run:  docker run --rm -v $(pwd):/data node-build-${{ github.run_id }}-${{ github.run_attempt }}
+        run:  docker run --rm -v $(pwd):/data ${{ env.DOCKERTAG }}
 
       - name: Clean up the docker build image
         if: always()
-        run:  docker rmi $(docker images | grep node-build-${{ github.run_id }}-${{ github.run_attempt }} | tr -s ' ' | cut -d ' ' -f 3) --force
+        run:  docker rmi $(docker images | grep ${{ env.DOCKERTAG }} | tr -s ' ' | cut -d ' ' -f 3) --force
 
       - name: Setup node
         uses: actions/setup-node@v3

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -239,6 +239,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
 
   publish_binary_linux_arm64:
+    #runs-on: ubuntu-latest
     runs-on: macos-12-arm
     needs: bump_version
     name: publish_binary (ubuntu-20.04, arm64)
@@ -251,6 +252,12 @@ jobs:
 
       - name: Get Latest Version
         run: git pull
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64'
 
       - name: Install dependencies macOS
         if: runner.os == 'macOS'

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -239,8 +239,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
 
   publish_binary_linux_arm64:
-    #runs-on: ubuntu-latest
-    runs-on: macos-12-arm
+    runs-on: ${{ (github.action_repository == 'maplibre/maplibre-gl-native' && 'macos-12-arm') || 'ubuntu-latest' }}
     needs: bump_version
     name: publish_binary (ubuntu-20.04, arm64)
     steps:

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -131,11 +131,11 @@ jobs:
           cache-name: ccache-v1
         with:
           path: ~/.ccache
-          key: ${{ env.cache-name }}-${{ matrix.os }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}-${{ github.head_ref }}
+          key: ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}-${{ github.head_ref }}
           restore-keys: |
-            ${{ env.cache-name }}-${{ matrix.os }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}
-            ${{ env.cache-name }}-${{ matrix.os }}-${{ github.job }}-${{ github.ref }}
-            ${{ env.cache-name }}-${{ matrix.os }}-${{ github.job }}
+            ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}
+            ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ github.ref }}
+            ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}
 
       - name: Clear ccache statistics
         run: |

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -239,7 +239,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
 
   publish_binary_linux_arm64:
-    runs-on: ${{ (github.action_repository == 'maplibre/maplibre-gl-native' && 'macos-12-arm') || 'ubuntu-latest' }}
+    runs-on: ${{ (github.repository == 'maplibre/maplibre-gl-native' && 'macos-12-arm') || 'ubuntu-latest' }}
     needs: bump_version
     name: publish_binary (ubuntu-20.04, arm64)
     steps:

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -239,7 +239,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
 
   publish_binary_linux_arm64:
-    runs-on: ${{ (github.repository == 'maplibre/maplibre-gl-native' && 'macos-12-arm') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     needs: bump_version
     name: publish_binary (ubuntu-20.04, arm64)
     env:

--- a/platform/node/scripts/Dockerfile_Build
+++ b/platform/node/scripts/Dockerfile_Build
@@ -27,6 +27,6 @@ RUN set -ex; \
 VOLUME /data
 
 RUN mkdir -p /usr/src/app
-COPY / /usr/src/app
-ENTRYPOINT ["/usr/src/app/platform/node/scripts/docker_build_entrypoint.sh"]
-RUN ["chmod", "+x", "/usr/src/app/platform/node/scripts/docker_build_entrypoint.sh"]
+COPY /platform/node/scripts/docker_build_entrypoint.sh /usr/src/app/docker_build_entrypoint.sh
+ENTRYPOINT ["/usr/src/app/docker_build_entrypoint.sh"]
+RUN ["chmod", "+x", "/usr/src/app/docker_build_entrypoint.sh"]

--- a/platform/node/scripts/docker_build_entrypoint.sh
+++ b/platform/node/scripts/docker_build_entrypoint.sh
@@ -12,5 +12,5 @@ cmake . -B build -G Ninja  -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNC
 cmake --build build -j $(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null)
 
 #Test
-xvfb-run --auto-servernum ./build/mbgl-render-test-runner --manifestPath metrics/macos-xcode11-release-style.json
+xvfb-run --auto-servernum ./build/mbgl-render-test-runner --manifestPath metrics/linux-gcc8-release-style.json
 xvfb-run --auto-servernum npm test

--- a/platform/node/scripts/docker_build_entrypoint.sh
+++ b/platform/node/scripts/docker_build_entrypoint.sh
@@ -4,12 +4,13 @@ node -v
 cat /etc/os-release
 uname -m
 
-cd /usr/src/app
+#build lib files
+cd /data/
 npm ci --ignore-scripts
 ccache --clear --set-config cache_dir=~/.ccache
 cmake . -B build -G Ninja  -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
 cmake --build build -j $(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null)
-cp -R ./lib/ /data/lib/
 
+#Test
 xvfb-run --auto-servernum ./build/mbgl-render-test-runner --manifestPath metrics/macos-xcode11-release-style.json
 xvfb-run --auto-servernum npm test


### PR DESCRIPTION
This PR is an attempt to fix the node (ubuntu-20.04, arm64) docker build space issues.

1.) I've made some changes so the docker images the workflow creates get cleaned up when it finishes, whether it finishes successfully or not. I did the by giving each build a unique name, and then removing those images after the build is complete. I set the cleanup to use "always()" so even if steps fail, this cleanup still runs.

2.) I've updated 'Dockerfile_Build' so it no longer copies all the source code inside the docker image. It instead just copies 'docker_build_entrypoint.sh', and then does the build inside the mounted volume. since it builds inside the mounted /data/ volume, it does not add space inside the docker image.

3.) I've added in an alternative config to run this on an ubuntu-latest runner. if the runner is switched to that, the build will use qemu. This is mainly so it is easier to switch if needed, like when someone tries to run this on their own fork and doesn't have the mac-os arm runner (like me in my fork)



