### PR TITLE
Upload Linux render tests in separate unprivileged workflow

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -13,11 +13,6 @@ on:
       - "CMakeLists.txt"
       - metrics/linux-gcc8-release-style.json
 
-# https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
-permissions:
-  id-token: write # This is required for requesting the JWT (AWS)
-  contents: read  # This is required for actions/checkout (AWS)
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # INFO: We are cancelling the concurrency group if the change is on PR. For workflow dispatch, this will not work.
@@ -121,27 +116,8 @@ jobs:
         id: render_test
         run: xvfb-run -a ./mbgl-render-test-runner --manifestPath=metrics/linux-gcc8-release-style.json
 
-      - name: Configure AWS Credentials
-        if: ${{ steps.render_test.outcome == 'failure' }}
-        uses: aws-actions/configure-aws-credentials@v2
+      - name: Upload render test result
+        uses: actions/upload-artifact@v3
         with:
-          aws-region: us-west-2
-          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ github.run_id	}}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      
-      - name: Upload render test results to S3
-        if: ${{ steps.render_test.outcome == 'failure' }}
-        id: upload_render_test_results
-        run: |
-          aws s3 cp metrics/linux-gcc8-release-style.html \
-            s3://maplibre-native-test-artifacts/${{ github.run_id	}}-linux-gcc8-release-style.html \
-            --expires "$(date -d '+30 days' --utc +'%Y-%m-%dT%H:%M:%SZ')
-
-      - name: Make comment with test results
-        if: ${{ steps.upload_render_test_results.outcome == 'success' }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: |
-            Test results at https://maplibre-native-test-artifacts.s3.eu-central-1.amazonaws.com/${{ github.run_id }}-linux-gcc8-release-style.html
+          name: render-test-result
+          path: metrics/linux-gcc8-release-style.html

--- a/.github/workflows/upload-render-test-results.yml
+++ b/.github/workflows/upload-render-test-results.yml
@@ -1,0 +1,66 @@
+name: upload-render-test-results
+
+on:
+  workflow_run:
+    workflows: [linux-ci]
+    types:
+      - completed
+
+jobs:
+  upload-render-test-results:
+    runs-on: ubuntu-22.04
+    if: ${{ github.event.workflow_run.pull_requests.length === 1 }}
+    steps:
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
+      - name: 'Download render-test-result artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "render-test-result"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/render-test-result.zip`, Buffer.from(download.data));
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id	}}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: 'Unzip render-test-result artifact'
+        run: unzip render-test-result.zip
+
+      - name: Upload render test results to S3
+        id: upload_render_test_results
+        run: |
+          aws s3 cp linux-gcc8-release-style.html \
+            s3://maplibre-native-test-artifacts/${{ github.run_id	}}-linux-gcc8-release-style.html \
+            --expires "$(date -d '+30 days' --utc +'%Y-%m-%dT%H:%M:%SZ')
+
+      - name: 'Leave comment on PR with test results'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let fs = require('fs');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number:  context.payload.workflow_run.pull_requests[0].number,
+              body: `Test results at https://maplibre-native-test-artifacts.s3.eu-central-1.amazonaws.com/${context.runId}-linux-gcc8-release-style.html`
+            });


### PR DESCRIPTION
Second attempt to upload the render test results of the `linux-ci` workflow, which needs to happen in a privileged workflow.

Instead of doing it in the same workflow with a `pull_request_target` event trigger, which cannot really be made secure, I use a separate workflow with the `workflow_run` event.

I based my implementation on the GitHub workflow docs. It's not easy to debug, I don't think I got it right in one go. https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
