### PR TITLE
Add custom name support to shader registry

### DIFF
--- a/include/mbgl/gfx/shader.hpp
+++ b/include/mbgl/gfx/shader.hpp
@@ -11,7 +11,7 @@ class Shader;
 // Assert that a type is a valid shader for downcasting.
 // A valid shader must:
 //   * Inherit gfx::Shader
-//   * Have properly called DECLARE_SHADER_TYPEINFO in the class body
+//   * Declare a public, unique type name (string_view T::Name)
 //   * Be a final class
 template<typename T>
 inline constexpr bool is_shader_v =
@@ -28,9 +28,9 @@ class Shader {
     public:
         virtual ~Shader() = default;
 
-        /// @brief Get the name of this shader
-        /// @return Shader name
-        virtual const std::string_view name() const noexcept = 0;
+        /// @brief Get the type name of this shader
+        /// @return Shader type name
+        virtual const std::string_view typeName() const noexcept = 0;
 
         /// @brief Downcast to a type
         /// @tparam T Derived type
@@ -38,7 +38,7 @@ class Shader {
         template<typename T,
             typename std::enable_if_t<is_shader_v<T>, bool>* = nullptr>
         T* to() noexcept {
-            if (name() != T::Name) {
+            if (typeName() != T::Name) {
                 return nullptr;
             }
             return static_cast<T*>(this);

--- a/include/mbgl/gfx/shader_registry.hpp
+++ b/include/mbgl/gfx/shader_registry.hpp
@@ -36,13 +36,23 @@ class ShaderRegistry {
             const std::string& shaderName) const noexcept;
 
         /// @brief Replace a matching shader in the registry with the provided
-        /// instance. Shader names must match.
+        /// instance. Shader type-names must match.
         /// @param shader A `gfx::Shader`. The ShaderRegistry will take ownership.
         /// @return True if a match was found and the shader was replaced, false
         /// otherwise.
         [[nodiscard]] virtual bool replaceShader(
             std::shared_ptr<Shader>&& shader) noexcept;
 
+        /// @brief Replace a matching shader in the registry with the provided
+        /// instance. Shader type-names must match.
+        /// This variant replaces by explicit name.
+        /// @param shader A `gfx::Shader`. The ShaderRegistry will take ownership.
+        /// @param shaderName Unique name to register the shader under.
+        /// @return True if a match was found and the shader was replaced, false
+        /// otherwise.
+        [[nodiscard]] virtual bool replaceShader(
+            std::shared_ptr<Shader>&& shader, const std::string& shaderName) noexcept;
+            
         /// @brief Register a new shader with the registry. If a shader is present
         /// in the registry with a conflicting name, registration will fail.
         /// @param shader A `gfx::Shader` to register. The ShaderRegistry will
@@ -51,15 +61,41 @@ class ShaderRegistry {
         /// already present with a conflicting name.
         [[nodiscard]] virtual bool registerShader(
             std::shared_ptr<Shader>&& shader) noexcept;
+        
+        /// @brief Register a new shader with the registry. If a shader is present
+        /// in the registry with a conflicting name, registration will fail.
+        /// This variant registers using an explicit name.
+        /// @param shader A `gfx::Shader` to register. The ShaderRegistry will
+        /// take ownership.
+        /// @param shaderName Unique name to register the shader under.
+        /// @return True if the shader was registered, false if another shader is
+        /// already present with a conflicting name.
+        [[nodiscard]] virtual bool registerShader(
+            std::shared_ptr<Shader>&& shader, const std::string& shaderName) noexcept;
 
         /// @brief Shorthand helper to quickly get a derived type from the registry.
+        /// @tparam T Derived type, inheriting `gfx::Shader`
+        /// @param shaderName The registry name to look up
+        /// @return T or nullptr if not found in the registry
+        template<typename T,
+            typename std::enable_if_t<is_shader_v<T>, bool>* = nullptr>
+        std::shared_ptr<T> get(const std::string& shaderName) noexcept {
+            auto shader = getShader(shaderName);
+            if (!shader || shader->typeName() != T::Name) {
+                return nullptr;
+            }
+            return std::static_pointer_cast<T>(shader);
+        }
+
+        /// @brief Shorthand helper to quickly get a derived type from the registry.
+        /// This variant looks up shaders only by type name.
         /// @tparam T Derived type, inheriting `gfx::Shader`
         /// @return T or nullptr if not found in the registry
         template<typename T,
             typename std::enable_if_t<is_shader_v<T>, bool>* = nullptr>
         std::shared_ptr<T> get() noexcept {
             auto shader = getShader(std::string(T::Name));
-            if (!shader || (shader->name() != T::Name)) {
+            if (!shader || shader->typeName() != T::Name) {
                 return nullptr;
             }
             return std::static_pointer_cast<T>(shader);
@@ -67,6 +103,28 @@ class ShaderRegistry {
 
         /// @brief Ensure the destination 'to' is populated with the requested
         /// shader. If already non-null, does nothing.
+        /// @tparam T Derived type, inheriting `gfx::Shader`
+        /// @param to Location to store the shader
+        /// @param shaderName The registry name to look up
+        /// @return True if 'to' has a valid program object, false otherwise.
+        template<typename T,
+            typename std::enable_if_t<is_shader_v<T>, bool>* = nullptr>
+        bool populate(std::shared_ptr<T>& to, const std::string& shaderName) noexcept {
+            if (to) {
+                return true;
+            }
+
+            auto shader = getShader(shaderName);
+            if (!shader || shader->typeName() != T::Name) {
+                return false;
+            }
+            to = std::static_pointer_cast<T>(shader);
+            return true;
+        }
+
+        /// @brief Ensure the destination 'to' is populated with the requested
+        /// shader. If already non-null, does nothing. This variant looks up
+        /// shaders only by type name.
         /// @tparam T Derived type, inheriting `gfx::Shader`
         /// @param to Location to store the shader
         /// @return True if 'to' has a valid program object, false otherwise.
@@ -78,7 +136,7 @@ class ShaderRegistry {
             }
 
             auto shader = getShader(std::string(T::Name));
-            if (!shader || (shader->name() != T::Name)) {
+            if (!shader || shader->typeName() != T::Name) {
                 return false;
             }
             to = std::static_pointer_cast<T>(shader);

--- a/src/mbgl/gfx/shader_registry.cpp
+++ b/src/mbgl/gfx/shader_registry.cpp
@@ -28,26 +28,36 @@ const std::shared_ptr<gfx::Shader> ShaderRegistry::getShader(const std::string& 
 bool ShaderRegistry::replaceShader(
     std::shared_ptr<gfx::Shader>&& shader) noexcept
 {
+    return replaceShader(std::move(shader), std::string{shader->typeName()});
+}
+
+bool ShaderRegistry::replaceShader(std::shared_ptr<Shader>&& shader,
+    const std::string& shaderName) noexcept
+{
     std::unique_lock<std::shared_mutex> writerLock(programLock);
-    const std::string programName{shader->name()}; // TODO: C++ 20 heterogenous lookup
-    if (programs.find(programName) == programs.end()) {
+    if (programs.find(shaderName) == programs.end()) {
         return false;
     }
 
-    programs[programName] = std::move(shader);
+    programs[shaderName] = std::move(shader);
     return true;
 }
 
 bool ShaderRegistry::registerShader(
     std::shared_ptr<gfx::Shader>&& shader) noexcept
 {
+    return registerShader(std::move(shader), std::string{shader->typeName()});
+}
+
+bool ShaderRegistry::registerShader(std::shared_ptr<Shader>&& shader,
+    const std::string& shaderName) noexcept
+{
     std::unique_lock<std::shared_mutex> writerLock(programLock);
-    const std::string programName{shader->name()};
-    if (programs.find(programName) != programs.end()) {
+    if (programs.find(shaderName) != programs.end()) {
         return false;
     }
 
-    programs.emplace(programName, std::move(shader));
+    programs.emplace(shaderName, std::move(shader));
     return true;
 }
 

--- a/src/mbgl/programs/background_program.hpp
+++ b/src/mbgl/programs/background_program.hpp
@@ -50,7 +50,7 @@ class BackgroundProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"BackgroundProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 
@@ -69,7 +69,7 @@ class BackgroundPatternProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"BackgroundPatternProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 

--- a/src/mbgl/programs/circle_program.hpp
+++ b/src/mbgl/programs/circle_program.hpp
@@ -30,7 +30,7 @@ class CircleProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"CircleProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 

--- a/src/mbgl/programs/clipping_mask_program.hpp
+++ b/src/mbgl/programs/clipping_mask_program.hpp
@@ -19,7 +19,7 @@ class ClippingMaskProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"ClippingMaskProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 

--- a/src/mbgl/programs/collision_box_program.hpp
+++ b/src/mbgl/programs/collision_box_program.hpp
@@ -31,7 +31,7 @@ class CollisionBoxProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"CollisionBoxProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 
@@ -129,7 +129,7 @@ class CollisionCircleProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"CollisionCircleProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 

--- a/src/mbgl/programs/debug_program.hpp
+++ b/src/mbgl/programs/debug_program.hpp
@@ -22,7 +22,7 @@ class DebugProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"DebugProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 

--- a/src/mbgl/programs/fill_extrusion_program.hpp
+++ b/src/mbgl/programs/fill_extrusion_program.hpp
@@ -65,7 +65,7 @@ class FillExtrusionProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"FillExtrusionProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 
@@ -107,7 +107,7 @@ class FillExtrusionPatternProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"FillExtrusionPatternProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 

--- a/src/mbgl/programs/fill_program.hpp
+++ b/src/mbgl/programs/fill_program.hpp
@@ -44,7 +44,7 @@ class FillProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"FillProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 
@@ -72,7 +72,7 @@ class FillPatternProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"FillPatternProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 
@@ -98,7 +98,7 @@ class FillOutlineProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"FillOutlineProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 
@@ -117,7 +117,7 @@ class FillOutlinePatternProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"FillOutlinePatternProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 

--- a/src/mbgl/programs/heatmap_program.hpp
+++ b/src/mbgl/programs/heatmap_program.hpp
@@ -28,7 +28,7 @@ class HeatmapProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"HeatmapProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 

--- a/src/mbgl/programs/heatmap_texture_program.hpp
+++ b/src/mbgl/programs/heatmap_texture_program.hpp
@@ -24,7 +24,7 @@ class HeatmapTextureProgram final : public Program<
     style::Properties<>> {
 public:
     static constexpr std::string_view Name{"HeatmapTextureProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 

--- a/src/mbgl/programs/hillshade_prepare_program.hpp
+++ b/src/mbgl/programs/hillshade_prepare_program.hpp
@@ -32,7 +32,7 @@ class HillshadePrepareProgram final : public Program<
     style::Properties<>> {
 public:
     static constexpr std::string_view Name{"HillshadePrepareProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 

--- a/src/mbgl/programs/hillshade_program.hpp
+++ b/src/mbgl/programs/hillshade_program.hpp
@@ -37,7 +37,7 @@ class HillshadeProgram final : public Program<
     style::HillshadePaintProperties>{
 public:
     static constexpr std::string_view Name{"HillshadeProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 

--- a/src/mbgl/programs/line_program.hpp
+++ b/src/mbgl/programs/line_program.hpp
@@ -45,7 +45,7 @@ class LineProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"LineProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 
@@ -120,7 +120,7 @@ class LinePatternProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"LinePatternProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 
@@ -157,7 +157,7 @@ class LineSDFProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"LineSDFProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 
@@ -191,7 +191,7 @@ class LineGradientProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"LineGradientProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 

--- a/src/mbgl/programs/raster_program.hpp
+++ b/src/mbgl/programs/raster_program.hpp
@@ -47,7 +47,7 @@ class RasterProgram final : public Program<
 {
 public:
     static constexpr std::string_view Name{"RasterProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 

--- a/src/mbgl/programs/symbol_program.hpp
+++ b/src/mbgl/programs/symbol_program.hpp
@@ -427,7 +427,7 @@ class SymbolIconProgram final : public SymbolProgram<
 {
 public:
     static constexpr std::string_view Name{"SymbolIconProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 
@@ -511,7 +511,7 @@ class SymbolTextAndIconProgram final
                            style::TextPaintProperties> {
 public:
     static constexpr std::string_view Name{"SymbolTextAndIconProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 
@@ -547,7 +547,7 @@ class SymbolSDFIconProgram final : public SymbolSDFProgram<
 {
 public:
     static constexpr std::string_view Name{"SymbolSDFIconProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 
@@ -561,7 +561,7 @@ class SymbolSDFTextProgram final : public SymbolSDFProgram<
 {
 public:
     static constexpr std::string_view Name{"SymbolSDFTextProgram"};
-    const std::string_view name() const noexcept override {
+    const std::string_view typeName() const noexcept override {
         return Name;
     }
 


### PR DESCRIPTION
This PR introduces support for shader registry names distinct from gfx::Shader-derived type names. This enables registration of many instances of the same shader type, all under different names, to support runtime-configurable shaders.

Adds new tests and changes the type name method `name` to `typeName` to better communicate intent.