### PR TITLE
make LocationEngineProxy constructor public

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/engine/LocationEngineProxy.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/engine/LocationEngineProxy.java
@@ -16,7 +16,7 @@ public class LocationEngineProxy<T> implements LocationEngine {
   private final LocationEngineImpl<T> locationEngineImpl;
   private Map<LocationEngineCallback<LocationEngineResult>, T> listeners;
 
-  LocationEngineProxy(LocationEngineImpl<T> locationEngineImpl) {
+  public LocationEngineProxy(LocationEngineImpl<T> locationEngineImpl) {
     this.locationEngineImpl = locationEngineImpl;
   }
 


### PR DESCRIPTION
LocationEngineProxy constructor class access modifier changed to public in order to make custom LocationEngine from it