### PR TITLE
Remove internal build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1090,19 +1090,11 @@ add_library(
     Mapbox::Map ALIAS mbgl-core
 )
 
-if(MBGL_WITH_PLATFORM_EXTRAS)
-    include(${MBGL_WITH_PLATFORM_EXTRAS})
-endif()
-
 if(MBGL_WITH_CORE_ONLY)
     return()
 endif()
 
 include(${PROJECT_SOURCE_DIR}/scripts/license.cmake)
-
-if(NOT EXISTS ${PROJECT_SOURCE_DIR}/internal/internal.cmake)
-    set(MBGL_PUBLIC_BUILD TRUE)
-endif()
 
 if(MBGL_WITH_QT)
     include(${PROJECT_SOURCE_DIR}/platform/qt/qt.cmake)
@@ -1123,7 +1115,3 @@ endif()
 add_subdirectory(${PROJECT_SOURCE_DIR}/test)
 add_subdirectory(${PROJECT_SOURCE_DIR}/benchmark)
 add_subdirectory(${PROJECT_SOURCE_DIR}/render-test)
-
-if(EXISTS ${PROJECT_SOURCE_DIR}/internal/internal.cmake)
-    include(${PROJECT_SOURCE_DIR}/internal/internal.cmake)
-endif()

--- a/platform/android/android.cmake
+++ b/platform/android/android.cmake
@@ -147,7 +147,7 @@ if(ANDROID_NATIVE_API_LEVEL VERSION_LESS 24)
 else()
     target_sources(
         mbgl-test-runner
-        PRIVATE $<$<BOOL:${MBGL_PUBLIC_BUILD}>:${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/http_file_source.cpp>
+        PRIVATE ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/http_file_source.cpp
     )
 
     include(${PROJECT_SOURCE_DIR}/vendor/curl.cmake)

--- a/platform/ios/ios.cmake
+++ b/platform/ios/ios.cmake
@@ -39,17 +39,11 @@ if(MBGL_WITH_OPENGL)
     )
 endif()
 
-if(MBGL_PUBLIC_BUILD)
-    list(APPEND 
-        PLATFORM_FILES
-            ${PROJECT_SOURCE_DIR}/platform/darwin/src/http_file_source.mm
-    )
-endif()
-
 list(APPEND 
     PLATFORM_FILES
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/async_task.cpp
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/collator.mm
+        ${PROJECT_SOURCE_DIR}/platform/darwin/src/http_file_source.mm
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/image.mm
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/local_glyph_rasterizer.mm
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/logging_nslog.mm

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -23,7 +23,7 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/database_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/file_source_manager.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/file_source_request.cpp
-        $<$<BOOL:${MBGL_PUBLIC_BUILD}>:${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/http_file_source.cpp>
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/http_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/local_file_request.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/local_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/mbtiles_file_source.cpp

--- a/platform/macos/macos.cmake
+++ b/platform/macos/macos.cmake
@@ -35,7 +35,7 @@ target_sources(
     PRIVATE
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/async_task.cpp
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/collator.mm
-        $<$<BOOL:${MBGL_PUBLIC_BUILD}>:${PROJECT_SOURCE_DIR}/platform/darwin/src/http_file_source.mm>
+        ${PROJECT_SOURCE_DIR}/platform/darwin/src/http_file_source.mm
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/image.mm
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/local_glyph_rasterizer.mm
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/logging_nslog.mm

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -101,10 +101,10 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/async_task.cpp
         ${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/async_task_impl.hpp
         ${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/gl_functions.cpp
-        $<$<BOOL:${MBGL_PUBLIC_BUILD}>:${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/http_file_source.cpp>
-        $<$<BOOL:${MBGL_PUBLIC_BUILD}>:${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/http_file_source.hpp>
-        $<$<BOOL:${MBGL_PUBLIC_BUILD}>:${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/http_request.cpp>
-        $<$<BOOL:${MBGL_PUBLIC_BUILD}>:${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/http_request.hpp>
+        ${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/http_file_source.cpp
+        ${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/http_file_source.hpp
+        ${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/http_request.cpp
+        ${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/http_request.hpp
         ${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/image.cpp
         ${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/number_format.cpp
         ${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/local_glyph_rasterizer.cpp

--- a/platform/windows/windows.cmake
+++ b/platform/windows/windows.cmake
@@ -40,7 +40,7 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/database_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/file_source_manager.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/file_source_request.cpp
-        $<$<BOOL:${MBGL_PUBLIC_BUILD}>:${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/http_file_source.cpp>
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/http_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/local_file_request.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/local_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/mbtiles_file_source.cpp


### PR DESCRIPTION
Remove internal build support. I am not sure if we should support it. If clients need it, they can wrap `maplibre-gl-native` repo and override some options.