### PR TITLE
Roll back linux metrics submit along with macos metrics.

### DIFF
--- a/metrics/linux-gcc8-release/render-tests/icon-rotate/with-offset/metrics.json
+++ b/metrics/linux-gcc8-release/render-tests/icon-rotate/with-offset/metrics.json
@@ -13,7 +13,7 @@
     ],
     "gfx": [
         [
-            "probeGFX - default1 - end",
+            "probeGFX - default - end",
             2,
             6,
             12,


### PR DESCRIPTION
fix #1002 

I fix render test in macOS, this Linux metrics should not change, roll it back