### PR TITLE
Fix render tests failing on Xcode 14.3

### DIFF
--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -118,7 +118,7 @@ Feature::geometry_type convertGeometry(const GeometryTileFeature& geometryTileFe
         double y2 = 180 - (p.y + y0) * 360 / size;
         return Point<double>(
             (p.x + x0) * 360 / size - 180,
-            360.0 / M_PI * std::atan(std::exp(y2 * M_PI / 180)) - 90.0
+            std::atan(std::exp(y2 * M_PI / 180)) * 360.0 / M_PI - 90.0
         );
     };
 


### PR DESCRIPTION
Switched math operations order to fix Xcode 14.3 issue which generates some render tests to fail on iOS.

Fixed 27 failing tests, 1 remaining.