### PR TITLE
Upgrade nan for node 19.x support

### DIFF
--- a/platform/node/CMakeLists.txt
+++ b/platform/node/CMakeLists.txt
@@ -5,13 +5,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/module.cmake)
 add_node_module(
     mbgl-node
     INSTALL_PATH ${PROJECT_SOURCE_DIR}/lib/{node_abi}/mbgl.node
-    NAN_VERSION 2.14.2
+    NAN_VERSION 2.17.0
     EXCLUDE_NODE_ABIS
         46
         47
         48
         51
-        111
 )
 find_package(PkgConfig REQUIRED)
 pkg_search_module(LIBUV libuv REQUIRED)

--- a/platform/node/src/node_expression.cpp
+++ b/platform/node/src/node_expression.cpp
@@ -17,7 +17,11 @@ namespace node_mbgl {
 Nan::Persistent<v8::Function> NodeExpression::constructor;
 
 void NodeExpression::Init(v8::Local<v8::Object> target) {
+#if defined NODE_MODULE_VERSION && NODE_MODULE_VERSION < 93
     v8::Local<v8::Context> context = target->CreationContext();
+#else
+    v8::Local<v8::Context> context = target->GetCreationContext().ToLocalChecked();
+#endif
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
     tpl->SetClassName(Nan::New("Expression").ToLocalChecked());
     tpl->InstanceTemplate()->SetInternalFieldCount(1); // what is this doing?
@@ -50,7 +54,11 @@ type::Type parseType(v8::Local<v8::Object> type) {
     std::string kind(*v8::String::Utf8Value(v8::Isolate::GetCurrent(), v8kind));
 
     if (kind == "array") {
+#if defined NODE_MODULE_VERSION && NODE_MODULE_VERSION < 93
         v8::Local<v8::Context> context = type->CreationContext();
+#else
+        v8::Local<v8::Context> context = type->GetCreationContext().ToLocalChecked();
+#endif
         type::Type itemType = parseType(Nan::Get(type, Nan::New("itemType").ToLocalChecked()).ToLocalChecked()->ToObject(context).ToLocalChecked());
         mbgl::optional<std::size_t> N;
 

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -116,7 +116,11 @@ ParseError)JS").ToLocalChecked()).ToLocalChecked();
 
     Nan::SetPrototypeMethod(tpl, "dumpDebugLogs", DumpDebugLogs);
     Nan::SetPrototypeMethod(tpl, "queryRenderedFeatures", QueryRenderedFeatures);
+#if defined NODE_MODULE_VERSION && NODE_MODULE_VERSION < 93
     v8::Local<v8::Context> context = target->CreationContext();
+#else
+    v8::Local<v8::Context> context = target->GetCreationContext().ToLocalChecked();
+#endif
 
     constructor.Reset(tpl->GetFunction(context).ToLocalChecked());
     Nan::Set(target, Nan::New("Map").ToLocalChecked(), tpl->GetFunction(context).ToLocalChecked());

--- a/platform/node/src/node_request.cpp
+++ b/platform/node/src/node_request.cpp
@@ -27,7 +27,11 @@ NodeRequest::~NodeRequest() {
 Nan::Persistent<v8::Function> NodeRequest::constructor;
 
 void NodeRequest::Init(v8::Local<v8::Object> target) {
+#if defined NODE_MODULE_VERSION && NODE_MODULE_VERSION < 93
     v8::Local<v8::Context> context = target->CreationContext();
+#else
+    v8::Local<v8::Context> context = target->GetCreationContext().ToLocalChecked();
+#endif
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
 
     tpl->InstanceTemplate()->SetInternalFieldCount(1);


### PR DESCRIPTION
Fixes https://github.com/maplibre/maplibre-gl-native/issues/545.

Old v8::object only supported `CreationContext()` while new only supports `GetCreationContext()`, so if we want to support both we need some macros.