### PR TITLE
Rename MapLibre GL Native -> MapLibre Native

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: true
 contact_links:
   - name: "🙏 Q&A - GitHub Discussions"
     url: https://github.com/maplibre/maplibre-gl-native/discussions/categories/q-a
-    about: If you have a question about using MapLibre GL Native
+    about: If you have a question about using MapLibre Native
   - name: "💬 Chat with us on Slack"
     url: https://slack.openstreetmap.us/
     about: "Join #maplibre-native on the Open Street Map Slack"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,8 @@
-This document aims to outline at a high level the various parts that make up MapLibre GL Native and how they work together.
+This document aims to outline at a high level the various parts that make up MapLibre Native and how they work together.
 
 # Repository structure
 
-MapLibre GL Native uses a monolithic repository that houses both core C++ code and code that wraps the C++ core with SDKs for Android, iOS, macOS, Node.js, and Qt. A "monorepo" allows us to:
+MapLibre Native uses a monolithic repository that houses both core C++ code and code that wraps the C++ core with SDKs for Android, iOS, macOS, Node.js, and Qt. A "monorepo" allows us to:
 
  * Make changes to the core API and SDKs simultaneously, ensuring no platform falls behind.
  * Ensure that core changes do not inadvertently break SDK tests.
@@ -38,7 +38,7 @@ Code and build scripts belonging to platform SDKs are contained in the `platform
 
 # Build system
 
-The MapLibre GL Native build system uses a variety of tools.
+The MapLibre Native build system uses a variety of tools.
 
 ## Make
 
@@ -50,17 +50,17 @@ Git submodules are used to pull in several dependencies: mason (see below) and s
 
 ## npm
 
-npm is a package manager for Node.js. MapLibre GL Native uses it to pull in several development dependencies that happen to be packaged as node modules -- mainly for testing needs.
+npm is a package manager for Node.js. MapLibre Native uses it to pull in several development dependencies that happen to be packaged as node modules -- mainly for testing needs.
 
 ## Mason
 
-[Mason](https://github.com/mapbox/mason) is Mapbox's own cross platform C/C++ package manager. MapLibre GL Native uses mason packages as a source of precompiled binaries for third-party dependencies such as Boost, RapidJSON, and SQLite, and Mapbox's own C++ modules such as [earcut.hpp](https://github.com/mapbox/earcut.hpp) and [geojson-vt-cpp](https://github.com/mapbox/geojson-vt-cpp). It is also used to obtain a toolchain for Android platform cross-compiliation.
+[Mason](https://github.com/mapbox/mason) is Mapbox's own cross platform C/C++ package manager. MapLibre Native uses mason packages as a source of precompiled binaries for third-party dependencies such as Boost, RapidJSON, and SQLite, and Mapbox's own C++ modules such as [earcut.hpp](https://github.com/mapbox/earcut.hpp) and [geojson-vt-cpp](https://github.com/mapbox/geojson-vt-cpp). It is also used to obtain a toolchain for Android platform cross-compiliation.
 
 We track mason dependencies for a given platform in the file `platform/<platform>/scripts/configure.sh`. The `configure` script at the root handles sourcing this file during the build, running the appropriate mason commands, and writing configuration settings for the subsequent build to a `config.gypi` in the build output directory.
 
 ## gyp
 
-[gyp](https://gyp.gsrc.io/) is a build system originally created for Chromium and since adopted by Node.js. In MapLibre GL Native it's used to build the core C++ static library, the Node.js platform module, and the shared JNI module for Android.
+[gyp](https://gyp.gsrc.io/) is a build system originally created for Chromium and since adopted by Node.js. In MapLibre Native it's used to build the core C++ static library, the Node.js platform module, and the shared JNI module for Android.
 
 ## Platform-specific subsystems
 
@@ -77,9 +77,9 @@ See the relevant platform-specific `README.md` / `INSTALL.md` for details.
 ## Map
 ## Style
 
-The "Style" component of MapLibre GL Native contains an implementation of the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/), defining what data to draw, the order to draw it in, and how to style the data when drawing it.
+The "Style" component of MapLibre Native contains an implementation of the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/), defining what data to draw, the order to draw it in, and how to style the data when drawing it.
 
-In addition to supporting styles loaded from a URL, MapLibre GL Native includes a runtime styling API, which allows users to dynamically modify the current style: add and remove layers, modify layer properties, and so on. As appropriate for a C++ API, the runtime styling API API is _strongly typed_: there are subclasses for each layer type, with correctly-typed accessors for each style property. This results in a large API surface area. Fortunately, this is automated, by generating the API – and the regular portion of the implementation – from the style specification.
+In addition to supporting styles loaded from a URL, MapLibre Native includes a runtime styling API, which allows users to dynamically modify the current style: add and remove layers, modify layer properties, and so on. As appropriate for a C++ API, the runtime styling API API is _strongly typed_: there are subclasses for each layer type, with correctly-typed accessors for each style property. This results in a large API surface area. Fortunately, this is automated, by generating the API – and the regular portion of the implementation – from the style specification.
 
 The layers API makes a distinction between public API and internal implementation using [the `Impl` idiom](https://github.com/mapbox/mapbox-gl-native/issues/3254) seen elsewhere in the codebase. Here, it takes the form of parallel class hierarchies:
 
@@ -132,7 +132,7 @@ One final benefit of this approach of diffing immutable objects: we get "smart" 
 
 # Threading
 
-At runtime, MapLibre GL Native uses the following threads:
+At runtime, MapLibre Native uses the following threads:
 
 * The "main thread" (or other thread on which a `Map` object is created) handles direct `Map` API requests, owns the active `Style` and its associated objects, and renders the map. Since this thread is usually dispatching events triggered by user input, it's important that these duties not require significant computation or perform blocking I/O that would cause UI jank or hangs.
 * Many of the tasks that require significant computation are associated with layout and styling of map features: parsing vector tiles, computing text layout, and generating data buffers to be consumed by OpenGL. This work happens on "worker threads" that are spawned by the main thread, four per `Style` object. The `Style` and its associated objects handle dispatching tasks to the workers, typically on a tile-by-tile basis.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Documentation
 
-- For a high-level overview of MapLibre GL Native, check out the [MapLibre GL Native Markdown Book](https://maplibre.org/maplibre-gl-native/docs/book/).
+- For a high-level overview of MapLibre Native, check out the [MapLibre Native Markdown Book](https://maplibre.org/maplibre-gl-native/docs/book/).
 - See [`DEVELOPING.md`](DEVELOPING.md) for getting started with development.
 
 ## Source code checkout
@@ -13,7 +13,7 @@ git clone --recurse-submodules https://github.com/maplibre/maplibre-gl-native.gi
 
 ## Building
 
-MapLibre GL Native shares a single C++ core library with all platforms. To build it, we utilize CMake.
+MapLibre Native shares a single C++ core library with all platforms. To build it, we utilize CMake.
 
 To build, run the following from the root directory
 ```bash
@@ -37,11 +37,11 @@ If you want to contribute code:
 
 4. Prefix your commit messages with the platform(s) your changes affect, e.g. `[ios]`.
 
-Please note the special instructions for contributing new source code files, asset files, or user-facing strings to MapLibre GL Native for [iOS](platform/ios/CONTRIBUTING.md), [Android](platform/android/DEVELOPING.md) or [macOS](platform/ios/platform/macos/DEVELOPING.md).
+Please note the special instructions for contributing new source code files, asset files, or user-facing strings to MapLibre Native for [iOS](platform/ios/CONTRIBUTING.md), [Android](platform/android/DEVELOPING.md) or [macOS](platform/ios/platform/macos/DEVELOPING.md).
 
 ## Design Proposals
 
-If you would like to change MapLibre GL Native in a substantial way, we recommend that you write a Design Proposal. Examples for substantial changes could be if you would like to split the mono-repo or if you would like to introduce shaders written in Metal.
+If you would like to change MapLibre Native in a substantial way, we recommend that you write a Design Proposal. Examples for substantial changes could be if you would like to split the mono-repo or if you would like to introduce shaders written in Metal.
 
 The purpose of a Design Proposal is to collectively think through a problem before starting to implement a solution. Every implementation has advantages and disadvantages. We can discuss them in a Design Proposal, and once we reach an agreement, we follow the guidelines in the Design Proposal and work on the implementation.
 

--- a/FORK.md
+++ b/FORK.md
@@ -1,6 +1,6 @@
 # Fork
 
-MapLibre GL Native is a community led fork derived from [mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native) prior to their switch to a non-OSS license. The fork also includes Maps SDK for iOS and MacOS (forked from [mapbox-gl-native-ios](https://github.com/mapbox/mapbox-gl-native-ios)) and Android SDK (forked from [mapbox-gl-native-android](https://github.com/mapbox/mapbox-gl-native-android)). These platform-specific SDKs were merged under platform directory and they reference mapbox-gl-native directly, not as a submodule.
+MapLibre Native is a community led fork derived from [mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native) prior to their switch to a non-OSS license. The fork also includes Maps SDK for iOS and MacOS (forked from [mapbox-gl-native-ios](https://github.com/mapbox/mapbox-gl-native-ios)) and Android SDK (forked from [mapbox-gl-native-android](https://github.com/mapbox/mapbox-gl-native-android)). These platform-specific SDKs were merged under platform directory and they reference mapbox-gl-native directly, not as a submodule.
 
 Beside merging in platform specific SDKs, the following changes were made compared to original mapbox projects:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![MapLibre Logo](https://maplibre.org/img/maplibre-logo-big.svg)](https://maplibre.org/)
 
-# MapLibre GL Native
+# MapLibre Native
 
-MapLibre GL Native is a free and open-source library for publishing maps in your apps and desktop applications on various platforms. Fast displaying of maps is possible thanks to GPU-accelerated vector tile rendering.
+MapLibre Native is a free and open-source library for publishing maps in your apps and desktop applications on various platforms. Fast displaying of maps is possible thanks to GPU-accelerated vector tile rendering.
 
 This project originated as a fork of Mapbox GL Native, before their switch to a non-OSS license in December 2020. For more information, see: [`FORK.md`](./FORK.md).
 
@@ -12,11 +12,11 @@ This project originated as a fork of Mapbox GL Native, before their switch to a 
 
 ## Getting Started
 
-To get started with MapLibre GL Native, go to your platform below.
+To get started with MapLibre Native, go to your platform below.
 
 ## Documentation
 
-The documentation of MapLibre GL Native is a work in progress. To get an architectural overview and to learn about the current state of the project and its path forward read the [MapLibre GL Native Markdown Book](https://maplibre.org/maplibre-gl-native/docs/book/). See below for platform-specific documentation.
+The documentation of MapLibre Native is a work in progress. To get an architectural overview and to learn about the current state of the project and its path forward read the [MapLibre Native Markdown Book](https://maplibre.org/maplibre-gl-native/docs/book/). See below for platform-specific documentation.
 
 ## Platforms
 
@@ -35,7 +35,7 @@ Platforms with a ⭐️ are **MapLibre Core Projects** and have a substantial am
 
 ![image-metal](https://user-images.githubusercontent.com/53421382/214308933-66cd4efb-b5a5-4de3-b4b4-7ed59045a1c3.png)
 
-MapLibre GL Native is being actively developed. Our big goal for 2023 is to modularize the OpenGL renderer and implement a Metal graphics backend (https://developer.apple.com/metal/). This will improve the performance and yield lower power consumption on iOS devices. At the same time, the Metal preparations will help us in the implementation of a Vulkan graphics backend.
+MapLibre Native is being actively developed. Our big goal for 2023 is to modularize the OpenGL renderer and implement a Metal graphics backend (https://developer.apple.com/metal/). This will improve the performance and yield lower power consumption on iOS devices. At the same time, the Metal preparations will help us in the implementation of a Vulkan graphics backend.
 
 Your help in preparing the codebase for the latest graphics backends is more than welcome. Feel free to reach out if you are interested in joining the effort!
 
@@ -44,7 +44,7 @@ Your help in preparing the codebase for the latest graphics backends is more tha
 
 ## Contributing
 
-To contribute to MapLibre GL Native, see [`CONTRIBUTING.md`](CONTRIBUTING.md) and (if applicable) the specific instructions for the platform you want to contribute to.
+To contribute to MapLibre Native, see [`CONTRIBUTING.md`](CONTRIBUTING.md) and (if applicable) the specific instructions for the platform you want to contribute to.
 
 ### Getting Involved
 
@@ -78,4 +78,4 @@ Backers and Supporters:
 
 ## License
 
-**MapLibre GL Native** is licensed under the [BSD 2-Clause License](./LICENSE.md).
+**MapLibre Native** is licensed under the [BSD 2-Clause License](./LICENSE.md).

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -42,7 +42,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "MapLibre GL Native Core"
+PROJECT_NAME           = "MapLibre Native Core"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/docs/doxygen/MAINPAGE.md
+++ b/docs/doxygen/MAINPAGE.md
@@ -1,5 +1,5 @@
-# MapLibre GL Native Core Documentation
+# MapLibre Native Core Documentation
 
-This is the documentation of the public C++ API of MapLibre GL Native Core. You would normally only use this API if you are a contributor to one of the platform specific APIs. If you want to intergrate use MapLibre GL Native in your project, you are better served by [documentation specific to your platform](https://maplibre.org/projects/maplibre-native/), unless you are interested in the internals of MapLibre GL Native.
+This is the documentation of the public C++ API of MapLibre Native Core. You would normally only use this API if you are a contributor to one of the platform specific APIs. If you want to intergrate use MapLibre Native in your project, you are better served by [documentation specific to your platform](https://maplibre.org/projects/maplibre-native/), unless you are interested in the internals of MapLibre Native.
 
 The source code can be found [on GitHub](https://github.com/maplibre/maplibre-gl-native) (the `include` directory contains the public API).

--- a/docs/doxygen/README.md
+++ b/docs/doxygen/README.md
@@ -1,6 +1,6 @@
 # Doxygen documentation
 
-This directory contains the files needed to generate the documentation of MapLibre GL Native Core using [Doxygen](https://www.doxygen.nl).
+This directory contains the files needed to generate the documentation of MapLibre Native Core using [Doxygen](https://www.doxygen.nl).
 
 [Doxygen Awesome](https://jothepro.github.io/doxygen-awesome-css/index.html) is used as a theme and is included as a submodule. To update, simply check out a new version of the submodule.
 

--- a/docs/mdbook/README.md
+++ b/docs/mdbook/README.md
@@ -1,4 +1,4 @@
-# MapLibre GL Native Docs
+# MapLibre Native Docs
 
 ## Build Locally
 

--- a/docs/mdbook/book.toml
+++ b/docs/mdbook/book.toml
@@ -3,7 +3,7 @@ authors = ["MapLibre Contributors"]
 language = "en"
 multilingual = false
 src = "src"
-title = "MapLibre GL Native Documentation"
+title = "MapLibre Native Documentation"
 
 [output.html]
 additional-css = ["diff.css"]

--- a/docs/mdbook/src/SUMMARY.md
+++ b/docs/mdbook/src/SUMMARY.md
@@ -1,4 +1,4 @@
-# MapLibre GL Native Documentation
+# MapLibre Native Documentation
 
 [Introduction](./introduction.md)
 
@@ -10,5 +10,5 @@
     - [Android Map Rendering Data Flow](design/android-map-rendering-data-flow.md)
     - [Geometry Tile Worker](design/geometry-tile-worker.md)
 
-- [MapLibre GL Native for Android](./android/README.md)
+- [MapLibre Native for Android](./android/README.md)
     - [Quickstart](./android/getting-started-guide.md)

--- a/docs/mdbook/src/android/README.md
+++ b/docs/mdbook/src/android/README.md
@@ -1,3 +1,3 @@
-# MapLibre GL Native for Android
+# MapLibre Native for Android
 
-MapLibre GL Native for Android is a library for embedding interactive map views with scalable, customizable vector maps onto Android devices.
+MapLibre Native for Android is a library for embedding interactive map views with scalable, customizable vector maps onto Android devices.

--- a/docs/mdbook/src/android/getting-started-guide.md
+++ b/docs/mdbook/src/android/getting-started-guide.md
@@ -11,7 +11,7 @@
     }
     ```
 
-2. Add the library as a dependency into your module Gradle file (usually `<project>/<app-module>/build.gradle`). Replace `<version>` with the latest MapLibre GL Native version (e.g.: `org.maplibre.gl:android-sdk:10.0.2`). Visit [https://mvnrepository.com/artifact/org.maplibre.gl/android-sdk](https://mvnrepository.com/artifact/org.maplibre.gl/android-sdk) to view the version history of MapLibre GL Native for android. 
+2. Add the library as a dependency into your module Gradle file (usually `<project>/<app-module>/build.gradle`). Replace `<version>` with the latest MapLibre Native version (e.g.: `org.maplibre.gl:android-sdk:10.0.2`). Visit [https://mvnrepository.com/artifact/org.maplibre.gl/android-sdk](https://mvnrepository.com/artifact/org.maplibre.gl/android-sdk) to view the version history of MapLibre Native for android. 
 
     ```gradle
     dependencies {

--- a/docs/mdbook/src/design/README.md
+++ b/docs/mdbook/src/design/README.md
@@ -1,3 +1,3 @@
 # Design
 
-This section is dedicated to documenting current state of MapLibre GL Native. [Architectural Problems and Recommendations](./archictural-problems-and-recommendations.md) section notes recommendations for future improvements from an architectural perspective.
+This section is dedicated to documenting current state of MapLibre Native. [Architectural Problems and Recommendations](./archictural-problems-and-recommendations.md) section notes recommendations for future improvements from an architectural perspective.

--- a/docs/mdbook/src/design/android-map-rendering-data-flow.md
+++ b/docs/mdbook/src/design/android-map-rendering-data-flow.md
@@ -6,7 +6,7 @@
 Figure 5 shows a simplified data flow diagram of initializing a map. The
 device section of this data flow diagram is based on Android platform.
 
-Before the map initialization request makes it to MapLibre GL Native
+Before the map initialization request makes it to MapLibre Native
 Core, the request initializes a set of peer components in the platform
 or device runtime. Especially for Android, we have parts written in C++
 using *Android Native Development Kit* and parts written in Java.
@@ -25,13 +25,13 @@ the generic Map Component. For Android, this maintains the JNI method
 contract established from the Java runtime. The render thread this
 document talked about before is seen in the form of *MapRenderer*. This
 is an Actor that passes the rendering events from the device runtime to
-*MapLibre GL Native* renderer.
+*MapLibre Native* renderer.
 
 ![](media/workflow-of-rendering-tiles.jpg)    
 *Figure 6: Workflow of rendering tiles*
 
 Before the frame-by-frame map rendering
-starts with *MapLibre GL Native* renderer, the generic map component
+starts with *MapLibre Native* renderer, the generic map component
 gets initialized. Rendering each frame of a map tile or initializing the
 map view requires a set of *Transforms.* Through transform basic
 mutations like rotation, tilt, projection is accomplished. Transforms
@@ -46,7 +46,7 @@ like other components inside MapLibre works as a state machine. The
 to the map. To simplify to change the camera orientation, zoom, or pitch
 a Map View will update the state of the Transform class. And the
 Transform class will use observers to send a transform event to
-*MapLibre GL Native* renderer. This overall transform directive, such as
+*MapLibre Native* renderer. This overall transform directive, such as
 change camera location from point A to point B will translate to a set
 of transformations deduced by the *Renderer* component.
 
@@ -70,10 +70,10 @@ rendering, MapLibre Native GL only renders *dirty* tiles. A dirty tile
 is a tile rendered in the viewport that has changed due to user
 interaction. To initiate this process, MapLibre Native GL loads the
 tileset to be rendered first. In a rendering request, if the tileset is
-already loaded, MapLibre GL Native will use a cached tile set.
+already loaded, MapLibre Native will use a cached tile set.
 
 The next decision to make here is which tiles are to be rendered on the
-viewport. To deduce this, MapLibre GL Native translates the device
+viewport. To deduce this, MapLibre Native translates the device
 viewport coordinates[^20] to a tile cover. A tile cover loads all the
 tiles that will rendered to current viewport. If the viewport already
 has all the tiles that is needed to be rendered by the deduced tile

--- a/docs/mdbook/src/design/archictural-problems-and-recommendations.md
+++ b/docs/mdbook/src/design/archictural-problems-and-recommendations.md
@@ -2,7 +2,7 @@
 
 Up until now, this document focused solely on the state of MapLibre GL
 Native at the time of writing. This section speaks of possible future
-improvements for MapLibre GL Native from an architectural point of view.
+improvements for MapLibre Native from an architectural point of view.
 Before that, let's look into the architectural challenges MapLibre GL
 Native is facing[^18]:
 
@@ -21,37 +21,37 @@ Native does not have a clear separation between the following:
 
 The current rendering loop is only implemented for OpenGL. In 2018,
 Apple deprecated OpenGL for both iOS 12 and macOS in favour of Metal.
-Metal is Apple's own 3D graphics API. MapLibre GL Native's sole
+Metal is Apple's own 3D graphics API. MapLibre Native's sole
 dependency on OpenGL ES puts it in a risk of deprecation for iOS
 customers.
 
 ## Lack of support for other map projections except Web Mercator
 
-MapLibre GL Native supports Web Mercator (EPSG:3857) as its only
+MapLibre Native supports Web Mercator (EPSG:3857) as its only
 supported projection. This fulfills most of the web and device map
 needs. At the time of writing, modern map renderers such as Google Maps
 and Mapbox GL offers 3D globe, conic, and rectangular projections too.
-At the time of writing, MapLibre GL Native renderer component does not
+At the time of writing, MapLibre Native renderer component does not
 have an architectural separation for supporting multiple projections and
 coordinate reference systems.
 
 ## Inconsistency among platforms
 
-Each MapLibre GL Native platform has a Map View and Map Renderer
+Each MapLibre Native platform has a Map View and Map Renderer
 component. The inconsistency introduced due to differences in
 concurrency model and programming language is unavoidable. But from an
 abstractions point of view there are inconsistencies that can be
 mitigated:
 
-1.  Map Configuration is modeled inside MapLibre GL Native Core, the
+1.  Map Configuration is modeled inside MapLibre Native Core, the
     shared cross platform codebase. Each platform creates its own
     configuration class and creates a shadow native object. The native
     configuration object is consistent across platforms but the platform
     specific configuration is not.
 
-2.  MapLibre GL Native has a sister repository named MapLibre GL JS. At
+2.  MapLibre Native has a sister repository named MapLibre GL JS. At
     the time of writing, MapLibre GL JS does not share any code with
-    MapLibre GL Native except shaders, the style specification, and
+    MapLibre Native except shaders, the style specification, and
     render test fixtures. This creates a feature inconsistency across
     web and device experience for customers. The rendering architecture
     is also different between Web and Mobile. MapLibre GL JS currently
@@ -66,11 +66,11 @@ mitigated:
     ChromeOS, macOS, and Windows 10. Technically, it can be used with
     Android and iOS but these platforms do not provide out of the box
     support for it. This also has created a divergent experience for
-    customers when it comes to using MapLibre GL Native.
+    customers when it comes to using MapLibre Native.
 
 ## Lack of documentation
 
-Last but not the least, MapLibre GL Native suffers from a general lack
+Last but not the least, MapLibre Native suffers from a general lack
 of documentation. This includes current state of the code architecture,
 continuous integration and development, testing strategy, and a roadmap
 for future improvement. This document intends to address the first.
@@ -81,9 +81,9 @@ This document proposes the following component architecture for MapLibre
 GL Native to address the architectural shortcomings.
 
 ![](media/proposed-architecture-of-maplibre-gl.png)    
-*Figure 4: Proposed Architecture of MapLibre GL Native*
+*Figure 4: Proposed Architecture of MapLibre Native*
 
-Proposed architecture of MapLibre GL Native in Figure 4 addresses the 
+Proposed architecture of MapLibre Native in Figure 4 addresses the 
 aforementioned problems by:
 
 #### Modular Rendering
@@ -112,7 +112,7 @@ native device coordinates.
 
 One example of introducing new component is supporting 3D maps in the
 future. This could mean rendering map tiles on a spherical globe instead
-of a flat 3D plane. At the time of writing MapLibre GL Native supports
+of a flat 3D plane. At the time of writing MapLibre Native supports
 2.5D extrusion for buildings and terrain tiles. Supporting confidential
 datums like *GCJ-02* can also be achieved through this.
 
@@ -132,7 +132,7 @@ interoperability with Rust, this document proposes the following to be
 done in sequence:
 
 1.  At first, this document proposes to implement ***Modularized
-    Rendering*** in C++ for MapLibre GL Native. This document also
+    Rendering*** in C++ for MapLibre Native. This document also
     proposes that Unified Rendering Interface will keep the door open
     for a *WebGPU* backed renderer in MapLibre Rust. This will address
     the divergence of web and native platforms in the future. The Rust
@@ -146,7 +146,7 @@ done in sequence:
 
 3.  Finally, this document proposes to migrate Unified Rendering
     Interface and its implementations to Rust. This will completely
-    transform MapLibre GL Native from a C++ ecosystem to a Rust
+    transform MapLibre Native from a C++ ecosystem to a Rust
     ecosystem.
 
 Following the above steps will merge towards a single MapLibre
@@ -155,7 +155,7 @@ implementation for web and native.
 ____________________________
 
 [^18]: This document deliberately does not speak of problems regarding
-    build and infrastructure of MapLibre GL Native. They will be handled
+    build and infrastructure of MapLibre Native. They will be handled
     in individual design PR requests / documents.
 
 [^19]: Rust Foreign Function Interface allows interop bindings and code

--- a/docs/mdbook/src/design/coordinate-system.md
+++ b/docs/mdbook/src/design/coordinate-system.md
@@ -24,7 +24,7 @@ which we all live in and make map tiles for. This document uses the word
 *World* to denote the world MapLibre Native GL renders. The word *world*
 in rendering terms mean the *world* to render. It could be a set of
 cones and boxes, a modeled city, anything composed of 3D objects.
-MapLibre GL Native renders map tiles in a range of zoom levels on a 3D
+MapLibre Native renders map tiles in a range of zoom levels on a 3D
 plane. Map tiles are already produced from a WGS84 ellipsoid. Therefore,
 when this document uses the word *World,* it means the 3D plane
 containing a set of map tiles to be rendered, not the *Earth*.
@@ -57,7 +57,7 @@ a bit. To render anything through a GPU:
 4.  Finally, the *World Space* is transformed to device screen by
     applying viewport transform matrix.
 
-Going forward, scoping our discussion only to MapLibre GL Native, we
+Going forward, scoping our discussion only to MapLibre Native, we
 will talk mostly about two categories of coordinate systems:
 
 1.  World Coordinates
@@ -98,7 +98,7 @@ Projections are used to translate WGS84 coordinates to a plane. To be
 specific, projections are used to translate a location on the ellipsoid
 to a two-dimensional square. EPSG:3857[^11] or projected
 *Pseudo-Mercator Coordinate System* is such a coordinate system.
-EPSG:3857 is used by MapLibre GL Native as a default coordinate system
+EPSG:3857 is used by MapLibre Native as a default coordinate system
 to display maps. This system takes WGS84 coordinates and projects them
 into sphere. This stretches out the landmass in the hemispheres but
 mathematically makes it simpler to project a location back to a 2D
@@ -179,7 +179,7 @@ tile's X, Y, and Z.
 To reach our goal of translating a location to a coordinate inside a
 tile, we need to know what is the *extent* of the tile. MapLibre GL
 Native follows Mapbox Vector Tile (MVT) spec. Following said spec,
-MapLibre GL Native internally normalizes each tile to an *extent* of
+MapLibre Native internally normalizes each tile to an *extent* of
 8192. Tile extent describes the width and height of the tile in integer
 coordinates. This means a tile coordinate can have higher precision than
 a pixel. Because normally a tile has a height and width of 512 pixels.
@@ -219,9 +219,9 @@ positioned on the top left.
 
 ## Device Coordinates
 
-World space for MapLibre GL Native contains a plane in 3D with all the
+World space for MapLibre Native contains a plane in 3D with all the
 tiles for any specific zoom level. Map tiles are hierarchical in nature.
-As in they have different zoom levels. MapLibre GL Native internally
+As in they have different zoom levels. MapLibre Native internally
 stores a tree object that mimics a tile pyramid. However, it does not
 create a hierarchy of 3D planes where each plane mimics one zoom level.
 It reuses the same 3D plane to re-render the tiles in the requested zoom
@@ -232,7 +232,7 @@ world space starts with *View Matrix*, as defined in the world space.
 The key part here is the *camera*. A *view matrix* is a matrix that
 scales, rotates, and translates[^14] the world space from the view of
 the camera. To add the perspective of the camera, we apply the
-*Projection Matrix*. In MapLibre GL Native, a camera initialization
+*Projection Matrix*. In MapLibre Native, a camera initialization
 requires map center, bearing, and pitch.
 
 *Initializing the map with a center (lon, lat) does not translate or
@@ -250,7 +250,7 @@ Once a tile is built, the GPU can quickly draw the same tile with different
 bearing, pan, pitch, and zoom parameters[^15].
 
 If we keep following Figure 2, we see we need to also add a projection
-matrix. And MapLibre GL Native uses a *perspective projection*.
+matrix. And MapLibre Native uses a *perspective projection*.
 Perspective projection matrix introduces the sense of depth perspective
 through the camera. As in objects further from the camera will look
 smaller and objects closer to the camera will look bigger. This
@@ -271,7 +271,7 @@ pitch: 45 degrees
 tile: 585/783/11
 ```
 
-On top of this, MapLibre GL Native uses a field of view of 36.87 degrees
+On top of this, MapLibre Native uses a field of view of 36.87 degrees
 or 0.6435011087932844 radians. This is somewhat arbitrary. The altitude
 of the camera used to be defined as 1.5 screen heights above the ground.
 The ground is the 3D plane that paints the map tiles. The field of view
@@ -322,7 +322,7 @@ with perspective component *w*.
 ```
 
 Doing this will take us into *clip space.* Clip coordinates contain all
-the tile coordinates we wish to render in MapLibre GL Native but only in
+the tile coordinates we wish to render in MapLibre Native but only in
 a normalized coordinate space of `[-1.0, 1.0]`.
 
 All that is left now is to translate this to viewport coordinates.
@@ -351,7 +351,7 @@ _________________________
 
 [^11]: There are other coordinate systems such as EPSG:54001 that uses
     equirectangles over squares to project the WGS84 coordinates. This
-    document focuses on EPSG:3857 because MapLibre GL Native uses it by
+    document focuses on EPSG:3857 because MapLibre Native uses it by
     default.
 
 [^12]: This document scopes out the trigonometric proof of this
@@ -369,7 +369,7 @@ _________________________
     so order of operation matters.
 
 [^15]: The piece of code we run on GPU is called a shader. We will see
-    more how shaders influence MapLibre GL Native rendering later in the
+    more how shaders influence MapLibre Native rendering later in the
     document.
 
 [^16]: Matrix and examples produced from Chris Loers work hosted in:

--- a/docs/mdbook/src/design/expressions.md
+++ b/docs/mdbook/src/design/expressions.md
@@ -77,7 +77,7 @@ implementation evaluates both inputs because they are expressions too.
 Expressions can be nested.
 
 **Although it looks like JavaScript, for MapLibre Native GL**, **the
-parser for any expression is written in MapLibre GL Native Core**. Each
+parser for any expression is written in MapLibre Native Core**. Each
 platform such as iOS, Android has their own Expression class which
 provides builders to build an expression and add it to a layer. When an
 expression is added to a layer, the rendering part of the code picks it
@@ -146,8 +146,8 @@ fillLayer.setProperties(
 );
 ```
 
-**To render the built expression, MapLibre GL Native uses expression
-parsers.** **Expression parsers are written in MapLibre GL Native Core
+**To render the built expression, MapLibre Native uses expression
+parsers.** **Expression parsers are written in MapLibre Native Core
 (in C++).** Each expression outputs an *EvaluationResult* class.
 Resolving an *EvaluationResult* can be deferred. As in, the result of an
 expression can be computed only when its necessary to be computed in

--- a/docs/mdbook/src/design/ten-thousand-foot-view.md
+++ b/docs/mdbook/src/design/ten-thousand-foot-view.md
@@ -85,7 +85,7 @@ map, style with source and layers, and observers.*
 
 ### Layer
 
-*Layer* is an overloaded terminology in the MapLibre GL Native's
+*Layer* is an overloaded terminology in the MapLibre Native's
 context. *Layer* can mean any of the following:
 
 1.  From the point of view of data that needs to be rendered on map,
@@ -129,8 +129,8 @@ When it does, we will dive more into *glyph* rendering.
 
 ### Actor Framework
 
-MapLibre GL Native is used in mobile platforms. To be performant in
-underpowered environments, MapLibre GL Native tries to leverage message
+MapLibre Native is used in mobile platforms. To be performant in
+underpowered environments, MapLibre Native tries to leverage message
 passing across threads to render frames asynchronously. The threading
 architecture in implementation realizes this using the Actor
 interface[^6]. In reality the messages are raw pointers. This ranges
@@ -147,10 +147,10 @@ rendering events that render layers, sources, and subsequently tiles. An
 
 A *Map Renderer* translates geospatial features in a vector or raster
 tile to rendered or rasterized map tiles shown in a *slippy map.*
-MapLibre GL Native uses a *Renderer* component to translate map tiles
+MapLibre Native uses a *Renderer* component to translate map tiles
 fetched from a tile server to a rendered map.
 
-MapLibre GL Native uses a pool of *workers*. These workers are
+MapLibre Native uses a pool of *workers*. These workers are
 responsible for background tile generation. A render thread continuously
 renders the current state of the map with available tiles at the time of
 rendering. In Javascript and iOS, the render thread is the same as the
@@ -168,7 +168,7 @@ Android uses a *GLSurfaceView* with a *GLThread* where the iOS SDK uses
 
 ### Tile Worker
 
-We have noted early in this document that MapLibre GL Native uses message
+We have noted early in this document that MapLibre Native uses message
 passing to communicate with the renderer. These messages are *immutable*
 by design and the render loops checks for these in each iteration. To
 simplify, there is only one thread allocated for rendering loop,

--- a/docs/mdbook/src/introduction.md
+++ b/docs/mdbook/src/introduction.md
@@ -1,5 +1,5 @@
 # Introduction
 
-*[MapLibre GL Native](https://github.com/maplibre/maplibre-gl-native)* is a community led fork of *Mapbox GL Native*. It's a C++ library that powers 
+*[MapLibre Native](https://github.com/maplibre/maplibre-gl-native)* is a community led fork of *Mapbox GL Native*. It's a C++ library that powers 
 vector maps in native applications on multiple platforms by taking stylesheets that conform to the *MapLibre Style Specification,* a fork of the 
 Mapbox Style Specification. Since it is derived from Mapbox's original work it also uses *Mapbox Vector Tile Specification* as its choice of vector tile format.

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -48,7 +48,7 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
   >  locationComponent.activateLocationComponent(options)
   >  ```
 
-* 💥 Breaking: the `LocationEngine` implemented with Google Location Services has been removed to make MapLibre GL Native for Android fully FLOSS ([#379](https://github.com/maplibre/maplibre-gl-native/issues/379)).
+* 💥 Breaking: the `LocationEngine` implemented with Google Location Services has been removed to make MapLibre Native for Android fully FLOSS ([#379](https://github.com/maplibre/maplibre-gl-native/issues/379)).
 
   > To migrate:  
   > Include the source code of the removed [`GoogleLocationEngineImpl`](https://github.com/maplibre/maplibre-gl-native/blob/4a34caab7593f4f1b6d8c09c06a5e25d7c6cfc43/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/engine/GoogleLocationEngineImpl.java) in your source tree.

--- a/platform/android/DEVELOPING.md
+++ b/platform/android/DEVELOPING.md
@@ -1,4 +1,4 @@
-# Developing - MapLibre GL Native for Android
+# Developing - MapLibre Native for Android
 
 These instructions are for developers interested in making code-level contributions to the SDK itself.
 

--- a/platform/android/MapboxGLAndroidSDK/README.md
+++ b/platform/android/MapboxGLAndroidSDK/README.md
@@ -1,5 +1,5 @@
-# Module MapLibre GL Native for Android
+# Module MapLibre Native for Android
 
-This is the MapLibre GL Native API for Android doccumentation. 
+This is the MapLibre Native API for Android doccumentation. 
 
-Visit [https://maplibre.org/maplibre-gl-native/docs/book/android/getting-started-guide.html](https://maplibre.org/maplibre-gl-native/docs/book/android/getting-started-guide.html) to view the Getting Started Guide for MapLibre GL Native for Android.
+Visit [https://maplibre.org/maplibre-gl-native/docs/book/android/getting-started-guide.html](https://maplibre.org/maplibre-gl-native/docs/book/android/getting-started-guide.html) to view the Getting Started Guide for MapLibre Native for Android.

--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 }
 
 tasks.withType(DokkaTask.class) {
-    moduleName.set("MapLibre GL Native for Android")
+    moduleName.set("MapLibre Native for Android")
 
     dokkaSourceSets {
 

--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -1,16 +1,16 @@
-# MapLibre GL Native for Android
+# MapLibre Native for Android
 
 [![GitHub Action build status](https://github.com/maplibre/maplibre-gl-native/workflows/android-ci/badge.svg)](https://github.com/maplibre/maplibre-gl-native/actions/workflows/android-ci.yml) [![GitHub Action build status](https://github.com/maplibre/maplibre-gl-native/workflows/android-release/badge.svg)](https://github.com/maplibre/maplibre-gl-native/actions/workflows/android-release.yml)
 
-MapLibre GL Native for Android is a library for embedding interactive map views with scalable, customizable vector maps onto Android devices.
+MapLibre Native for Android is a library for embedding interactive map views with scalable, customizable vector maps onto Android devices.
 
 ## Getting Started
 
-Visit [https://maplibre.org/maplibre-gl-native/docs/book/android/getting-started-guide.html](https://maplibre.org/maplibre-gl-native/docs/book/android/getting-started-guide.html) to view the Getting Started Guide for MapLibre GL Native for Android.
+Visit [https://maplibre.org/maplibre-gl-native/docs/book/android/getting-started-guide.html](https://maplibre.org/maplibre-gl-native/docs/book/android/getting-started-guide.html) to view the Getting Started Guide for MapLibre Native for Android.
 
 ## Documentation
 
-Visit [https://maplibre.org/maplibre-gl-native/android/api/](https://maplibre.org/maplibre-gl-native/android/api/) to view the current API reference Javadoc files for MapLibre GL Native for Android.
+Visit [https://maplibre.org/maplibre-gl-native/android/api/](https://maplibre.org/maplibre-gl-native/android/api/) to view the current API reference Javadoc files for MapLibre Native for Android.
 
 ## Contributing
 

--- a/platform/darwin/README.md
+++ b/platform/darwin/README.md
@@ -2,7 +2,7 @@
 
 The code in the Darwin platform targets Apple platforms but is not specific
 to iOS or macOS. This code is not distributed as an SDK in itself, but is required
-by iOS and macOS builds of MapLibre GL Native and ultimately by the
+by iOS and macOS builds of MapLibre Native and ultimately by the
 [MapLibre Maps SDK for iOS](https://github.com/maplibre/maplibre-gl-native/tree/main/platform/ios)
 and [MapLibre Maps SDK for macOS](https://github.com/maplibre/maplibre-gl-native/tree/main/platform/macos).
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Each MapLibre GL Native SDK has a separate changelog that highlights changes relevant to their respective platforms:
+Each MapLibre Native SDK has a separate changelog that highlights changes relevant to their respective platforms:
 
 * [MapLibre Maps SDK for Android](../../platform/android/CHANGELOG.md)
 * [MapLibre Maps SDK for iOS](platform/ios/CHANGELOG.md)

--- a/platform/ios/CONTRIBUTING.md
+++ b/platform/ios/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-If you have a usage question for a product built on Maplibre GL Native (such as our iOS or Android SDKs), please create a discussion thread on [GitHub Discussions](https://github.com/maplibre/maplibre-gl-native/discussions/categories/q-a).
+If you have a usage question for a product built on MapLibre Native (such as our iOS or Android SDKs), please create a discussion thread on [GitHub Discussions](https://github.com/maplibre/maplibre-gl-native/discussions/categories/q-a).
 
 If you want to contribute code:
 

--- a/platform/ios/README.md
+++ b/platform/ios/README.md
@@ -1,11 +1,11 @@
-# MapLibre GL Native for iOS and macOS
+# MapLibre Native for iOS and macOS
 
-MapLibre GL Native for iOS and macOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 9.0 and above using Objective-C, Swift, or Interface Builder. It takes stylesheets that conform to the [MapLibre GL Style Specification](https://maplibre.org/maplibre-gl-js-docs/style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://www.mapbox.com/developers/vector-tiles/), and renders them using OpenGL. It is based on the MapLibre GL Native library.
+MapLibre Native for iOS and macOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 9.0 and above using Objective-C, Swift, or Interface Builder. It takes stylesheets that conform to the [MapLibre GL Style Specification](https://maplibre.org/maplibre-gl-js-docs/style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://www.mapbox.com/developers/vector-tiles/), and renders them using OpenGL. It is based on the MapLibre Native library.
 
-- [MapLibre GL Native for iOS](platform/ios/README.md)
-- [MapLibre GL Native for macOS](platform/macos/README.md)
+- [MapLibre Native for iOS](platform/ios/README.md)
+- [MapLibre Native for macOS](platform/macos/README.md)
 
 
 ## License
 
-MapLibre GL Native is licensed under the [2-Clause BSD license](LICENSE.md).
+MapLibre Native is licensed under the [2-Clause BSD license](LICENSE.md).

--- a/platform/ios/platform/ios/CHANGELOG.md
+++ b/platform/ios/platform/ios/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog for MapLibre GL Native for iOS 
+# Changelog for MapLibre Native for iOS 
 
 MapLibre welcomes participation and contributions from everyone. Please read [`Contributing Guide`](https://github.com/maplibre/maplibre-gl-native/blob/master/CONTRIBUTING.md) to get started.
 

--- a/platform/ios/platform/ios/CONTRIBUTING.md
+++ b/platform/ios/platform/ios/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to MapLibre GL Native for iOS
+# Contributing to MapLibre Native for iOS
 
-This document explains how to build MapLibre GL Native for iOS from source. It is intended for advanced developers who wish to contribute to the library.
+This document explains how to build MapLibre Native for iOS from source. It is intended for advanced developers who wish to contribute to the library.
 
 ## Requirements
 

--- a/platform/ios/platform/ios/Documentation.docc/Documentation.md
+++ b/platform/ios/platform/ios/Documentation.docc/Documentation.md
@@ -1,5 +1,5 @@
 # ``Mapbox``
 
 @Metadata {
-    @DisplayName("MapLibre GL Native")
+    @DisplayName("MapLibre Native")
 }

--- a/platform/ios/platform/ios/README.md
+++ b/platform/ios/platform/ios/README.md
@@ -1,8 +1,8 @@
-# MapLibre GL Native for iOS
+# MapLibre Native for iOS
 
 [![GitHub Action build status](https://github.com/maplibre/maplibre-gl-native/workflows/ios-ci/badge.svg)](https://github.com/maplibre/maplibre-gl-native/actions/workflows/ios-ci.yml) [![GitHub Action build status](https://github.com/maplibre/maplibre-gl-native/workflows/ios-release/badge.svg)](https://github.com/maplibre/maplibre-gl-native/actions/workflows/ios-release.yml)
 
-A library based on [MapLibre GL Native](https://github.com/maplibre/maplibre-gl-native) for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS using Objective-C, Swift, or Interface Builder.
+A library based on [MapLibre Native](https://github.com/maplibre/maplibre-gl-native) for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS using Objective-C, Swift, or Interface Builder.
 
 * [Learn about custom builds](INSTALL.md)
 
@@ -18,7 +18,7 @@ A library based on [MapLibre GL Native](https://github.com/maplibre/maplibre-gl-
 
 ## Documentation
 
-- [MapLibre GL Native for iOS API Reference](https://maplibre.org/maplibre-gl-native/ios/api/)
+- [MapLibre Native for iOS API Reference](https://maplibre.org/maplibre-gl-native/ios/api/)
 
 ## Contributing
 

--- a/platform/ios/platform/ios/docs/pod-README.md
+++ b/platform/ios/platform/ios/docs/pod-README.md
@@ -1,16 +1,16 @@
-# MapLibre GL Native for iOS
+# MapLibre Native for iOS
 
-MapLibre GL Native for iOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 9.0 and above using Objective-C, Swift, or Interface Builder. It takes stylesheets that conform to the [MapLibre Style Specification](https://maplibre.org/maplibre-gl-js-docs/style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://docs.mapbox.com/data/tilesets/guides/vector-tiles-standards/), and renders them using OpenGL.
+MapLibre Native for iOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 9.0 and above using Objective-C, Swift, or Interface Builder. It takes stylesheets that conform to the [MapLibre Style Specification](https://maplibre.org/maplibre-gl-js-docs/style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://docs.mapbox.com/data/tilesets/guides/vector-tiles-standards/), and renders them using OpenGL.
 
-For more information, check out the [MapLibre GL Native for iOS repository](https://github.com/maplibre/maplibre-gl-native) and the [full changelog](https://github.com/maplibre/maplibre-gl-native/blob/main/platform/ios/platform/ios/CHANGELOG.md) online.
+For more information, check out the [MapLibre Native for iOS repository](https://github.com/maplibre/maplibre-gl-native) and the [full changelog](https://github.com/maplibre/maplibre-gl-native/blob/main/platform/ios/platform/ios/CHANGELOG.md) online.
 
 [![](https://raw.githubusercontent.com/mapbox/mapbox-gl-native-ios/master/platform/ios/docs/img/screenshot.png)]()
 
 ## Installation
 
-MapLibre GL Native for iOS may be installed as either a dynamic framework or a static framework. (To reduce the download size, the static framework is omitted from some distributions; you may need to download the full package from the [release page](https://github.com/mapbox/mapbox-gl-native-ios/releases/).)
+MapLibre Native for iOS may be installed as either a dynamic framework or a static framework. (To reduce the download size, the static framework is omitted from some distributions; you may need to download the full package from the [release page](https://github.com/mapbox/mapbox-gl-native-ios/releases/).)
 
-Integrating MapLibre GL Native for iOS requires Xcode 8.0 or higher.
+Integrating MapLibre Native for iOS requires Xcode 8.0 or higher.
 
 {{DYNAMIC}}
 

--- a/platform/ios/platform/ios/scripts/document.sh
+++ b/platform/ios/platform/ios/scripts/document.sh
@@ -49,5 +49,5 @@ jazzy \
     --theme ${THEME} \
     --head "${CUSTOM_HEAD}" \
     --output ${OUTPUT} \
-    --title "MapLibre GL Native for iOS" \
+    --title "MapLibre Native for iOS" \
     --module-version ${SHORT_VERSION}

--- a/platform/ios/platform/ios/scripts/release-notes-jazzy.md.ejs
+++ b/platform/ios/platform/ios/scripts/release-notes-jazzy.md.ejs
@@ -1,8 +1,8 @@
-# MapLibre GL Native for iOS
+# MapLibre Native for iOS
 
-MapLibre GL Native for iOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 9.0 and above using Objective-C, Swift, or Interface Builder. It takes stylesheets that conform to the [MapLibre Style Specification](https://maplibre.org/maplibre-gl-js-docs/style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://docs.mapbox.com/data/tilesets/guides/vector-tiles-standards/), and renders them using OpenGL.
+MapLibre Native for iOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 9.0 and above using Objective-C, Swift, or Interface Builder. It takes stylesheets that conform to the [MapLibre Style Specification](https://maplibre.org/maplibre-gl-js-docs/style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://docs.mapbox.com/data/tilesets/guides/vector-tiles-standards/), and renders them using OpenGL.
 
-![MapLibre GL Native for iOS screenshots](img/screenshot.png)
+![MapLibre Native for iOS screenshots](img/screenshot.png)
 
 We welcome your [bug reports, feature requests, and contributions](https://github.com/maplibre/maplibre-gl-native/issues).
 

--- a/platform/ios/platform/ios/scripts/swift_package_template.swift
+++ b/platform/ios/platform/ios/scripts/swift_package_template.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "MapLibre GL Native",
+    name: "MapLibre Native",
     products: [
         .library(
             name: "Mapbox",

--- a/platform/ios/platform/macos/README.md
+++ b/platform/ios/platform/macos/README.md
@@ -1,11 +1,11 @@
-# MapLibre GL Native for macOS
+# MapLibre Native for macOS
 
 > **Note**  
 > https://github.com/maplibre/maplibre-gl-native/pull/995 introduced OpenGL ES 3.0 shaders which are not supported by macOS without workarounds. That means that while the [Metal backend implementation](https://github.com/maplibre/maplibre-gl-native/blob/main/design-proposals/2022-11-29-metal-port.md) is underway, builds from the `main` branch will not work on macOS. Use the `opengl-2` branch in the meantime.
 
 [![GitHub Action build status](https://github.com/maplibre/maplibre-gl-native/workflows/macos-ci/badge.svg)](https://github.com/maplibre/maplibre-gl-native/actions/workflows/macos-ci.yml) [![GitHub Action build status](https://github.com/maplibre/maplibre-gl-native/workflows/macos-release/badge.svg)](https://github.com/maplibre/maplibre-gl-native/actions/workflows/macos-release.yml)
 
-Put interactive, scalable world maps into your native Cocoa application with MapLibre GL Native for macOS.
+Put interactive, scalable world maps into your native Cocoa application with MapLibre Native for macOS.
 
 * High-performance OpenGL rendering and multitouch gestures keep your users happy.
 * A well-designed, fully documented API helps you stay productive.
@@ -13,12 +13,12 @@ Put interactive, scalable world maps into your native Cocoa application with Map
 
 ![](docs/img/screenshot.jpg)
 
-MapLibre GL Native for macOS is compatible with macOS 10.10.0 and above for Cocoa applications developed in Objective-C, Swift, Interface Builder, or AppleScript. For hybrid applications, consider [MapLibre GL JS]([https://github.com/mapbox/mapbox-gl-js/](https://github.com/maplibre/maplibre-gl-js)).
+MapLibre Native for macOS is compatible with macOS 10.10.0 and above for Cocoa applications developed in Objective-C, Swift, Interface Builder, or AppleScript. For hybrid applications, consider [MapLibre GL JS]([https://github.com/mapbox/mapbox-gl-js/](https://github.com/maplibre/maplibre-gl-js)).
 
 ## Contributing
 
-* [Build the MapLibre GL Native for macOS from source](INSTALL.md)
-* [Contribute to MapLibre GL Native for macOS](CONTRIBUTING.md)
+* [Build the MapLibre Native for macOS from source](INSTALL.md)
+* [Contribute to MapLibre Native for macOS](CONTRIBUTING.md)
 * [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/)
 * [Mapbox Vector Tile Specification](https://www.mapbox.com/developers/vector-tiles/)
 

--- a/platform/linux/README.md
+++ b/platform/linux/README.md
@@ -1,14 +1,14 @@
 # Linux
 
-A simple executable and test suite for Linux based on [MapLibre GL Native](../../README.md).
+A simple executable and test suite for Linux based on [MapLibre Native](../../README.md).
 
 This guide focuses on Debian and Ubuntu distributions.
 
-The build process should give you a set of `.a` files that you can use to include MapLibre GL Native in other C++ projects, as well as a set of executables that you can run to render map tile images and test the project.
+The build process should give you a set of `.a` files that you can use to include MapLibre Native in other C++ projects, as well as a set of executables that you can run to render map tile images and test the project.
 
 ## Prerequisites
 
-The following dependencies are required to build MapLibre GL Native on Debian 11.
+The following dependencies are required to build MapLibre Native on Debian 11.
 
 ```bash
 apt install ccache cmake ninja-build pkg-config xvfb libcurl4-openssl-dev libglfw3-dev libuv1-dev g++-10 libc++-9-dev libc++abi-9-dev libpng-dev libgl1-mesa-dev libgl1-mesa-dri
@@ -53,7 +53,7 @@ If all went well, there should now be a `maplibre-gl-native/build/bin/mbgl-rende
 
 > I get an error `Error: Failed to open X display.` when I run this command.
 
-If you're setting up MapLibre GL Native on a headless server (i.e. one without a display), you'll need to simulate an X server to do any rendering.
+If you're setting up MapLibre Native on a headless server (i.e. one without a display), you'll need to simulate an X server to do any rendering.
 
 ```bash
 xvfb-run -a ./build/bin/mbgl-render --style https://raw.githubusercontent.com/maplibre/demotiles/gh-pages/style.json --output out.png

--- a/platform/macos/README.md
+++ b/platform/macos/README.md
@@ -1,3 +1,3 @@
 # macOS
 
-This folder contains build configuration files for the macOS distribution of MapLibre GL Native, which ultimately targets Cocoa applications written in Objective-C, Swift, Interface Builder, or AppleScript via the MapLibre Maps SDK for macOS.
+This folder contains build configuration files for the macOS distribution of MapLibre Native, which ultimately targets Cocoa applications written in Objective-C, Swift, Interface Builder, or AppleScript via the MapLibre Maps SDK for macOS.

--- a/platform/node/DEVELOPING.md
+++ b/platform/node/DEVELOPING.md
@@ -1,6 +1,6 @@
-# Developing the Maplibre GL Native Node.js module
+# Developing the MapLibre Native Node.js module
 
-This document explains how to build the [Node.js](https://nodejs.org/) bindings for [Maplibre GL Native](../../README.md) for contributing to the development of the bindings themselves. If you just want to use the module, you can simply install it via `npm`; see [README.md](README.md) for installation and usage instructions.
+This document explains how to build the [Node.js](https://nodejs.org/) bindings for [MapLibre Native](../../README.md) for contributing to the development of the bindings themselves. If you just want to use the module, you can simply install it via `npm`; see [README.md](README.md) for installation and usage instructions.
 
 ## Building
 

--- a/platform/qt/README.md
+++ b/platform/qt/README.md
@@ -1,4 +1,4 @@
-# MapLibre GL Native for Qt
+# MapLibre Native for Qt
 
 [![GitHub Action build status](https://github.com/maplibre/maplibre-gl-native/workflows/qt-ci/badge.svg)](https://github.com/maplibre/maplibre-gl-native/actions/workflows/qt-ci.yml) 
 

--- a/platform/qt/src/map.cpp
+++ b/platform/qt/src/map.cpp
@@ -186,11 +186,11 @@ namespace QMapLibreGL {
 
 /*!
     \class QMapLibreGL::Map
-    \brief The QMapLibreGL::Map class is a Qt wrapper for the MapLibre GL Native engine.
+    \brief The QMapLibreGL::Map class is a Qt wrapper for the MapLibre Native engine.
 
     \inmodule MapLibre Maps SDK for Qt
 
-    QMapLibreGL::Map is a Qt friendly version the MapLibre GL Native engine using Qt types
+    QMapLibreGL::Map is a Qt friendly version the MapLibre Native engine using Qt types
     and deep integration with Qt event loop. QMapLibreGL::Map relies as much as possible
     on Qt, trying to minimize the external dependencies. For instance it will use
     QNetworkAccessManager for HTTP requests and QString for UTF-8 manipulation.

--- a/platform/qt/src/utils.cpp
+++ b/platform/qt/src/utils.cpp
@@ -35,7 +35,7 @@ NetworkMode networkMode()
 /*!
     \fn void QMapLibreGL::setNetworkMode(QMapLibreGL::NetworkMode mode)
 
-    Forwards the network status \a mode to MapLibre GL Native engine.
+    Forwards the network status \a mode to MapLibre Native engine.
 
     File source requests uses the available network when \a mode is set to \b
     Online, otherwise scoped to the local cache.

--- a/platform/qt/src/utils/renderer_backend.cpp
+++ b/platform/qt/src/utils/renderer_backend.cpp
@@ -46,7 +46,7 @@ void RendererBackend::updateFramebuffer(quint32 fbo, const mbgl::Size& newSize) 
 
 /*!
     Initializes an OpenGL extension function such as Vertex Array Objects (VAOs),
-    required by MapLibre GL Native engine.
+    required by MapLibre Native engine.
 */
 mbgl::gl::ProcAddress RendererBackend::getExtensionFunctionPointer(const char* name) {
     QOpenGLContext* thisContext = QOpenGLContext::currentContext();

--- a/platform/windows/README.md
+++ b/platform/windows/README.md
@@ -6,7 +6,7 @@ The files produced by building mbgl-core target can be reused as libraries in ot
 
 ## Prerequisites
 
-The Windows port, for while, relies on `Microsoft Visual Studio` to build Maplibre GL Native, either using `Ninja` or `Microsoft Visual Studio`. The build was tested with `Microsoft Visual Studio 2022 Community Edition`. Other 2022 editions might work as well. Earlier versions are not guaranteed to work, but `Microsoft Visual Studio 2019` might work.
+The Windows port, for while, relies on `Microsoft Visual Studio` to build MapLibre Native, either using `Ninja` or `Microsoft Visual Studio`. The build was tested with `Microsoft Visual Studio 2022 Community Edition`. Other 2022 editions might work as well. Earlier versions are not guaranteed to work, but `Microsoft Visual Studio 2019` might work.
 
 To install the required Visual Studio components, open Visual Studio Installer and check `Desktop Development with C++` option. Make sure `C++ CMake tools for Windows` is selected in the right pane. If `git` is not already installed, select `Git for Windows` option in `Individual Components`. When Visual Studio finishes the install process, everything is ready to start.
 

--- a/qt_attribution.json
+++ b/qt_attribution.json
@@ -1,10 +1,10 @@
 {
   "Id": "maplibre-gl-native",
-  "Name": "MapLibre GL Native",
+  "Name": "MapLibre Native",
   "QDocModule": "qtlocation",
   "QtUsage": "Used in the MapLibre backend of Qt Location.",
 
-  "Description": "MapLibre GL Native is a community led fork derived from mapbox-gl-native.",
+  "Description": "MapLibre Native is a community led fork derived from mapbox-gl-native.",
   "Homepage": "https://github.com/maplibre/maplibre-gl-native",
   "LicenseId": "BSD-2-Clause",
   "License": "BSD 2-Clause License",


### PR DESCRIPTION
This touches mainly .md files, a few comments i c++ files, and the titles of the docs (doxygen / dokka).

Also, the [swift package](https://swiftpackageindex.com/maplibre/maplibre-gl-native-distribution) title is updated. Because the package url stays the same ([maplibre-gl-native-distribution](https://github.com/maplibre/maplibre-gl-native-distribution)), I'd expect the title to update for the existing entry at next release.