### PR TITLE
Run macOS workflows only on `opengl-2` branch

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - opengl-2
     tags:
       - 'macos-*'
     paths:
@@ -27,6 +28,7 @@ on:
   pull_request:
     branches:
       - main
+      - opengl-2
     paths:
       - 'platform/ios/**'
       - 'platform/darwin/**'
@@ -131,6 +133,7 @@ jobs:
           ctest -VV --test-dir $BUILD_DIR -R mbgl-test-runner
         env:
           BUILD_DIR: ../../../maplibre-gl-native-macostestbuild
+        if: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Check public symbols
         run: make darwin-check-public-symbols

--- a/.github/workflows/node-ci-mac.yml
+++ b/.github/workflows/node-ci-mac.yml
@@ -1,10 +1,15 @@
+# Note: this workflow has been copied from node-ci.yml
+# That workflow runs for main, this one runs for opengl-2 due to
+# the lacking OpenGL ES 3.0 support on macOS.
+# Once the Metal backend is completed this workflow can be removed.
+
 name: node-ci
 
 on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - opengl-2
     tags:
       - 'node-*'
     paths:
@@ -30,7 +35,7 @@ on:
 
   pull_request:
     branches:
-      - main
+      - opengl-2
     paths:
       - "platform/default/**"
       - 'platform/node/**'
@@ -64,12 +69,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-20.04
+          - runs-on: macos-12
             arch: x86_64
-          - runs-on: [self-hosted, linux, ARM64]
+          - runs-on: macos-12-arm
             arch: arm64
-          - runs-on: windows-2022
-            arch: x86_64
     continue-on-error: true
     env:
       BUILDTYPE: 'Release'

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -57,10 +57,13 @@ jobs:
             arch: x86_64
           - runs-on: [self-hosted, linux, ARM64]
             arch: arm64
-          - runs-on: macos-12
-            arch: x86_64
-          - runs-on: macos-12-arm
-            arch: arm64
+          # Disabled until Metal backend is complete
+          # A release for macOS can be made from the opengl-2 branch
+
+          # - runs-on: macos-12
+          #   arch: x86_64
+          # - runs-on: macos-12-arm
+          #   arch: arm64
           - runs-on: windows-2022
             arch: x86_64
     needs: bump_version


### PR DESCRIPTION
Cherry pick to `opengl-2`: Run macOS workflows only on `opengl-2` branch (#1012).