### PR TITLE
Compile Node targets without -std=c++11 option

### DIFF
--- a/platform/node/cmake/module.cmake
+++ b/platform/node/cmake/module.cmake
@@ -169,7 +169,6 @@ function(add_node_module NAME)
         )
 
         if(_NAN_VERSION)
-            # Nan requires C++11. Use a compile option to allow interfaces to override this with a later version.
             target_include_directories(${_TARGET} SYSTEM PRIVATE
                 "${_CACHE_DIR}/nan/${_NAN_VERSION}"
             )

--- a/platform/node/cmake/module.cmake
+++ b/platform/node/cmake/module.cmake
@@ -170,7 +170,6 @@ function(add_node_module NAME)
 
         if(_NAN_VERSION)
             # Nan requires C++11. Use a compile option to allow interfaces to override this with a later version.
-            target_compile_options(${_TARGET} PRIVATE -std=c++11)
             target_include_directories(${_TARGET} SYSTEM PRIVATE
                 "${_CACHE_DIR}/nan/${_NAN_VERSION}"
             )


### PR DESCRIPTION
There is a `-std=c++11` switch configured in Node modules [here](https://github.com/maplibre/maplibre-gl-native/blob/343bfe443f4f389d791095329dc32c4f0bdd545e/platform/node/cmake/module.cmake#L172). I can imagine this was put there because of older compilers. Now we have C++17, this is a limiting option, not a better one. This PR removes this option in Node targets.