### PR TITLE
Fix Makefile `style-code` target

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -139,6 +139,3 @@ jobs:
 
       - name: Lint plist files
         run: make macos-lint
-
-      - name: Darwin Style Code check
-        run: make darwin-style-code

--- a/platform/ios/Makefile
+++ b/platform/ios/Makefile
@@ -189,7 +189,7 @@ ios-uitest: $(IOS_PROJ_PATH)
 	echo "You can review uitest results:  open $(IOS_OUTPUT_PATH)/Logs/Test"
 
 .PHONY: ios-test
-ios-test: $(IOS_PROJ_PATH) style-code
+ios-test: style-code $(IOS_PROJ_PATH)
 	set -o pipefail && $(IOS_XCODEBUILD_SIM) -scheme 'CI' test $(XCPRETTY)
 
 .PHONY: ios-integration-test
@@ -292,7 +292,7 @@ xproj: $(MACOS_PROJ_PATH) style-code
 
 #  make macos-test
 .PHONY: macos-test
-macos-test: $(MACOS_PROJ_PATH) style-code
+macos-test: style-code $(MACOS_PROJ_PATH)
 	set -o pipefail && $(MACOS_XCODEBUILD) -scheme 'CI' test $(XCPRETTY)
 
 .PHONY: macos-lint

--- a/platform/ios/Makefile
+++ b/platform/ios/Makefile
@@ -331,6 +331,7 @@ node-modules:
 .PHONY: style-code
 style-code: node-modules
 	node ../../scripts/generate-style-code.js
+	node platform/darwin/scripts/generate-style-code.js
 	node platform/darwin/scripts/update-examples.js
 
 .PHONY: codestyle

--- a/platform/ios/Makefile
+++ b/platform/ios/Makefile
@@ -240,18 +240,6 @@ ideploy:
 idocument:
 	OUTPUT=$(OUTPUT) ./platform/ios/scripts/document.sh
 
-#  make darwin-style-code
-.PHONY: darwin-style-code
-darwin-style-code:
-	node platform/darwin/scripts/generate-style-code.js
-	node platform/darwin/scripts/update-examples.js
-style-code: darwin-style-code
-
-# make darwin-update-examples
-.PHONY: darwin-update-examples
-darwin-update-examples:
-	node platform/darwin/scripts/update-examples.js
-
 .PHONY: darwin-check-public-symbols
 darwin-check-public-symbols:
 	node platform/darwin/scripts/check-public-symbols.js macOS iOS
@@ -336,9 +324,14 @@ endif
 
 #### Miscellaneous targets #####################################################
 
+.PHONY: node-modules
+node-modules:
+	npm ci --prefix ../.. --ignore-scripts
+
 .PHONY: style-code
-style-code:
+style-code: node-modules
 	node ../../scripts/generate-style-code.js
+	node platform/darwin/scripts/update-examples.js
 
 .PHONY: codestyle
 codestyle:


### PR DESCRIPTION
Now the `style-code` target really will install the node modules in the root.