### PR TITLE
Update License - Mapbox to MapLibre / Update Copyright

### DIFF
--- a/LICENSE.mbgl-core.md
+++ b/LICENSE.mbgl-core.md
@@ -1,7 +1,11 @@
-### [Mapbox GL Native](https://github.com/mapbox/mapbox-gl-native) by Mapbox
+### [Maplibre GL Native](https://github.com/maplibre/maplibre-gl-native/) by MapLibre
 
 ```
-mapbox-gl-native Copyright (c) 2014-2020 Mapbox.
+BSD 2-Clause License
+
+Copyright (c) 2021-2023 MapLibre contributors
+Copyright (c) 2018-2021 MapTiler.com
+Copyright (c) 2014-2020 Mapbox
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,7 @@
 BSD 2-Clause License
 
-Copyright (c) 2021 MapLibre contributors
-
+Copyright (c) 2021-2023 MapLibre contributors
 Copyright (c) 2018-2021 MapTiler.com
-
 Copyright (c) 2014-2020 Mapbox
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Update the license files. This is something I found while I was trying to update TileServer-GL license, which included the mapox-gl-native license and dependencies.

1.) Update LICENSE.mbgl-core.md from Mapbox to MapLibre. 
2.) Update Copyright terms to match in LICENSE.mbgl-core.md and LICENSE.md