### PR TITLE
Add find_package(Threads) to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1004,8 +1004,6 @@ include(${PROJECT_SOURCE_DIR}/vendor/unique_resource.cmake)
 include(${PROJECT_SOURCE_DIR}/vendor/vector-tile.cmake)
 include(${PROJECT_SOURCE_DIR}/vendor/wagyu.cmake)
 
-find_package(Threads REQUIRED)
-
 target_link_libraries(
     mbgl-core
     PRIVATE
@@ -1025,7 +1023,6 @@ target_link_libraries(
         mbgl-vendor-unique_resource
         mbgl-vendor-vector-tile
         mbgl-vendor-wagyu
-        ${CMAKE_THREAD_LIBS_INIT}
     PUBLIC
         Mapbox::Base
         Mapbox::Base::Extras::expected-lite

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1004,6 +1004,8 @@ include(${PROJECT_SOURCE_DIR}/vendor/unique_resource.cmake)
 include(${PROJECT_SOURCE_DIR}/vendor/vector-tile.cmake)
 include(${PROJECT_SOURCE_DIR}/vendor/wagyu.cmake)
 
+find_package(Threads REQUIRED)
+
 target_link_libraries(
     mbgl-core
     PRIVATE
@@ -1023,6 +1025,7 @@ target_link_libraries(
         mbgl-vendor-unique_resource
         mbgl-vendor-vector-tile
         mbgl-vendor-wagyu
+        ${CMAKE_THREAD_LIBS_INIT}
     PUBLIC
         Mapbox::Base
         Mapbox::Base::Extras::expected-lite

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -5,6 +5,7 @@ find_package(JPEG REQUIRED)
 find_package(PNG REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(X11 REQUIRED)
+find_package(Threads REQUIRED)
 
 pkg_search_module(LIBUV libuv REQUIRED)
 
@@ -112,6 +113,7 @@ target_link_libraries(
         ${JPEG_LIBRARIES}
         ${LIBUV_LIBRARIES}
         ${X11_LIBRARIES}
+        ${CMAKE_THREAD_LIBS_INIT}
         $<$<NOT:$<BOOL:${MBGL_USE_BUILTIN_ICU}>>:ICU::i18n>
         $<$<NOT:$<BOOL:${MBGL_USE_BUILTIN_ICU}>>:ICU::uc>
         $<$<BOOL:${MBGL_USE_BUILTIN_ICU}>:mbgl-vendor-icu>


### PR DESCRIPTION
Building on a Debian server, I frequently ran into link time issues with pthread. Examples:

g++
```
[425/628] Linking CXX executable bin/mbgl-render
FAILED: bin/mbgl-render
: && /usr/bin/g++ -g  bin/CMakeFiles/mbgl-render.dir/render.cpp.o -o bin/mbgl-render  libmbgl-core.a  libmbgl-vendor-csscolorparser.a  libmbgl-vendor-parsedate.a  /usr/lib/x86_64-linux-gnu/libGLX.so  /usr/lib/x86_64-linux-gnu/libOpenGL.so  /usr/lib/x86_64-linux-gnu/libcurl.so  /usr/lib/x86_64-linux-gnu/libjpeg.so  -luv  /usr/lib/x86_64-linux-gnu/libSM.so  /usr/lib/x86_64-linux-gnu/libICE.so  /usr/lib/x86_64-linux-gnu/libX11.so  /usr/lib/x86_64-linux-gnu/libXext.so  /usr/lib/x86_64-linux-gnu/libicui18n.so  /usr/lib/x86_64-linux-gnu/libicuuc.so  -ldl  /usr/lib/x86_64-linux-gnu/libpng.so  /usr/lib/x86_64-linux-gnu/libz.so  libmbgl-vendor-nunicode.a  libmbgl-vendor-sqlite.a && :
/usr/bin/ld: libmbgl-vendor-sqlite.a(sqlite3.c.o): undefined reference to symbol 'pthread_mutex_trylock@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
```

clang++
```
[388/613] Linking CXX executable expression-test/mbgl-expression-test
FAILED: expression-test/mbgl-expression-test
: && /home/linuxbrew/.linuxbrew/bin/clang++ -O3 -DNDEBUG  expression-test/CMakeFiles/mbgl-expression-test.dir/expression_test_logger.cpp.o expression-test/CMakeFiles/mbgl-expression-test.dir/expression_test_parser.cpp.o expression-test/CMakeFiles/mbgl-expression-test.dir/expression_test_runner.cpp.o expression-test/CMakeFiles/mbgl-expression-test.dir/test_runner_common.cpp.o expression-test/CMakeFiles/mbgl-expression-test.dir/main.cpp.o -o expression-test/mbgl-expression-test  libmbgl-core.a  libmbgl-vendor-csscolorparser.a  libmbgl-vendor-parsedate.a  /usr/lib/x86_64-linux-gnu/libGLX.so  /usr/lib/x86_64-linux-gnu/libOpenGL.so  /usr/lib/x86_64-linux-gnu/libcurl.so  /usr/lib/x86_64-linux-gnu/libjpeg.so  -luv  /usr/lib/x86_64-linux-gnu/libSM.so  /usr/lib/x86_64-linux-gnu/libICE.so  /usr/lib/x86_64-linux-gnu/libX11.so  /usr/lib/x86_64-linux-gnu/libXext.so  /usr/lib/x86_64-linux-gnu/libicui18n.so  /usr/lib/x86_64-linux-gnu/libicuuc.so  -ldl  /usr/lib/x86_64-linux-gnu/libpng.so  /usr/lib/x86_64-linux-gnu/libz.so  libmbgl-vendor-nunicode.a  libmbgl-vendor-sqlite.a && :
/usr/bin/ld: libmbgl-core.a(thread_local.cpp.o): undefined reference to symbol 'pthread_getspecific@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
```

This PR adds a find_package call for threads to the CMake and links mbgl-core with it resolving these linker issues.