### PR TITLE
Fix compiler error seen in Xcode 14.3 Beta 2

### DIFF
--- a/platform/ios/platform/darwin/src/NSDate+MGLAdditions.mm
+++ b/platform/ios/platform/darwin/src/NSDate+MGLAdditions.mm
@@ -1,4 +1,5 @@
 #import "NSDate+MGLAdditions.h"
+#import <ratio>
 
 mbgl::Duration MGLDurationFromTimeInterval(NSTimeInterval duration)
 {


### PR DESCRIPTION
`#import <ratio>` to fix compiler error seen in Xcode 14.3 Beta 2

---

*Error without this fix*

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/118112/222814912-3e05da32-2f13-4ea9-95de-9a3b6a046a8c.png">

---

<details markdown=1><summary> Xcode 14.3 Beta 2 build details </summary>

make iproj. Opening MapLibre in Xcode using:  'xed platform/ios/ios.xcworkspace'.  To skip opening Xcode, use 'make iproj CI=1'
## Xcode dependencies
Xcode 14.3
Build version 14E5207e
Darwin oldSanJuan.local 22.3.0 Darwin Kernel Version 22.3.0: Mon Jan 30 20:42:11 PST 2023; root:xnu-8792.81.3~2/RELEASE_X86_64 x86_64
ProductName:            macOS
ProductVersion:         13.2.1
BuildVersion:           22D68
i386
ccache 4.7.4
cmake 3.25.2
glfw 3.3.8
pkg-config 0.29.2_3
</details>

