### PR TITLE
Wayland Support

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -8,6 +8,7 @@ on:
     tags:
       - 'node-*'
     paths:
+      - "platform/linux/**"
       - "platform/default/**"
       - 'platform/node/**'
       - 'platform/windows/**'
@@ -32,6 +33,7 @@ on:
     branches:
       - main
     paths:
+      - "platform/linux/**"
       - "platform/default/**"
       - 'platform/node/**'
       - 'platform/windows/**'

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -559,9 +559,9 @@ void GLFWView::updateFreeCameraDemo() {
 }
 
 mbgl::Color GLFWView::makeRandomColor() const {
-    const auto r = static_cast<float>(std::rand()) / RAND_MAX;
-    const auto g = static_cast<float>(std::rand()) / RAND_MAX;
-    const auto b = static_cast<float>(std::rand()) / RAND_MAX;
+    const auto r = static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX);
+    const auto g = static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX);
+    const auto b = static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX);
     return { r, g, b, 1.0f };
 }
 

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -1,10 +1,15 @@
+option(MBGL_WITH_X11 "Build with X11 Support" ON)
+option(MBGL_WITH_WAYLAND "Build with Wayland Support" OFF)
+
 find_package(CURL REQUIRED)
 find_package(ICU OPTIONAL_COMPONENTS i18n)
 find_package(ICU OPTIONAL_COMPONENTS uc)
 find_package(JPEG REQUIRED)
 find_package(PNG REQUIRED)
 find_package(PkgConfig REQUIRED)
-find_package(X11 REQUIRED)
+if (MBGL_WITH_X11)
+    find_package(X11 REQUIRED)
+endif ()
 find_package(Threads REQUIRED)
 
 pkg_search_module(LIBUV libuv REQUIRED)
@@ -64,6 +69,13 @@ if(MBGL_WITH_EGL)
         PRIVATE
             OpenGL::EGL
     )
+    if (MBGL_WITH_WAYLAND)
+        target_compile_definitions(mbgl-core PUBLIC
+                EGL_NO_X11
+                MESA_EGL_NO_X11_HEADERS
+                WL_EGL_PLATFORM
+        )
+    endif()
 else()
     find_package(OpenGL REQUIRED GLX)
     target_sources(


### PR DESCRIPTION
To build on Linux pass `-DMBGL_WITH_EGL=ON`

-expects GLFW built for Wayland
-defaults to Wayland over X11