### PR TITLE
Only allow one concurrent AWS Device Farm run

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -149,6 +149,7 @@ jobs:
 
       - name: Write uploads.env
         if: github.ref == 'refs/heads/main'
+        working-directory: .
         run: |
           echo "ANDROID_APP_ARN=${{ steps.upload-android-app.outputs.arn }}" >> uploads.env
           echo "ANDROID_TEST_ARN=${{ steps.upload-android-test.outputs.arn }}" >> uploads.env

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -174,6 +174,10 @@ jobs:
 
   instrumentation-test:
     needs: build
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
+
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
I edited the workflow so that we do not end up with many different concurrent runs of the instrumentation tests on AWS Device Farm if we end up multiple PRs in quick succession.