### PR TITLE
[qt] Try to reduce number of ccache caches

### DIFF
--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -176,7 +176,8 @@ jobs:
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: ${{ matrix.name }}_${{ matrix.qt_version }}
+          key: Qt_${{ matrix.name }}_${{ matrix.qt_version }}
+          append-timestamp: false
 
       - name: Build maplibre-gl-native (macOS)
         if: runner.os == 'macOS' && matrix.qt_target == 'desktop'


### PR DESCRIPTION
We are running out of cache space very fast. Try to make cache keys less unique for Qt builds as a start to see if this is flexible enough.