### PR TITLE
Fix "Filename too long" when cloning the repository in Qt CI

### DIFF
--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -139,7 +139,7 @@ jobs:
           cd source
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1 || true
+          git -c core.longpaths=true -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1 || true
 
       - name: Download Qt
         uses: jurplel/install-qt-action@v3


### PR DESCRIPTION
Qt CI currently generate a lot of `Filename too long` errors when cloning the repository, because filepaths have more than 256 characters. Adding the `-c core.longpaths=true` switch in git command fixes this.