### PR TITLE
Remove Mapbox::Base::optional dependency from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1059,7 +1059,6 @@ target_link_libraries(
         Mapbox::Base::Extras::rapidjson
         Mapbox::Base::geojson.hpp
         Mapbox::Base::geometry.hpp
-        Mapbox::Base::optional
         Mapbox::Base::variant
 )
 


### PR DESCRIPTION
We moved to std::optional some time ago and this is no longer needed.