### PR TITLE
Node platform improvements

### DIFF
--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -5,6 +5,7 @@
 - *...Add new stuff here...*
 
 # 5.2.0
+* Node platform improvements (added setSize and a new render call without render options object) by @tdcosta100 in https://github.com/maplibre/maplibre-gl-native/pull/891
 * Move node ci+release to self hosted Ubuntu arm64 by @acalcutt in https://github.com/maplibre/maplibre-gl-native/pull/873
 * Add windows support by @tdcosta100 in https://github.com/maplibre/maplibre-gl-native/pull/707
 * Add Typings for Node Platform by @KiwiKilian in https://github.com/maplibre/maplibre-gl-native/pull/766

--- a/platform/node/README.md
+++ b/platform/node/README.md
@@ -173,6 +173,8 @@ var map = new mbgl.Map({
                 response.data = body;
 
                 callback(null, response);
+            } else if (res.statusCode == 204) {
+                callback();
             } else {
                 callback(new Error(JSON.parse(body).message));
             }

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -474,13 +474,12 @@ void NodeMap::startRender() {
         if (eptr) {
             error = eptr;
             uv_async_send(async);
-        }
-        else {
+        } else {
             assert(!image.data);
             image = frontend->readStillImage();
             uv_async_send(async);
         }
-        });
+    });
 
     // Retain this object, otherwise it might get destructed before we are finished rendering the
     // still image.

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -1473,7 +1473,7 @@ NodeMap::NodeMap(v8::Local<v8::Object> options)
             : true;
     }())
     , mapObserver(NodeMapObserver())
-    , frontend(std::make_unique<mbgl::HeadlessFrontend>(mbgl::Size { 256, 256 }, pixelRatio))
+    , frontend(std::make_unique<mbgl::HeadlessFrontend>(mbgl::Size { 512, 512 }, pixelRatio))
     , map(std::make_unique<mbgl::Map>(*frontend, mapObserver,
                                       mbgl::MapOptions().withSize(frontend->getSize())
                                       .withPixelRatio(pixelRatio)

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -431,7 +431,7 @@ void NodeMap::Render(const Nan::FunctionCallbackInfo<v8::Value>& info) {
         return Nan::ThrowTypeError("First argument must be an options object or a callback function");
     }
 
-    if (info.Length() <= 1 && !info[0]->IsFunction()) {
+    if (info.Length() <= 1 && !info[0]->IsFunction() || info.Length() > 1 && !info[1].IsFunction()) {
         return Nan::ThrowTypeError("Second argument must be a callback function");
     }
 

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -427,7 +427,7 @@ void NodeMap::Render(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     auto nodeMap = Nan::ObjectWrap::Unwrap<NodeMap>(info.Holder());
     if (!nodeMap->map) return Nan::ThrowError(releasedMessage());
 
-    if (info.Length() <= 0 || !info[0]->IsObject() || !info[0]->IsFunction()) {
+    if (info.Length() <= 0 || (!info[0]->IsObject() && !info[0]->IsFunction())) {
         return Nan::ThrowTypeError("First argument must be an options object or a callback function");
     }
 

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -102,6 +102,7 @@ ParseError)JS").ToLocalChecked()).ToLocalChecked();
     Nan::SetPrototypeMethod(tpl, "setLayoutProperty", SetLayerProperty);
     Nan::SetPrototypeMethod(tpl, "setPaintProperty", SetLayerProperty);
     Nan::SetPrototypeMethod(tpl, "setFilter", SetFilter);
+    Nan::SetPrototypeMethod(tpl, "setSize", SetSize);
     Nan::SetPrototypeMethod(tpl, "setCenter", SetCenter);
     Nan::SetPrototypeMethod(tpl, "setZoom", SetZoom);
     Nan::SetPrototypeMethod(tpl, "setBearing", SetBearing);
@@ -426,11 +427,11 @@ void NodeMap::Render(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     auto nodeMap = Nan::ObjectWrap::Unwrap<NodeMap>(info.Holder());
     if (!nodeMap->map) return Nan::ThrowError(releasedMessage());
 
-    if (info.Length() <= 0 || !info[0]->IsObject()) {
-        return Nan::ThrowTypeError("First argument must be an options object");
+    if (info.Length() <= 0 || !info[0]->IsObject() || !info[0]->IsFunction()) {
+        return Nan::ThrowTypeError("First argument must be an options object or a callback function");
     }
 
-    if (info.Length() <= 1 || !info[1]->IsFunction()) {
+    if (info.Length() > 1 && !info[1]->IsFunction()) {
         return Nan::ThrowTypeError("Second argument must be a callback function");
     }
 
@@ -443,12 +444,20 @@ void NodeMap::Render(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     }
 
     try {
-        auto options = ParseOptions(Nan::To<v8::Object>(info[0]).ToLocalChecked());
-        assert(!nodeMap->req);
-        assert(!nodeMap->image.data);
-        nodeMap->req = std::make_unique<RenderRequest>(Nan::To<v8::Function>(info[1]).ToLocalChecked());
+        if (info[0]->IsFunction()) {
+            assert(!nodeMap->req);
+            assert(!nodeMap->image.data);
+            nodeMap->req = std::make_unique<RenderRequest>(Nan::To<v8::Function>(info[0]).ToLocalChecked());
 
-        nodeMap->startRender(options);
+            nodeMap->startRender();
+        } else {
+            auto options = ParseOptions(Nan::To<v8::Object>(info[0]).ToLocalChecked());
+            assert(!nodeMap->req);
+            assert(!nodeMap->image.data);
+            nodeMap->req = std::make_unique<RenderRequest>(Nan::To<v8::Function>(info[1]).ToLocalChecked());
+
+            nodeMap->startRender(options);
+        }
     } catch (const mbgl::style::conversion::Error& err) {
         return Nan::ThrowTypeError(err.message.c_str());
     } catch (const mbgl::util::StyleParseException& ex) {
@@ -458,6 +467,28 @@ void NodeMap::Render(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     }
 
     info.GetReturnValue().SetUndefined();
+}
+
+void NodeMap::startRender() {
+    map->renderStill([this](const std::exception_ptr& eptr) {
+        if (eptr) {
+            error = eptr;
+            uv_async_send(async);
+        }
+        else {
+            assert(!image.data);
+            image = frontend->readStillImage();
+            uv_async_send(async);
+        }
+        });
+
+    // Retain this object, otherwise it might get destructed before we are finished rendering the
+    // still image.
+    Ref();
+
+    // Similarly, we're now waiting for the async to be called, so we need to make sure that it
+    // keeps the loop alive.
+    uv_ref(reinterpret_cast<uv_handle_t*>(async));
 }
 
 void NodeMap::startRender(const NodeMap::RenderOptions& options) {
@@ -923,6 +954,30 @@ void NodeMap::SetFilter(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     }
 
     layer->setFilter(filter);
+}
+
+void NodeMap::SetSize(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+    auto nodeMap = Nan::ObjectWrap::Unwrap<NodeMap>(info.Holder());
+    if (!nodeMap->map) return Nan::ThrowError(releasedMessage());
+
+    if (info.Length() <= 0 || !info[0]->IsArray()) {
+        return Nan::ThrowTypeError("First argument must be an array");
+    }
+
+    auto size = info[0].As<v8::Array>();
+    uint32_t width= 0;
+    uint32_t height = 0;
+    if (size->Length() > 0) { width = Nan::To<uint32_t>(Nan::Get(size, 0).ToLocalChecked()).ToChecked(); }
+    if (size->Length() > 1) { height = Nan::To<uint32_t>(Nan::Get(size, 1).ToLocalChecked()).ToChecked(); }
+
+    try {
+        nodeMap->frontend->setSize({ width, height });
+        nodeMap->map->setSize({ width, height });
+    } catch (const std::exception &ex) {
+        return Nan::ThrowError(ex.what());
+    }
+
+    info.GetReturnValue().SetUndefined();
 }
 
 void NodeMap::SetCenter(const Nan::FunctionCallbackInfo<v8::Value>& info) {

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -431,7 +431,7 @@ void NodeMap::Render(const Nan::FunctionCallbackInfo<v8::Value>& info) {
         return Nan::ThrowTypeError("First argument must be an options object or a callback function");
     }
 
-    if (info.Length() <= 1 && !info[0]->IsFunction() || info.Length() > 1 && !info[1]->IsFunction()) {
+    if ((info.Length() <= 1 && !info[0]->IsFunction()) || (info.Length() > 1 && !info[1]->IsFunction())) {
         return Nan::ThrowTypeError("Second argument must be a callback function");
     }
 

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -431,7 +431,7 @@ void NodeMap::Render(const Nan::FunctionCallbackInfo<v8::Value>& info) {
         return Nan::ThrowTypeError("First argument must be an options object or a callback function");
     }
 
-    if (info.Length() <= 1 && !info[0]->IsFunction() || info.Length() > 1 && !info[1].IsFunction()) {
+    if (info.Length() <= 1 && !info[0]->IsFunction() || info.Length() > 1 && !info[1]->IsFunction()) {
         return Nan::ThrowTypeError("Second argument must be a callback function");
     }
 

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -670,7 +670,7 @@ void NodeMap::cancel() {
         reinterpret_cast<NodeMap *>(h->data)->renderFinished();
     });
 
-    frontend = std::make_unique<mbgl::HeadlessFrontend>(mbgl::Size{ 256, 256 }, pixelRatio);
+    frontend = std::make_unique<mbgl::HeadlessFrontend>(mbgl::Size{ 512, 512 }, pixelRatio);
     map = std::make_unique<mbgl::Map>(*frontend, mapObserver,
                                       mbgl::MapOptions().withSize(frontend->getSize())
                                       .withPixelRatio(pixelRatio)

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -431,7 +431,7 @@ void NodeMap::Render(const Nan::FunctionCallbackInfo<v8::Value>& info) {
         return Nan::ThrowTypeError("First argument must be an options object or a callback function");
     }
 
-    if (info.Length() > 1 && info[0]->IsObject() && !info[1]->IsFunction()) {
+    if (info.Length() <= 1 && !info[0]->IsFunction()) {
         return Nan::ThrowTypeError("Second argument must be a callback function");
     }
 

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -431,7 +431,7 @@ void NodeMap::Render(const Nan::FunctionCallbackInfo<v8::Value>& info) {
         return Nan::ThrowTypeError("First argument must be an options object or a callback function");
     }
 
-    if (info.Length() > 1 && !info[1]->IsFunction()) {
+    if (info.Length() > 1 && info[0]->IsObject() && !info[1]->IsFunction()) {
         return Nan::ThrowTypeError("Second argument must be a callback function");
     }
 

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -55,6 +55,7 @@ public:
     static void SetLayerZoomRange(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetLayerProperty(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetFilter(const Nan::FunctionCallbackInfo<v8::Value>&);
+    static void SetSize(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetCenter(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetZoom(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetBearing(const Nan::FunctionCallbackInfo<v8::Value>&);
@@ -72,6 +73,7 @@ public:
 
     static v8::Local<v8::Value> ParseError(const char* msg);
 
+    void startRender();
     void startRender(const RenderOptions& options);
     void renderFinished();
 

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -118,6 +118,7 @@ test('Map', function(t) {
             'setLayoutProperty',
             'setPaintProperty',
             'setFilter',
+            'setSize',
             'setCenter',
             'setZoom',
             'setBearing',


### PR DESCRIPTION
This PR brings some improvements to the Node platform:

* Allows calling Map.render without an options object (just with a callback function), mapping to the [`void mbgl::Map::renderStill(StillImageCallback)`](https://github.com/maplibre/maplibre-gl-native/blob/main/include/mbgl/map/map.hpp#L46) method
* Implements Map.setSize, which was missing
* Changes the default map size from 256x256 to 512x512 (which is the default size elsewhere, including  [`NodeMap::RenderOptions`](https://github.com/tdcosta100/maplibre-gl-native/blob/f8c1fd2194d92b284ce7781c76868066e27901b3/platform/node/src/node_map.cpp#L44))

Bonus: a little addition to the code example at README.md when the status code is 204 (empty response).