### PR TITLE
Add mbgl-compiler-options to Node targets

### DIFF
--- a/platform/node/cmake/module.cmake
+++ b/platform/node/cmake/module.cmake
@@ -160,7 +160,7 @@ function(add_node_module NAME)
             )
         endif()
 
-        target_link_libraries(${_TARGET} PRIVATE ${NAME})
+        target_link_libraries(${_TARGET} PRIVATE ${NAME} mbgl-compiler-options)
 
         if(APPLE)
             # Ensures that linked symbols are loaded when the module is loaded instead of causing

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -192,7 +192,7 @@ void NodeMap::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     info.This()->SetInternalField(1, options);
 
     mbgl::FileSourceManager::get()->registerFileSourceFactory(
-        mbgl::FileSourceType::ResourceLoader, [](const mbgl::ResourceOptions& resourceOptions, const mbgl::ClientOptions& clientOptions) {
+        mbgl::FileSourceType::ResourceLoader, [](const mbgl::ResourceOptions& resourceOptions, const mbgl::ClientOptions&) {
             return std::make_unique<node_mbgl::NodeFileSource>(
                 reinterpret_cast<node_mbgl::NodeMap*>(resourceOptions.platformContext()));
         });


### PR DESCRIPTION
Node targets didn't inherit global compiler settings defined in `mbgl-compiler-options`. This PR adds this target to every Node target. But doing so revealed a problem in `platform/node/src/node_map.cpp` caused by a unused parameter in a lambda function. So this PR also correct that, allowing Node targets to be compiled without any error.