### PR TITLE
Add some missing cstdint inclusions (#872)

### DIFF
--- a/expression-test/expression_test_logger.hpp
+++ b/expression-test/expression_test_logger.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #define ANSI_COLOR_RED        "\x1b[31m"

--- a/include/mbgl/i18n/number_format.hpp
+++ b/include/mbgl/i18n/number_format.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace mbgl {

--- a/include/mbgl/util/geometry.hpp
+++ b/include/mbgl/util/geometry.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include <mapbox/geometry/geometry.hpp>
 #include <mapbox/geometry/point_arithmetic.hpp>
 #include <mapbox/geometry/for_each_point.hpp>

--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 #include <cstdlib>
 #include <type_traits>
 #include <exception>

--- a/src/mbgl/programs/gl/shaders.hpp
+++ b/src/mbgl/programs/gl/shaders.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace mbgl {


### PR DESCRIPTION
GCC 13 removed some indirect inclusions of cstdint which this relied on. Include it explicitly to fix build errors.

The eternal submodule had a fix for this in git, just pull it in.