### PR TITLE
put back docker process changed in #804

### DIFF
--- a/platform/node/scripts/Dockerfile_Build
+++ b/platform/node/scripts/Dockerfile_Build
@@ -27,6 +27,6 @@ RUN set -ex; \
 VOLUME /data
 
 RUN mkdir -p /usr/src/app
-COPY /platform/node/scripts/docker_build_entrypoint.sh /usr/src/app/docker_build_entrypoint.sh
-ENTRYPOINT ["/usr/src/app/docker_build_entrypoint.sh"]
-RUN ["chmod", "+x", "/usr/src/app/docker_build_entrypoint.sh"]
+COPY / /usr/src/app
+ENTRYPOINT ["/usr/src/app/platform/node/scripts/docker_build_entrypoint.sh"]
+RUN ["chmod", "+x", "/usr/src/app/platform/node/scripts/docker_build_entrypoint.sh"]

--- a/platform/node/scripts/docker_build_entrypoint.sh
+++ b/platform/node/scripts/docker_build_entrypoint.sh
@@ -4,12 +4,13 @@ node -v
 cat /etc/os-release
 uname -m
 
-#build lib files
-cd /data/
+#Build lib files
+cd /usr/src/app/
 npm ci --ignore-scripts
 ccache --clear --set-config cache_dir=~/.ccache
 cmake . -B build -G Ninja  -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
 cmake --build build -j $(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null)
+cp -R ./lib/ /data/lib/
 
 #Test
 xvfb-run --auto-servernum ./build/mbgl-render-test-runner --manifestPath metrics/linux-gcc8-release-style.json


### PR DESCRIPTION
Fixes https://github.com/maplibre/maplibre-gl-native/issues/860 . This is needed to publish a new node release, since the current workflow is failing to publish the arm64 binary.

In #804 I tried to change the linux arm64 docker build process so it worked inside the current directory instead of copying files inside the docker image. This worked fine in the ci tests, but in the real publish it adds extra step to install node-pre-gyp and publish. Unfortunately, when it tries to does "npm ci" to install node-pre-gyp it fails due to the node_modules directory already existing from the docker build (which is for a different platform). 

At first I tried several ideas to remove the node_modules folder to get around this. Trying to remove it in the workflow fails with permission issues. trying to remove it in the entrypoint file kind of worked, but then the publish still failed due to a permission issues.

This PR reverts changes in  https://github.com/maplibre/maplibre-gl-native/pull/804 which made the build happen in the current directory. It still keeps some changes, like running in linux and qemu, which has been helping this workflow run successfully.

I've tested this change on my own fork at https://github.com/WifiDB/maplibre-gl-native/actions/runs/4284198145/jobs/7460830106



