### PR TITLE
Get the benchmark UI test working again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ node_modules
 
 /bazel-*
 CMakeLists.txt.user
+CMakeFiles

--- a/platform/ios/platform/ios/bench UITests/bench_UITests.swift
+++ b/platform/ios/platform/ios/bench UITests/bench_UITests.swift
@@ -26,11 +26,7 @@ class bench_UITests: XCTestCase {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
         app.launch()
-        
-        // Give the app enough time to run
-        sleep(100)
-
-        // Use recording to get started writing UI tests.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        app.activate()
+        _ = app.wait(for: .notRunning, timeout: 1000)
     }
 }

--- a/platform/ios/platform/ios/benchmark/Info.plist
+++ b/platform/ios/platform/ios/benchmark/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSMultipleInstancesProhibited</key>
+	<true/>
+	<key>NSSupportsSuddenTermination</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/platform/ios/platform/ios/benchmark/MBXBenchAppDelegate.m
+++ b/platform/ios/platform/ios/benchmark/MBXBenchAppDelegate.m
@@ -7,7 +7,11 @@
 
 - (BOOL)application:(UIApplication*)application
     didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-    
+
+#ifndef MLN_DISABLE_LOGGING
+    [MLNLoggingConfiguration sharedConfiguration].loggingLevel = MLNLoggingLevelFault;
+#endif
+
     [MLNSettings useWellKnownTileServer:MLNMapTiler];
     
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];

--- a/platform/ios/platform/ios/benchmark/MBXBenchViewController.mm
+++ b/platform/ios/platform/ios/benchmark/MBXBenchViewController.mm
@@ -133,7 +133,24 @@ static const int benchmarkDuration = 200; // frames
         }
         NSLog(@"Total FPS: %4.1f", totalFPS);
         NSLog(@"Average FPS: %4.1f", totalFPS / result.size());
-        exit(0);
+
+        // this does not shut the application down correctly,
+        // and results in an assertion failure in thread-local code
+        //exit(0);
+
+        // Use the UIApplication lifecycle instead.
+        // Terminating an app programmatically is strongly discouraged by Apple.
+        // Combined with the plist setting "Application does not run in background" suspend allows
+        // the XCUITest to wake up, so it doesn't need to guess how long we'll take and wait.
+        UIApplication *app = [UIApplication sharedApplication];
+        if ([app respondsToSelector:@selector(suspend)])
+        {
+            [app performSelector:@selector(suspend)];
+        }
+        else if ([app respondsToSelector:@selector(terminate)])
+        {
+            [app performSelector:@selector(terminate)];
+        }
     }
 }
 

--- a/platform/ios/platform/ios/benchmark/assets/download.sh
+++ b/platform/ios/platform/ios/benchmark/assets/download.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -u
+
+(cd glyphs && ./download.sh)
+(cd tiles && ./download.sh)
+

--- a/platform/ios/platform/ios/benchmark/assets/glyphs/download.sh
+++ b/platform/ios/platform/ios/benchmark/assets/glyphs/download.sh
@@ -3,24 +3,29 @@
 set -u
 
 LIST=(
-    "Roboto%20Regular,Noto%20Sans%20Regular/0-255.pbf"
-    "Roboto%20Regular,Noto%20Sans%20Regular/8192-8447.pbf"
     "Noto%20Sans%20Regular/0-255.pbf"
     "Roboto%20Condensed%20Italic,Noto%20Sans%20Italic/0-255.pbf"
-    "Roboto%20Medium,Noto%20Sans%20Regular/0-255.pbf"
     "Roboto%20Condensed%20Italic,Noto%20Sans%20Italic/256-511.pbf"
+    "Roboto%20Medium,Noto%20Sans%20Regular/0-255.pbf"
+    "Roboto%20Medium,Noto%20Sans%20Regular/65024-65279.pbf"
+    "Roboto%20Medium,Noto%20Sans%20Regular/11520-11775.pbf"
+    "Roboto%20Regular,Noto%20Sans%20Regular/0-255.pbf"
+    "Roboto%20Regular,Noto%20Sans%20Regular/256-511.pbf"
+    "Roboto%20Regular,Noto%20Sans%20Regular/512-767.pbf"
+    "Roboto%20Regular,Noto%20Sans%20Regular/768-1023.pbf"
     "Roboto%20Regular,Noto%20Sans%20Regular/1024-1279.pbf"
+    "Roboto%20Regular,Noto%20Sans%20Regular/8192-8447.pbf"
     "Roboto%20Medium,Noto%20Sans%20Regular/256-511.pbf"
     "Roboto%20Medium,Noto%20Sans%20Regular/512-767.pbf"
     "Roboto%20Medium,Noto%20Sans%20Regular/768-1023.pbf"
     "Roboto%20Medium,Noto%20Sans%20Regular/1024-1279.pbf"
-    "Roboto%20Regular,Noto%20Sans%20Regular/256-511.pbf"
 )
+
 
 # from https://gist.github.com/cdown/1163649
 urldecode() {
     local url_encoded="${1//+/ }"
-    printf '%b' "${url_encoded//%/\x}"
+    printf '%b' "${url_encoded//%/\\x}"
 }
 
 for i in ${LIST[@]} ; do
@@ -28,6 +33,6 @@ for i in ${LIST[@]} ; do
     if [ ! -f "${OUTPUT}" ] ; then
         mkdir -p "`dirname "${OUTPUT}"`"
         echo "Downloading glyph '${OUTPUT}'"
-        curl -H "Accept-Encoding: gzip" -# "https://api.maptiler.com/fonts/${i}?key=${MLN_API_KEY}" | gunzip > "${OUTPUT}"
+        curl --compressed --progress-bar --output "${OUTPUT}" "https://api.maptiler.com/fonts/${i}?key=${MLN_API_KEY}"
     fi
 done


### PR DESCRIPTION
Fix a missing escape character in glyph downloading that kept URL-decoding from working fully.
Add missing glyph resources that kept `[mapView isFullyLoaded]` from ever returning true.
Make the Benchmarking UI Test finish as soon as the benchmarking is complete.

#949 
